### PR TITLE
[codex] Added the SFC block parser.

### DIFF
--- a/internal/compiler/sfc/parse.go
+++ b/internal/compiler/sfc/parse.go
@@ -1,0 +1,463 @@
+package sfc
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// Parse parses one .tue source file into source-spanned top-level blocks.
+func Parse(path string, source []byte) (*File, []Diagnostic) {
+	parser := newParser(path, string(source))
+	return parser.parse()
+}
+
+type parser struct {
+	path       string
+	source     string
+	lineStarts []int
+}
+
+type openTag struct {
+	name        string
+	attrs       []Attr
+	span        Span
+	nameSpan    Span
+	contentFrom int
+	selfClosing bool
+}
+
+func newParser(path string, source string) *parser {
+	lineStarts := []int{0}
+	for offset, r := range source {
+		if r == '\n' {
+			lineStarts = append(lineStarts, offset+1)
+		}
+	}
+
+	return &parser{
+		path:       path,
+		source:     source,
+		lineStarts: lineStarts,
+	}
+}
+
+func (p *parser) parse() (*File, []Diagnostic) {
+	file := &File{Path: p.path}
+	var diagnostics []Diagnostic
+	var fatal bool
+	var sawTemplate bool
+	var sawScript bool
+
+	for offset := 0; offset < len(p.source); {
+		next := strings.IndexByte(p.source[offset:], '<')
+		if next == -1 {
+			p.addUnexpectedText(&diagnostics, offset, len(p.source))
+			break
+		}
+
+		blockStart := offset + next
+		p.addUnexpectedText(&diagnostics, offset, blockStart)
+
+		if blockStart+1 < len(p.source) && p.source[blockStart+1] == '/' {
+			end := p.advancePastTag(blockStart)
+			diagnostics = append(diagnostics, Diagnostic{
+				Message: "unexpected closing tag",
+				Span:    p.span(blockStart, end),
+			})
+			offset = end
+			continue
+		}
+
+		tag, diagnostic, ok := p.parseOpenTag(blockStart)
+		if !ok {
+			diagnostics = append(diagnostics, diagnostic)
+			fatal = true
+			break
+		}
+
+		kind, supported := blockKind(tag.name)
+		if !supported {
+			diagnostics = append(diagnostics, Diagnostic{
+				Message: fmt.Sprintf("unsupported top-level block <%s>", tag.name),
+				Span:    tag.nameSpan,
+			})
+			offset = p.skipUnsupportedBlock(tag)
+			continue
+		}
+
+		switch kind {
+		case BlockTemplate:
+			sawTemplate = true
+		case BlockScript:
+			sawScript = true
+		}
+
+		if tag.selfClosing {
+			diagnostics = append(diagnostics, Diagnostic{
+				Message: fmt.Sprintf("<%s> block must have a closing tag", tag.name),
+				Span:    tag.span,
+			})
+			offset = tag.contentFrom
+			continue
+		}
+
+		closeStart, closeEnd, found := p.findCloseTag(tag.name, tag.contentFrom)
+		if !found {
+			diagnostics = append(diagnostics, Diagnostic{
+				Message: fmt.Sprintf("missing closing </%s> tag", tag.name),
+				Span:    tag.span,
+			})
+			fatal = true
+			break
+		}
+
+		block := &Block{
+			Kind:         kind,
+			Name:         tag.name,
+			Attrs:        tag.attrs,
+			Span:         p.span(blockStart, closeEnd),
+			OpenTagSpan:  tag.span,
+			CloseTagSpan: p.span(closeStart, closeEnd),
+			ContentSpan:  p.span(tag.contentFrom, closeStart),
+			Content:      p.source[tag.contentFrom:closeStart],
+		}
+
+		p.addBlock(file, block, &diagnostics)
+		offset = closeEnd
+	}
+
+	if !fatal {
+		eof := p.span(len(p.source), len(p.source))
+		if !sawTemplate {
+			diagnostics = append(diagnostics, Diagnostic{
+				Message: "missing required <template> block",
+				Span:    eof,
+			})
+		}
+		if !sawScript {
+			diagnostics = append(diagnostics, Diagnostic{
+				Message: "missing required <script lang=\"go\"> block",
+				Span:    eof,
+			})
+		}
+	}
+
+	return file, diagnostics
+}
+
+func (p *parser) addBlock(file *File, block *Block, diagnostics *[]Diagnostic) {
+	switch block.Kind {
+	case BlockTemplate:
+		if file.Template != nil {
+			*diagnostics = append(*diagnostics, Diagnostic{
+				Message: "duplicate <template> block",
+				Span:    block.OpenTagSpan,
+			})
+			return
+		}
+		file.Template = block
+	case BlockScript:
+		if file.Script != nil {
+			*diagnostics = append(*diagnostics, Diagnostic{
+				Message: "duplicate <script> block",
+				Span:    block.OpenTagSpan,
+			})
+			return
+		}
+		if !hasAttrValue(block.Attrs, "lang", "go") {
+			*diagnostics = append(*diagnostics, Diagnostic{
+				Message: "<script> block must set lang=\"go\"",
+				Span:    block.OpenTagSpan,
+			})
+			return
+		}
+		file.Script = block
+	case BlockStyle:
+		if file.Style != nil {
+			*diagnostics = append(*diagnostics, Diagnostic{
+				Message: "duplicate <style> block",
+				Span:    block.OpenTagSpan,
+			})
+			return
+		}
+		file.Style = block
+	}
+
+	file.Blocks = append(file.Blocks, block)
+}
+
+func blockKind(name string) (BlockKind, bool) {
+	switch name {
+	case string(BlockTemplate):
+		return BlockTemplate, true
+	case string(BlockScript):
+		return BlockScript, true
+	case string(BlockStyle):
+		return BlockStyle, true
+	default:
+		return "", false
+	}
+}
+
+func (p *parser) parseOpenTag(start int) (openTag, Diagnostic, bool) {
+	end, diagnostic, ok := p.findOpenTagEnd(start)
+	if !ok {
+		return openTag{}, diagnostic, false
+	}
+
+	bodyStart := start + 1
+	bodyEnd := end - 1
+	selfClosing := false
+	for bodyEnd > bodyStart && isSpace(p.source[bodyEnd-1]) {
+		bodyEnd--
+	}
+	if bodyEnd > bodyStart && p.source[bodyEnd-1] == '/' {
+		selfClosing = true
+		bodyEnd--
+		for bodyEnd > bodyStart && isSpace(p.source[bodyEnd-1]) {
+			bodyEnd--
+		}
+	}
+
+	nameStart := bodyStart
+	if nameStart >= bodyEnd || !isNameStart(rune(p.source[nameStart])) {
+		return openTag{}, Diagnostic{
+			Message: "malformed opening tag",
+			Span:    p.span(start, end),
+		}, false
+	}
+
+	nameEnd := nameStart + 1
+	for nameEnd < bodyEnd && isNameChar(rune(p.source[nameEnd])) {
+		nameEnd++
+	}
+
+	attrs, attrDiagnostic, ok := p.parseAttrs(nameEnd, bodyEnd)
+	if !ok {
+		return openTag{}, attrDiagnostic, false
+	}
+
+	return openTag{
+		name:        p.source[nameStart:nameEnd],
+		attrs:       attrs,
+		span:        p.span(start, end),
+		nameSpan:    p.span(nameStart, nameEnd),
+		contentFrom: end,
+		selfClosing: selfClosing,
+	}, Diagnostic{}, true
+}
+
+func (p *parser) findOpenTagEnd(start int) (int, Diagnostic, bool) {
+	var quote byte
+	for offset := start + 1; offset < len(p.source); offset++ {
+		current := p.source[offset]
+		if quote != 0 {
+			if current == quote {
+				quote = 0
+			}
+			continue
+		}
+
+		switch current {
+		case '\'', '"':
+			quote = current
+		case '>':
+			return offset + 1, Diagnostic{}, true
+		}
+	}
+
+	message := "unterminated opening tag"
+	if quote != 0 {
+		message = "unterminated quoted attribute in opening tag"
+	}
+
+	return len(p.source), Diagnostic{
+		Message: message,
+		Span:    p.span(start, len(p.source)),
+	}, false
+}
+
+func (p *parser) parseAttrs(start int, end int) ([]Attr, Diagnostic, bool) {
+	var attrs []Attr
+	for offset := skipSpaces(p.source, start, end); offset < end; offset = skipSpaces(p.source, offset, end) {
+		attrStart := offset
+		if !isNameStart(rune(p.source[offset])) {
+			return nil, Diagnostic{
+				Message: "malformed block attribute",
+				Span:    p.span(offset, end),
+			}, false
+		}
+
+		nameEnd := offset + 1
+		for nameEnd < end && isNameChar(rune(p.source[nameEnd])) {
+			nameEnd++
+		}
+
+		attr := Attr{
+			Name:     p.source[attrStart:nameEnd],
+			NameSpan: p.span(attrStart, nameEnd),
+		}
+
+		offset = skipSpaces(p.source, nameEnd, end)
+		if offset < end && p.source[offset] == '=' {
+			attr.HasValue = true
+			valueStart := skipSpaces(p.source, offset+1, end)
+			if valueStart >= end {
+				return nil, Diagnostic{
+					Message: "missing block attribute value",
+					Span:    p.span(attrStart, end),
+				}, false
+			}
+
+			var valueEnd int
+			var spanEnd int
+			if p.source[valueStart] == '"' || p.source[valueStart] == '\'' {
+				quote := p.source[valueStart]
+				valueStart++
+				valueEnd = valueStart
+				for valueEnd < end && p.source[valueEnd] != quote {
+					valueEnd++
+				}
+				if valueEnd >= end {
+					return nil, Diagnostic{
+						Message: "unterminated quoted block attribute",
+						Span:    p.span(attrStart, end),
+					}, false
+				}
+				spanEnd = valueEnd + 1
+			} else {
+				valueEnd = valueStart
+				for valueEnd < end && !isSpace(p.source[valueEnd]) {
+					valueEnd++
+				}
+				spanEnd = valueEnd
+			}
+
+			attr.Value = p.source[valueStart:valueEnd]
+			attr.ValueSpan = p.span(valueStart, valueEnd)
+			attr.Span = p.span(attrStart, spanEnd)
+			offset = spanEnd
+		} else {
+			attr.Span = p.span(attrStart, nameEnd)
+			offset = nameEnd
+		}
+
+		attrs = append(attrs, attr)
+	}
+
+	return attrs, Diagnostic{}, true
+}
+
+func (p *parser) findCloseTag(name string, start int) (int, int, bool) {
+	needle := "</" + name
+	for searchFrom := start; searchFrom < len(p.source); {
+		index := strings.Index(p.source[searchFrom:], needle)
+		if index == -1 {
+			return 0, 0, false
+		}
+
+		closeStart := searchFrom + index
+		offset := closeStart + len(needle)
+		if offset < len(p.source) && isNameChar(rune(p.source[offset])) {
+			searchFrom = offset
+			continue
+		}
+
+		offset = skipSpaces(p.source, offset, len(p.source))
+		if offset < len(p.source) && p.source[offset] == '>' {
+			return closeStart, offset + 1, true
+		}
+
+		searchFrom = offset
+	}
+
+	return 0, 0, false
+}
+
+func (p *parser) skipUnsupportedBlock(tag openTag) int {
+	if tag.selfClosing {
+		return tag.contentFrom
+	}
+	_, closeEnd, found := p.findCloseTag(tag.name, tag.contentFrom)
+	if !found {
+		return tag.contentFrom
+	}
+	return closeEnd
+}
+
+func (p *parser) addUnexpectedText(diagnostics *[]Diagnostic, start int, end int) {
+	for start < end && isSpace(p.source[start]) {
+		start++
+	}
+	for end > start && isSpace(p.source[end-1]) {
+		end--
+	}
+	if start >= end {
+		return
+	}
+	*diagnostics = append(*diagnostics, Diagnostic{
+		Message: "unexpected text outside top-level block",
+		Span:    p.span(start, end),
+	})
+}
+
+func (p *parser) advancePastTag(start int) int {
+	if end := strings.IndexByte(p.source[start:], '>'); end != -1 {
+		return start + end + 1
+	}
+	return len(p.source)
+}
+
+func hasAttrValue(attrs []Attr, name string, value string) bool {
+	for _, attr := range attrs {
+		if attr.Name == name && attr.HasValue && attr.Value == value {
+			return true
+		}
+	}
+	return false
+}
+
+func skipSpaces(source string, start int, end int) int {
+	for start < end && isSpace(source[start]) {
+		start++
+	}
+	return start
+}
+
+func isNameStart(r rune) bool {
+	return unicode.IsLetter(r)
+}
+
+func isNameChar(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '_' || r == ':'
+}
+
+func isSpace(b byte) bool {
+	switch b {
+	case ' ', '\n', '\r', '\t', '\f':
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *parser) span(start int, end int) Span {
+	return Span{
+		Start: p.position(start),
+		End:   p.position(end),
+	}
+}
+
+func (p *parser) position(offset int) Position {
+	line := 0
+	for line+1 < len(p.lineStarts) && p.lineStarts[line+1] <= offset {
+		line++
+	}
+
+	return Position{
+		Offset: offset,
+		Line:   line + 1,
+		Column: offset - p.lineStarts[line] + 1,
+	}
+}

--- a/internal/compiler/sfc/parse_test.go
+++ b/internal/compiler/sfc/parse_test.go
@@ -1,0 +1,327 @@
+package sfc
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseValidBlocks(t *testing.T) {
+	source := `<template>
+  <p>{{ greeting }}</p>
+</template>
+<script lang="go">
+package fixtures
+</script>
+<style scoped>
+p { color: red; }
+</style>
+`
+
+	file, diagnostics := Parse("hello.tue", []byte(source))
+	if len(diagnostics) != 0 {
+		t.Fatalf("Parse diagnostics = %#v, want none", diagnosticMessages(diagnostics))
+	}
+
+	if file.Path != "hello.tue" {
+		t.Fatalf("file.Path = %q, want hello.tue", file.Path)
+	}
+	if len(file.Blocks) != 3 {
+		t.Fatalf("len(file.Blocks) = %d, want 3", len(file.Blocks))
+	}
+
+	if file.Template == nil {
+		t.Fatal("file.Template is nil")
+	}
+	if file.Template.Kind != BlockTemplate {
+		t.Fatalf("template kind = %q, want %q", file.Template.Kind, BlockTemplate)
+	}
+	if got, want := file.Template.Content, "\n  <p>{{ greeting }}</p>\n"; got != want {
+		t.Fatalf("template content = %q, want %q", got, want)
+	}
+
+	if file.Script == nil {
+		t.Fatal("file.Script is nil")
+	}
+	lang, ok := file.Script.Attr("lang")
+	if !ok {
+		t.Fatal("script lang attr missing")
+	}
+	if !lang.HasValue || lang.Value != "go" {
+		t.Fatalf("script lang attr = %#v, want lang=\"go\"", lang)
+	}
+	if got, want := file.Script.Content, "\npackage fixtures\n"; got != want {
+		t.Fatalf("script content = %q, want %q", got, want)
+	}
+
+	if file.Style == nil {
+		t.Fatal("file.Style is nil")
+	}
+	if !file.Style.HasAttr("scoped") {
+		t.Fatal("style scoped attr missing")
+	}
+	if got, want := file.Style.Content, "\np { color: red; }\n"; got != want {
+		t.Fatalf("style content = %q, want %q", got, want)
+	}
+
+	scriptContentOffset := strings.Index(source, "\npackage fixtures\n")
+	if file.Script.ContentSpan.Start.Offset != scriptContentOffset {
+		t.Fatalf("script content start offset = %d, want %d", file.Script.ContentSpan.Start.Offset, scriptContentOffset)
+	}
+	if file.Script.ContentSpan.Start.Line != 4 || file.Script.ContentSpan.Start.Column != 19 {
+		t.Fatalf("script content start = %#v, want line 4 column 19", file.Script.ContentSpan.Start)
+	}
+	if file.Script.ContentSpan.End.Line != 6 || file.Script.ContentSpan.End.Column != 1 {
+		t.Fatalf("script content end = %#v, want line 6 column 1", file.Script.ContentSpan.End)
+	}
+}
+
+func TestParseScriptLangMayBeUnquoted(t *testing.T) {
+	source := `<template></template>
+<script lang=go></script>
+`
+
+	file, diagnostics := Parse("hello.tue", []byte(source))
+	if len(diagnostics) != 0 {
+		t.Fatalf("Parse diagnostics = %#v, want none", diagnosticMessages(diagnostics))
+	}
+	if file.Script == nil {
+		t.Fatal("file.Script is nil")
+	}
+	lang, ok := file.Script.Attr("lang")
+	if !ok {
+		t.Fatal("script lang attr missing")
+	}
+	if !lang.HasValue || lang.Value != "go" {
+		t.Fatalf("script lang attr = %#v, want unquoted go value", lang)
+	}
+}
+
+func TestParseFixtures(t *testing.T) {
+	root := filepath.Join("..", "..", "..", "testdata", "fixtures")
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || filepath.Ext(path) != ".tue" {
+			return nil
+		}
+
+		t.Run(filepath.ToSlash(path), func(t *testing.T) {
+			source, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read fixture: %v", err)
+			}
+
+			file, diagnostics := Parse(path, source)
+			if len(diagnostics) != 0 {
+				t.Fatalf("Parse diagnostics = %#v, want none", diagnosticMessages(diagnostics))
+			}
+			if file.Template == nil {
+				t.Fatal("file.Template is nil")
+			}
+			if file.Script == nil {
+				t.Fatal("file.Script is nil")
+			}
+		})
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk fixtures: %v", err)
+	}
+}
+
+func TestParseMissingRequiredBlocks(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "empty",
+			src:  "",
+			want: []string{
+				"missing required <template> block",
+				"missing required <script lang=\"go\"> block",
+			},
+		},
+		{
+			name: "template only",
+			src:  `<template></template>`,
+			want: []string{
+				"missing required <script lang=\"go\"> block",
+			},
+		},
+		{
+			name: "script only",
+			src:  `<script lang="go"></script>`,
+			want: []string{
+				"missing required <template> block",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, diagnostics := Parse("missing.tue", []byte(tt.src))
+			assertDiagnosticMessages(t, diagnostics, tt.want)
+		})
+	}
+}
+
+func TestParseRejectsUnsupportedAndUnexpectedTopLevelSyntax(t *testing.T) {
+	source := `intro
+<template></template>
+<route></route>
+</style>
+<script lang="go"></script>
+`
+
+	_, diagnostics := Parse("unsupported.tue", []byte(source))
+	assertDiagnosticMessages(t, diagnostics, []string{
+		"unexpected text outside top-level block",
+		"unsupported top-level block <route>",
+		"unexpected closing tag",
+	})
+
+	if diagnostics[0].Span.Start.Line != 1 || diagnostics[0].Span.Start.Column != 1 {
+		t.Fatalf("unexpected text position = %#v, want line 1 column 1", diagnostics[0].Span.Start)
+	}
+	if diagnostics[1].Span.Start.Line != 3 || diagnostics[1].Span.Start.Column != 2 {
+		t.Fatalf("unsupported block position = %#v, want line 3 column 2", diagnostics[1].Span.Start)
+	}
+	if diagnostics[2].Span.Start.Line != 4 || diagnostics[2].Span.Start.Column != 1 {
+		t.Fatalf("closing tag position = %#v, want line 4 column 1", diagnostics[2].Span.Start)
+	}
+}
+
+func TestParseRejectsDuplicateBlocks(t *testing.T) {
+	source := `<template></template>
+<template></template>
+<script lang="go"></script>
+<script lang="go"></script>
+<style></style>
+<style scoped></style>
+`
+
+	file, diagnostics := Parse("duplicates.tue", []byte(source))
+	assertDiagnosticMessages(t, diagnostics, []string{
+		"duplicate <template> block",
+		"duplicate <script> block",
+		"duplicate <style> block",
+	})
+
+	if file.Template == nil || file.Script == nil || file.Style == nil {
+		t.Fatalf("first valid blocks should be retained: template=%v script=%v style=%v", file.Template, file.Script, file.Style)
+	}
+	if len(file.Blocks) != 3 {
+		t.Fatalf("len(file.Blocks) = %d, want 3 first blocks only", len(file.Blocks))
+	}
+}
+
+func TestParseRejectsInvalidScriptLanguage(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "missing lang",
+			src: `<template></template>
+<script></script>
+`,
+		},
+		{
+			name: "wrong lang",
+			src: `<template></template>
+<script lang="ts"></script>
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, diagnostics := Parse("script.tue", []byte(tt.src))
+			assertDiagnosticMessages(t, diagnostics, []string{
+				"<script> block must set lang=\"go\"",
+			})
+			if file.Script != nil {
+				t.Fatalf("file.Script = %#v, want nil for invalid script lang", file.Script)
+			}
+		})
+	}
+}
+
+func TestParseRejectsMalformedTags(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "unterminated opening tag",
+			src:  `<template`,
+			want: "unterminated opening tag",
+		},
+		{
+			name: "unterminated quoted attr",
+			src:  `<template name="broken></template>`,
+			want: "unterminated quoted attribute in opening tag",
+		},
+		{
+			name: "missing closing tag",
+			src: `<template>
+  <p>Hello</p>
+<script lang="go"></script>
+`,
+			want: "missing closing </template> tag",
+		},
+		{
+			name: "malformed block attr",
+			src:  `<template @bad></template>`,
+			want: "malformed block attribute",
+		},
+		{
+			name: "self closing required block",
+			src: `<template />
+<script lang="go"></script>
+`,
+			want: "<template> block must have a closing tag",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, diagnostics := Parse("malformed.tue", []byte(tt.src))
+			if len(diagnostics) == 0 {
+				t.Fatal("Parse diagnostics = none, want malformed tag diagnostic")
+			}
+			if diagnostics[0].Message != tt.want {
+				t.Fatalf("first diagnostic = %q, want %q; all = %#v", diagnostics[0].Message, tt.want, diagnosticMessages(diagnostics))
+			}
+		})
+	}
+}
+
+func assertDiagnosticMessages(t *testing.T, diagnostics []Diagnostic, want []string) {
+	t.Helper()
+
+	got := diagnosticMessages(diagnostics)
+	if len(got) != len(want) {
+		t.Fatalf("diagnostics = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("diagnostic %d = %q, want %q; all = %#v", i, got[i], want[i], got)
+		}
+	}
+}
+
+func diagnosticMessages(diagnostics []Diagnostic) []string {
+	messages := make([]string, len(diagnostics))
+	for i, diagnostic := range diagnostics {
+		messages[i] = diagnostic.Message
+	}
+	return messages
+}

