### PR TITLE
walk parent elements to find event handlers

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -40,8 +40,15 @@ func (vm *ViewModel) vModel(event dom.Event) {
 // vOn is the vue on event callback.
 func (vm *ViewModel) vOn(event dom.Event) {
 	typ := event.Type()
-	method, ok := event.Target().Attributes()[typ]
-	if !ok {
+	var method string
+	for elem := event.Target(); elem != nil; elem = elem.ParentElement() {
+		var ok bool
+		method, ok = elem.Attributes()[typ]
+		if ok {
+			break
+		}
+	}
+	if method == "" {
 		must(fmt.Errorf("unknown event type: %s", typ))
 	}
 


### PR DESCRIPTION
If you have a chunk of DOM like this:
```
<button v-on:click="Foobar">Click <span>here</span></button>
```
then clicking in the span element causes a panic in vOn, because the event target is the span but the click attribute is on the button element. The proposed change causes vOn to check for an event handler on each parent element.