### PR TITLE
[codex] Renamed the module to Tue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,11 @@ examples have been removed. Reviewable Tue implementation slices will land in
 follow-up changes.
 
 The pre-migration Vue runtime and examples remain available on the
-[`vue` branch](https://github.com/norunners/vue/tree/vue).
+[`vue` branch](https://github.com/norunners/tue/tree/vue).
 
 ## Current State
 
-- The GitHub repository and Go module path are still `github.com/norunners/vue`
-  until the planned repository/module rename lands separately.
+- The GitHub repository and Go module path are `github.com/norunners/tue`.
 - The active root package is intentionally a placeholder until the Tue runtime
   is rebuilt in reviewable slices.
 - Initial `.tue` source fixtures live under `testdata/fixtures/`; they define

--- a/doc.go
+++ b/doc.go
@@ -1,3 +1,3 @@
-// Package vue is temporarily empty while the legacy runtime is removed and Tue
+// Package tue is temporarily empty while the legacy runtime is removed and Tue
 // implementation slices are rebuilt.
-package vue
+package tue

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/norunners/vue
+module github.com/norunners/tue
 
 go 1.26.4

--- a/testdata/fixtures/counter.tue
+++ b/testdata/fixtures/counter.tue
@@ -8,7 +8,7 @@
 <script lang="go">
 package fixtures
 
-import tue "github.com/norunners/vue"
+import tue "github.com/norunners/tue"
 
 type Counter struct {
 	count tue.Ref[int]

--- a/testdata/fixtures/interpolation.tue
+++ b/testdata/fixtures/interpolation.tue
@@ -7,7 +7,7 @@
 <script lang="go">
 package fixtures
 
-import tue "github.com/norunners/vue"
+import tue "github.com/norunners/tue"
 
 type Interpolation struct {
 	greeting string

--- a/testdata/fixtures/invalid_prop_type/Parent.tue
+++ b/testdata/fixtures/invalid_prop_type/Parent.tue
@@ -7,7 +7,7 @@
 <script lang="go">
 package invalidproptype
 
-import tue "github.com/norunners/vue"
+import tue "github.com/norunners/tue"
 
 type Parent struct {
 	name string

--- a/testdata/fixtures/invalid_prop_type/UserBadge.tue
+++ b/testdata/fixtures/invalid_prop_type/UserBadge.tue
@@ -8,7 +8,7 @@
 <script lang="go">
 package invalidproptype
 
-import tue "github.com/norunners/vue"
+import tue "github.com/norunners/tue"
 
 type UserBadge struct {
 	name    tue.Prop[string] `prop:"name,required"`

--- a/testdata/fixtures/parent_child_props/Parent.tue
+++ b/testdata/fixtures/parent_child_props/Parent.tue
@@ -7,7 +7,7 @@
 <script lang="go">
 package parentchildprops
 
-import tue "github.com/norunners/vue"
+import tue "github.com/norunners/tue"
 
 type Parent struct {
 	name string

--- a/testdata/fixtures/parent_child_props/UserBadge.tue
+++ b/testdata/fixtures/parent_child_props/UserBadge.tue
@@ -8,7 +8,7 @@
 <script lang="go">
 package parentchildprops
 
-import tue "github.com/norunners/vue"
+import tue "github.com/norunners/tue"
 
 type UserBadge struct {
 	name    tue.Prop[string] `prop:"name,required"`


### PR DESCRIPTION
## Summary

- Renamed the Go module from `github.com/norunners/vue` to `github.com/norunners/tue`.
- Renamed the placeholder root package from `vue` to `tue`.
- Updated README and `.tue` fixtures to use the new repository/module path.

## Scope

This is a mechanical naming PR after the repository rename. It does not add compiler, runtime, or generator behavior.

## Verification

- `go fmt ./...`
- `go mod tidy`
- `go test ./...`
- `git diff --check`
- `rg "github.com/norunners/vue|git@github.com:norunners/vue|package vue|module github.com/norunners/vue|norunners/vue" --glob '!docs/**'`
- `tokensave sync`