--- a/internal/compiler/sfc/sfc.go
+++ b/internal/compiler/sfc/sfc.go
@@ -1,0 +1,76 @@
+package sfc
+
+// BlockKind identifies a supported top-level .tue block.
+type BlockKind string
+
+const (
+	BlockTemplate BlockKind = "template"
+	BlockScript   BlockKind = "script"
+	BlockStyle    BlockKind = "style"
+)
+
+// Position is a byte-oriented source position. Line and Column are 1-based.
+type Position struct {
+	Offset int
+	Line   int
+	Column int
+}
+
+// Span is a half-open source range: Start is inclusive, End is exclusive.
+type Span struct {
+	Start Position
+	End   Position
+}
+
+// Attr is an attribute on a top-level SFC block.
+type Attr struct {
+	Name      string
+	Value     string
+	HasValue  bool
+	Span      Span
+	NameSpan  Span
+	ValueSpan Span
+}
+
+// Block is a parsed top-level .tue block.
+type Block struct {
+	Kind         BlockKind
+	Name         string
+	Attrs        []Attr
+	Span         Span
+	OpenTagSpan  Span
+	CloseTagSpan Span
+	ContentSpan  Span
+	Content      string
+}
+
+// Attr returns the first attribute with name.
+func (b *Block) Attr(name string) (Attr, bool) {
+	for _, attr := range b.Attrs {
+		if attr.Name == name {
+			return attr, true
+		}
+	}
+	return Attr{}, false
+}
+
+// HasAttr reports whether the block has an attribute with name.
+func (b *Block) HasAttr(name string) bool {
+	_, ok := b.Attr(name)
+	return ok
+}
+
+// File is a parsed .tue single-file component.
+type File struct {
+	Path     string
+	Blocks   []*Block
+	Template *Block
+	Script   *Block
+	Style    *Block
+}
+
+// Diagnostic is a source-mapped SFC parse diagnostic.
+type Diagnostic struct {
+	Message string
+	Span    Span
+}


### PR DESCRIPTION
## Summary

- Added `internal/compiler/sfc` with concrete parser data types for files, blocks, attributes, spans, positions, and diagnostics.
- Implemented parsing for top-level `<template>`, `<script lang="go">`, `<style>`, and `<style scoped>` blocks with byte offsets and 1-based line/column spans.
- Added diagnostics for missing required blocks, unsupported top-level blocks, duplicate blocks, malformed tags, unexpected top-level text/closing tags, and invalid script language.
- Added parser tests covering valid blocks, fixtures, missing blocks, duplicates, unsupported syntax, malformed tags, and source positions.

## Scope

This is the SFC block parser slice only. It does not build a template AST, type-check Go, transform CSS, or wire parser diagnostics into `tue check` yet. Multiple style blocks are intentionally rejected until the CSS generation slice needs them.

## Verification

- `go fmt ./...`
- `go test ./...`
- `go test ./internal/compiler/sfc -run TestParseFixtures -count=1`
- `git diff --check`
- lint config discovery found no configured linter
- `tokensave sync`