### PR TITLE
[codex] Added Tue source fixtures.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,26 +7,26 @@ The old reflection/template interpreter runtime and its legacy WebAssembly
 examples have been removed. Reviewable Tue implementation slices will land in
 follow-up changes.
 
+The pre-migration Vue runtime and examples remain available on the
+[`vue` branch](https://github.com/norunners/vue/tree/vue).
+
 ## Current State
 
 - The GitHub repository and Go module path are still `github.com/norunners/vue`
   until the planned repository/module rename lands separately.
-- There is intentionally no active runtime package in this slice after removing
-  the legacy Vue implementation.
-- Future changes will introduce Tue docs, the `.tue` compiler, the runtime, and
-  rebuilt examples in smaller reviewable pieces.
+- The active root package is intentionally a placeholder until the Tue runtime
+  is rebuilt in reviewable slices.
+- Initial `.tue` source fixtures live under `testdata/fixtures/`; they define
+  the intended component shape before parser/runtime work lands.
 
 ## Verification
 
-For this removal-only slice, the expected local checks are:
+For the current baseline, the expected local checks are:
 
 ```bash
 go fmt ./...
 go test ./...
 ```
-
-Both commands may report that `./...` matched no packages until the first Tue
-implementation slice adds Go packages back to the repository.
 
 License
 -------

--- a/testdata/fixtures/counter.tue
+++ b/testdata/fixtures/counter.tue
@@ -1,0 +1,24 @@
+<template>
+	<main>
+		<p>Count: {{ count }}</p>
+		<button type="button" @click="increment">Increment</button>
+	</main>
+</template>
+
+<script lang="go">
+package fixtures
+
+import tue "github.com/norunners/vue"
+
+type Counter struct {
+	count tue.Ref[int]
+}
+
+func (c *Counter) Init(ctx tue.Context) {
+	c.count = tue.RefOf(0)
+}
+
+func (c *Counter) increment() {
+	c.count.Set(c.count.Get() + 1)
+}
+</script>

--- a/testdata/fixtures/interpolation.tue
+++ b/testdata/fixtures/interpolation.tue
@@ -1,0 +1,21 @@
+<template>
+	<main>
+		<p>{{ greeting }}, {{ name }}!</p>
+	</main>
+</template>
+
+<script lang="go">
+package fixtures
+
+import tue "github.com/norunners/vue"
+
+type Interpolation struct {
+	greeting string
+	name     string
+}
+
+func (i *Interpolation) Init(ctx tue.Context) {
+	i.greeting = "Hello"
+	i.name = "Tue"
+}
+</script>

--- a/testdata/fixtures/invalid_prop_type/Parent.tue
+++ b/testdata/fixtures/invalid_prop_type/Parent.tue
@@ -1,0 +1,19 @@
+<template>
+	<main>
+		<UserBadge :name="name" :isAdmin='"yes"' />
+	</main>
+</template>
+
+<script lang="go">
+package invalidproptype
+
+import tue "github.com/norunners/vue"
+
+type Parent struct {
+	name string
+}
+
+func (p *Parent) Init(ctx tue.Context) {
+	p.name = "Ada"
+}
+</script>

--- a/testdata/fixtures/invalid_prop_type/UserBadge.tue
+++ b/testdata/fixtures/invalid_prop_type/UserBadge.tue
@@ -1,0 +1,17 @@
+<template>
+	<span class="badge">
+		{{ name }}
+		<strong v-if="isAdmin">Admin</strong>
+	</span>
+</template>
+
+<script lang="go">
+package invalidproptype
+
+import tue "github.com/norunners/vue"
+
+type UserBadge struct {
+	name    tue.Prop[string] `prop:"name,required"`
+	isAdmin tue.Prop[bool]   `prop:"isAdmin"`
+}
+</script>

--- a/testdata/fixtures/parent_child_props/Parent.tue
+++ b/testdata/fixtures/parent_child_props/Parent.tue
@@ -1,0 +1,21 @@
+<template>
+	<main>
+		<UserBadge :name="name" :isAdmin='role == "admin"' />
+	</main>
+</template>
+
+<script lang="go">
+package parentchildprops
+
+import tue "github.com/norunners/vue"
+
+type Parent struct {
+	name string
+	role string
+}
+
+func (p *Parent) Init(ctx tue.Context) {
+	p.name = "Ada"
+	p.role = "admin"
+}
+</script>

--- a/testdata/fixtures/parent_child_props/UserBadge.tue
+++ b/testdata/fixtures/parent_child_props/UserBadge.tue
@@ -1,0 +1,17 @@
+<template>
+	<span class="badge">
+		{{ name }}
+		<strong v-if="isAdmin">Admin</strong>
+	</span>
+</template>
+
+<script lang="go">
+package parentchildprops
+
+import tue "github.com/norunners/vue"
+
+type UserBadge struct {
+	name    tue.Prop[string] `prop:"name,required"`
+	isAdmin tue.Prop[bool]   `prop:"isAdmin"`
+}
+</script>

--- a/testdata/fixtures/static_hello.tue
+++ b/testdata/fixtures/static_hello.tue
@@ -1,0 +1,12 @@
+<template>
+	<main class="page">
+		<h1>Hello Tue</h1>
+		<p>Static markup renders without component state.</p>
+	</main>
+</template>
+
+<script lang="go">
+package fixtures
+
+type StaticHello struct{}
+</script>


### PR DESCRIPTION
## Summary

This PR establishes the next Tue migration slice after removing the legacy Vue runtime.

It updates the README for the current Tue-first baseline and adds initial `.tue` source fixtures for static rendering, interpolation, counter state, parent/child props, and an invalid prop type case. The counter fixture now models event behavior as a component method instead of a function-valued field.

The repository/module path intentionally remains `github.com/norunners/vue` in this slice. The Tue design and migration docs are kept locally for now and are not included in this PR.

## Validation

- `go fmt ./...`
- `go test ./...`
- fixture handler search for remaining function-valued handler fields
- fixture shape check for `<template>`, `<script lang="go">`, and `package`
- `git diff --check`
- lint config discovery: no configured Go linter found
- `tokensave sync`

## Deferred

- Tue design and migration docs PR
- GitHub repository rename to `norunners/tue`
- Go module/package/import rename
- CLI shell
- SFC parser, generator, runtime, dev server, and examples rebuild