### PR TITLE
Fix compile error when using newer versions of go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/norunners/vue
 
 require (
 	github.com/cbroglie/mustache v1.0.1
-	github.com/gowasm/go-js-dom v0.0.3
 	golang.org/x/net v0.0.0-20190311031020-56fb01167e7d
+	honnef.co/go/js/dom/v2 v2.0.0-20200509013220-d4405f7ab4d8
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/cbroglie/mustache v1.0.1 h1:ivMg8MguXq/rrz2eu3tw6g3b16+PQhoTn6EZAhst2mw=
 github.com/cbroglie/mustache v1.0.1/go.mod h1:R/RUa+SobQ14qkP4jtx5Vke5sDytONDQXNLPY/PO69g=
-github.com/gowasm/go-js-dom v0.0.3 h1:5TDTkogeJ137AMChH7/cxYIBM1hTitz2rd44j28+Cr0=
-github.com/gowasm/go-js-dom v0.0.3/go.mod h1:K37PTzggLHdwZwVKIlgreQbR7b1pwrudrZEFYcPifKE=
 golang.org/x/net v0.0.0-20190311031020-56fb01167e7d h1:vQJbQvu6+H699vOmHa20TEBI9nEqroRbMtf/9biIE3A=
 golang.org/x/net v0.0.0-20190311031020-56fb01167e7d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+honnef.co/go/js/dom/v2 v2.0.0-20200509013220-d4405f7ab4d8 h1:wEmxE7Y1Kwm9Nrzl+0+yYt3uGXkaqbEYLuRzl/hSDgE=
+honnef.co/go/js/dom/v2 v2.0.0-20200509013220-d4405f7ab4d8/go.mod h1:H5R0jAIe6IchQE778FS2QcrNVgS4vPFb0HPb72n/IJI=

--- a/template.go
+++ b/template.go
@@ -3,12 +3,13 @@ package vue
 import (
 	"bytes"
 	"fmt"
-	"github.com/cbroglie/mustache"
-	"golang.org/x/net/html"
-	"golang.org/x/net/html/atom"
 	"io"
 	"reflect"
 	"strings"
+
+	"github.com/cbroglie/mustache"
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
 )
 
 const (

--- a/vnode.go
+++ b/vnode.go
@@ -2,12 +2,13 @@ package vue
 
 import (
 	"fmt"
-	"github.com/gowasm/go-js-dom"
-	"golang.org/x/net/html"
 	"syscall/js"
+
+	"golang.org/x/net/html"
+	dom "honnef.co/go/js/dom/v2"
 )
 
-var document dom.Document
+var document = dom.WrapDocument(js.Global().Get("document"))
 
 type vnode struct {
 	parent, firstChild, lastChild, prevSibling, nextSibling *vnode
@@ -17,14 +18,6 @@ type vnode struct {
 	data  string
 
 	node dom.Node
-}
-
-func init() {
-	doc := js.Global().Get("document")
-	if doc == js.Undefined() || doc == js.Null() {
-		panic("failed to initialize document")
-	}
-	document = dom.WrapDocument(doc)
 }
 
 // newNode creates a virtual node by query selecting the given element.


### PR DESCRIPTION
- Switches the library used to access to dom to one that supports both newer and older versions of `syscall/js`
  * Also removes check for undefined or null document to avoid needing build tags to check go version
- Fixes behavior when `v-for` is used with empty slice
- Allows `v-if` to be used with negated value