### PR TITLE
[codex] Added the Tue CLI shell.

### DIFF
--- a/cmd/tue/main.go
+++ b/cmd/tue/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"os"
+
+	"github.com/norunners/tue/internal/cli"
+)
+
+func main() {
+	os.Exit(cli.Run(os.Args[1:], os.Stdout, os.Stderr))
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,0 +1,163 @@
+package cli
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+const (
+	exitOK = iota
+	exitError
+	exitUsage
+)
+
+// Run executes the Tue CLI with args that do not include the binary name.
+func Run(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		printUsage(stderr)
+		return exitUsage
+	}
+
+	switch args[0] {
+	case "-h", "--help", "help":
+		printUsage(stdout)
+		return exitOK
+	case "check":
+		return runCheck(args[1:], stdout, stderr)
+	case "build", "dev", "fmt":
+		return runStub(args[0], args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "tue: unknown command %q\n\n", args[0])
+		printUsage(stderr)
+		return exitUsage
+	}
+}
+
+func runCheck(args []string, stdout, stderr io.Writer) int {
+	root, code, ok := parseProjectRoot("check", args, stdout, stderr)
+	if !ok {
+		return code
+	}
+
+	files, err := discoverTueFiles(root)
+	if err != nil {
+		fmt.Fprintf(stderr, "tue check: %v\n", err)
+		return exitError
+	}
+
+	fmt.Fprintf(stdout, "tue check: found %d .tue file(s) in %s\n", len(files), filepath.Clean(root))
+	for _, file := range files {
+		fmt.Fprintf(stdout, "%s\n", file)
+	}
+
+	return exitOK
+}
+
+func runStub(command string, args []string, stdout, stderr io.Writer) int {
+	if _, code, ok := parseProjectRoot(command, args, stdout, stderr); !ok {
+		return code
+	}
+
+	fmt.Fprintf(stderr, "tue %s: not implemented yet\n", command)
+	return exitError
+}
+
+func parseProjectRoot(command string, args []string, stdout, stderr io.Writer) (string, int, bool) {
+	flags := flag.NewFlagSet("tue "+command, flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+
+	if err := flags.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printCommandUsage(command, stdout)
+			return "", exitOK, false
+		}
+		fmt.Fprintf(stderr, "tue %s: %v\n\n", command, err)
+		printCommandUsage(command, stderr)
+		return "", exitUsage, false
+	}
+
+	if flags.NArg() > 1 {
+		fmt.Fprintf(stderr, "tue %s: expected at most one project root\n\n", command)
+		printCommandUsage(command, stderr)
+		return "", exitUsage, false
+	}
+
+	root := "."
+	if flags.NArg() == 1 {
+		root = flags.Arg(0)
+	}
+
+	return root, exitOK, true
+}
+
+func discoverTueFiles(root string) ([]string, error) {
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, fmt.Errorf("stat project root %q: %w", root, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("project root %q is not a directory", root)
+	}
+
+	var files []string
+	err = filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if entry.IsDir() {
+			if path != root && shouldSkipDir(entry.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if filepath.Ext(path) != ".tue" {
+			return nil
+		}
+
+		relativePath, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		files = append(files, filepath.ToSlash(relativePath))
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("discover .tue files: %w", err)
+	}
+
+	sort.Strings(files)
+	return files, nil
+}
+
+func shouldSkipDir(name string) bool {
+	switch name {
+	case ".git", ".tue-cache", "node_modules":
+		return true
+	default:
+		return false
+	}
+}
+
+func printUsage(out io.Writer) {
+	fmt.Fprint(out, `Usage:
+  tue <command> [project-root]
+
+Commands:
+  check [project-root]  Discover .tue files under a project root.
+  build [project-root]  Build a Tue project. Not implemented yet.
+  dev [project-root]    Start the Tue dev server. Not implemented yet.
+  fmt [project-root]    Format Tue source files. Not implemented yet.
+`)
+}
+
+func printCommandUsage(command string, out io.Writer) {
+	fmt.Fprintf(out, "Usage:\n  tue %s [project-root]\n", command)
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,195 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunRequiresCommand(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := Run(nil, &stdout, &stderr)
+
+	if code != exitUsage {
+		t.Fatalf("Run(nil) exit code = %d, want %d", code, exitUsage)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "Usage:") {
+		t.Fatalf("stderr = %q, want usage", stderr.String())
+	}
+}
+
+func TestRunPrintsHelp(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := Run([]string{"--help"}, &stdout, &stderr)
+
+	if code != exitOK {
+		t.Fatalf("Run(--help) exit code = %d, want %d", code, exitOK)
+	}
+	if !strings.Contains(stdout.String(), "tue <command>") {
+		t.Fatalf("stdout = %q, want top-level usage", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunPrintsCommandHelp(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := Run([]string{"check", "--help"}, &stdout, &stderr)
+
+	if code != exitOK {
+		t.Fatalf("Run(check --help) exit code = %d, want %d", code, exitOK)
+	}
+	if !strings.Contains(stdout.String(), "tue check [project-root]") {
+		t.Fatalf("stdout = %q, want command usage", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunRejectsUnknownCommand(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := Run([]string{"create"}, &stdout, &stderr)
+
+	if code != exitUsage {
+		t.Fatalf("Run(create) exit code = %d, want %d", code, exitUsage)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), `unknown command "create"`) {
+		t.Fatalf("stderr = %q, want unknown command", stderr.String())
+	}
+}
+
+func TestRunStubCommandsReturnNotImplemented(t *testing.T) {
+	for _, command := range []string{"build", "dev", "fmt"} {
+		t.Run(command, func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			code := Run([]string{command}, &stdout, &stderr)
+
+			if code != exitError {
+				t.Fatalf("Run(%s) exit code = %d, want %d", command, code, exitError)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+			want := "tue " + command + ": not implemented yet"
+			if !strings.Contains(stderr.String(), want) {
+				t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+			}
+		})
+	}
+}
+
+func TestRunCheckDiscoversTueFiles(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "App.tue"), "<template></template>")
+	writeFile(t, filepath.Join(root, "notes.txt"), "not a component")
+	writeFile(t, filepath.Join(root, "components", "UserBadge.tue"), "<template></template>")
+	writeFile(t, filepath.Join(root, ".git", "ignored.tue"), "<template></template>")
+	writeFile(t, filepath.Join(root, ".tue-cache", "generated.tue"), "<template></template>")
+	writeFile(t, filepath.Join(root, "node_modules", "ignored.tue"), "<template></template>")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := Run([]string{"check", root}, &stdout, &stderr)
+
+	if code != exitOK {
+		t.Fatalf("Run(check) exit code = %d, want %d; stderr = %q", code, exitOK, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("stdout lines = %#v, want summary plus 2 files", lines)
+	}
+	if !strings.Contains(lines[0], "found 2 .tue file(s)") {
+		t.Fatalf("summary = %q, want discovered count", lines[0])
+	}
+	if lines[1] != "App.tue" || lines[2] != "components/UserBadge.tue" {
+		t.Fatalf("file lines = %#v, want sorted relative paths", lines[1:])
+	}
+}
+
+func TestRunCheckDefaultsToWorkingDirectory(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "App.tue"), "<template></template>")
+	t.Chdir(root)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := Run([]string{"check"}, &stdout, &stderr)
+
+	if code != exitOK {
+		t.Fatalf("Run(check) exit code = %d, want %d; stderr = %q", code, exitOK, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "App.tue") {
+		t.Fatalf("stdout = %q, want default-root file", stdout.String())
+	}
+}
+
+func TestRunCheckRejectsInvalidProjectRoot(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := Run([]string{"check", filepath.Join(t.TempDir(), "missing")}, &stdout, &stderr)
+
+	if code != exitError {
+		t.Fatalf("Run(check missing) exit code = %d, want %d", code, exitError)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "stat project root") {
+		t.Fatalf("stderr = %q, want stat error", stderr.String())
+	}
+}
+
+func TestRunCheckRejectsExtraProjectRoots(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := Run([]string{"check", "one", "two"}, &stdout, &stderr)
+
+	if code != exitUsage {
+		t.Fatalf("Run(check one two) exit code = %d, want %d", code, exitUsage)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "expected at most one project root") {
+		t.Fatalf("stderr = %q, want arity error", stderr.String())
+	}
+}
+
+func writeFile(t *testing.T, path string, contents string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary

- Added `cmd/tue` as the executable entry point.
- Added `internal/cli` with tested dispatch for `check`, `build`, `dev`, and `fmt`.
- Implemented `tue check [project-root]` as a discovery-only shell that reports sorted `.tue` files relative to the project root.

## Scope

This is the CLI shell slice. `build`, `dev`, and `fmt` intentionally return explicit not-implemented errors, and `check` does not parse or type-check `.tue` files yet.

## Verification

- `go fmt ./...`
- `go test ./...`
- `go run ./cmd/tue check testdata/fixtures`
- `go run ./cmd/tue --help`
- `go run ./cmd/tue fmt` (expected not-implemented exit)
- `git diff --cached --check`
- `tokensave sync`