### PR TITLE
[codex] Added the template AST parser.

### DIFF
--- a/internal/compiler/template/ast.go
+++ b/internal/compiler/template/ast.go
@@ -1,0 +1,80 @@
+package template
+
+import "github.com/norunners/tue/internal/compiler/sfc"
+
+// NodeKind identifies the concrete shape represented by a Node.
+type NodeKind string
+
+const (
+	NodeElement       NodeKind = "element"
+	NodeText          NodeKind = "text"
+	NodeInterpolation NodeKind = "interpolation"
+	NodeComment       NodeKind = "comment"
+)
+
+// AttrKind identifies the syntactic kind of a template attribute.
+type AttrKind string
+
+const (
+	AttrStatic    AttrKind = "static"
+	AttrBind      AttrKind = "bind"
+	AttrEvent     AttrKind = "event"
+	AttrDirective AttrKind = "directive"
+)
+
+// DirectiveKind identifies a supported v-* directive.
+type DirectiveKind string
+
+const (
+	DirectiveIf    DirectiveKind = "if"
+	DirectiveElse  DirectiveKind = "else"
+	DirectiveFor   DirectiveKind = "for"
+	DirectiveModel DirectiveKind = "model"
+	DirectiveHTML  DirectiveKind = "html"
+)
+
+// Tree is a parsed template AST.
+type Tree struct {
+	Nodes []*Node
+	Span  sfc.Span
+}
+
+// Node is a concrete template AST node. Fields are populated according to Kind.
+type Node struct {
+	Kind           NodeKind
+	Span           sfc.Span
+	ContentSpan    sfc.Span
+	Tag            string
+	TagSpan        sfc.Span
+	IsComponent    bool
+	SelfClosing    bool
+	Attrs          []Attr
+	Children       []*Node
+	Text           string
+	Expression     string
+	ExpressionSpan sfc.Span
+}
+
+// Attr is a parsed element attribute or directive.
+type Attr struct {
+	Kind           AttrKind
+	Directive      DirectiveKind
+	RawName        string
+	Name           string
+	Argument       string
+	Value          string
+	Expression     string
+	HasValue       bool
+	Span           sfc.Span
+	NameSpan       sfc.Span
+	DirectiveSpan  sfc.Span
+	ArgumentSpan   sfc.Span
+	ValueSpan      sfc.Span
+	ExpressionSpan sfc.Span
+}
+
+// Diagnostic is a source-mapped template parse diagnostic.
+type Diagnostic struct {
+	Message string
+	Span    sfc.Span
+}

--- a/internal/compiler/template/parse.go
+++ b/internal/compiler/template/parse.go
@@ -1,0 +1,700 @@
+package template
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/norunners/tue/internal/compiler/sfc"
+)
+
+// Parse parses template source with positions relative to the start of source.
+func Parse(source []byte) (*Tree, []Diagnostic) {
+	return parseSource(string(source), sfc.Position{Line: 1, Column: 1})
+}
+
+// ParseBlock parses a template block returned by the SFC parser.
+func ParseBlock(block *sfc.Block) (*Tree, []Diagnostic) {
+	if block == nil {
+		return &Tree{}, []Diagnostic{{
+			Message: "missing template block",
+		}}
+	}
+	return parseSource(block.Content, block.ContentSpan.Start)
+}
+
+type parser struct {
+	source      string
+	lineStarts  []int
+	base        sfc.Position
+	diagnostics []Diagnostic
+}
+
+type openTag struct {
+	name        string
+	attrs       []Attr
+	span        sfc.Span
+	nameSpan    sfc.Span
+	contentFrom int
+	selfClosing bool
+}
+
+type closeTag struct {
+	name string
+	span sfc.Span
+}
+
+type attrSyntax struct {
+	rawName   string
+	value     string
+	hasValue  bool
+	span      sfc.Span
+	nameSpan  sfc.Span
+	valueSpan sfc.Span
+}
+
+func parseSource(source string, base sfc.Position) (*Tree, []Diagnostic) {
+	parser := newParser(source, base)
+	nodes := parser.parseChildren("")
+	return &Tree{
+		Nodes: nodes,
+		Span:  parser.span(0, len(source)),
+	}, parser.diagnostics
+}
+
+func newParser(source string, base sfc.Position) *parser {
+	if base.Line == 0 {
+		base.Line = 1
+	}
+	if base.Column == 0 {
+		base.Column = 1
+	}
+
+	lineStarts := []int{0}
+	for offset, r := range source {
+		if r == '\n' {
+			lineStarts = append(lineStarts, offset+1)
+		}
+	}
+
+	return &parser{
+		source:     source,
+		lineStarts: lineStarts,
+		base:       base,
+	}
+}
+
+func (p *parser) parseChildren(parentTag string) []*Node {
+	var nodes []*Node
+
+	for offset := 0; offset < len(p.source); {
+		node, next, done := p.parseNode(offset, parentTag)
+		if done {
+			return nodes
+		}
+		if next <= offset {
+			next = offset + 1
+		}
+		if node != nil {
+			nodes = append(nodes, node)
+		}
+		offset = next
+	}
+
+	if parentTag != "" {
+		p.addDiagnostic(fmt.Sprintf("missing closing </%s> tag", parentTag), p.span(len(p.source), len(p.source)))
+	}
+
+	return nodes
+}
+
+func (p *parser) parseNode(offset int, parentTag string) (*Node, int, bool) {
+	if strings.HasPrefix(p.source[offset:], "</") {
+		close, next, ok := p.parseCloseTag(offset)
+		if !ok {
+			return nil, next, false
+		}
+		if parentTag == "" {
+			p.addDiagnostic(fmt.Sprintf("unexpected closing </%s> tag", close.name), close.span)
+			return nil, next, false
+		}
+		if close.name != parentTag {
+			p.addDiagnostic(fmt.Sprintf("unexpected closing </%s> tag; expected </%s>", close.name, parentTag), close.span)
+			return nil, next, false
+		}
+		return nil, next, true
+	}
+
+	if strings.HasPrefix(p.source[offset:], "<!--") {
+		node, next := p.parseComment(offset)
+		return node, next, false
+	}
+
+	if p.source[offset] == '<' && offset+1 < len(p.source) && isTagNameStart(rune(p.source[offset+1])) {
+		node, next := p.parseElement(offset)
+		return node, next, false
+	}
+
+	node, next := p.parseText(offset)
+	return node, next, false
+}
+
+func (p *parser) parseElement(start int) (*Node, int) {
+	tag, diagnostic, ok := p.parseOpenTag(start)
+	if !ok {
+		p.diagnostics = append(p.diagnostics, diagnostic)
+		return nil, p.advancePastTag(start)
+	}
+
+	node := &Node{
+		Kind:        NodeElement,
+		Span:        tag.span,
+		ContentSpan: p.span(tag.contentFrom, tag.contentFrom),
+		Tag:         tag.name,
+		TagSpan:     tag.nameSpan,
+		IsComponent: isComponentTag(tag.name),
+		SelfClosing: tag.selfClosing,
+		Attrs:       tag.attrs,
+	}
+
+	if tag.selfClosing {
+		return node, tag.contentFrom
+	}
+
+	children, close, found := p.parseElementChildren(tag)
+	node.Children = children
+	if !found {
+		p.addDiagnostic(fmt.Sprintf("missing closing </%s> tag", tag.name), tag.span)
+		return node, len(p.source)
+	}
+
+	node.ContentSpan = p.span(tag.contentFrom, p.relativeOffset(close.span.Start))
+	node.Span = p.span(start, p.relativeOffset(close.span.End))
+	return node, p.relativeOffset(close.span.End)
+}
+
+func (p *parser) parseElementChildren(tag openTag) ([]*Node, closeTag, bool) {
+	var children []*Node
+	offset := tag.contentFrom
+
+	for offset < len(p.source) {
+		if strings.HasPrefix(p.source[offset:], "</") {
+			close, next, ok := p.parseCloseTag(offset)
+			if !ok {
+				offset = next
+				continue
+			}
+			if close.name != tag.name {
+				p.addDiagnostic(fmt.Sprintf("unexpected closing </%s> tag; expected </%s>", close.name, tag.name), close.span)
+				offset = next
+				continue
+			}
+			return children, close, true
+		}
+
+		node, next, _ := p.parseNode(offset, tag.name)
+		if next <= offset {
+			next = offset + 1
+		}
+		if node != nil {
+			children = append(children, node)
+		}
+		offset = next
+	}
+
+	return children, closeTag{}, false
+}
+
+func (p *parser) parseText(start int) (*Node, int) {
+	end := len(p.source)
+	if next := findNextTagStart(p.source, start+1); next != -1 {
+		end = next
+	}
+
+	if strings.HasPrefix(p.source[start:end], "{{") {
+		return p.parseInterpolation(start, end)
+	}
+
+	openIndex := strings.Index(p.source[start:end], "{{")
+	closeIndex := strings.Index(p.source[start:end], "}}")
+	if closeIndex == 0 {
+		p.addDiagnostic("unexpected interpolation closing braces", p.span(start, start+2))
+		return nil, start + 2
+	}
+	if closeIndex != -1 && (openIndex == -1 || closeIndex < openIndex) {
+		return p.textNode(start, start+closeIndex), start + closeIndex
+	}
+	if openIndex != -1 {
+		return p.textNode(start, start+openIndex), start + openIndex
+	}
+
+	return p.textNode(start, end), end
+}
+
+func (p *parser) parseInterpolation(start int, end int) (*Node, int) {
+	closeIndex := strings.Index(p.source[start+2:end], "}}")
+	if closeIndex == -1 {
+		p.addDiagnostic("unterminated interpolation", p.span(start, end))
+		return nil, end
+	}
+
+	exprRawStart := start + 2
+	exprRawEnd := start + 2 + closeIndex
+	exprStart, exprEnd := trimSpaceRange(p.source, exprRawStart, exprRawEnd)
+	if exprStart == exprEnd {
+		p.addDiagnostic("empty interpolation expression", p.span(start, exprRawEnd+2))
+	}
+
+	return &Node{
+		Kind:           NodeInterpolation,
+		Span:           p.span(start, exprRawEnd+2),
+		ContentSpan:    p.span(exprRawStart, exprRawEnd),
+		Expression:     p.source[exprStart:exprEnd],
+		ExpressionSpan: p.span(exprStart, exprEnd),
+	}, exprRawEnd + 2
+}
+
+func (p *parser) textNode(start int, end int) *Node {
+	return &Node{
+		Kind:        NodeText,
+		Span:        p.span(start, end),
+		ContentSpan: p.span(start, end),
+		Text:        p.source[start:end],
+	}
+}
+
+func (p *parser) parseComment(start int) (*Node, int) {
+	contentStart := start + len("<!--")
+	endIndex := strings.Index(p.source[contentStart:], "-->")
+	if endIndex == -1 {
+		p.addDiagnostic("unterminated comment", p.span(start, len(p.source)))
+		return &Node{
+			Kind:        NodeComment,
+			Span:        p.span(start, len(p.source)),
+			ContentSpan: p.span(contentStart, len(p.source)),
+			Text:        p.source[contentStart:],
+		}, len(p.source)
+	}
+
+	contentEnd := contentStart + endIndex
+	end := contentEnd + len("-->")
+	return &Node{
+		Kind:        NodeComment,
+		Span:        p.span(start, end),
+		ContentSpan: p.span(contentStart, contentEnd),
+		Text:        p.source[contentStart:contentEnd],
+	}, end
+}
+
+func (p *parser) parseOpenTag(start int) (openTag, Diagnostic, bool) {
+	end, diagnostic, ok := p.findOpenTagEnd(start)
+	if !ok {
+		return openTag{}, diagnostic, false
+	}
+
+	bodyStart := start + 1
+	bodyEnd := end - 1
+	selfClosing := false
+	for bodyEnd > bodyStart && isSpace(p.source[bodyEnd-1]) {
+		bodyEnd--
+	}
+	if bodyEnd > bodyStart && p.source[bodyEnd-1] == '/' {
+		selfClosing = true
+		bodyEnd--
+		for bodyEnd > bodyStart && isSpace(p.source[bodyEnd-1]) {
+			bodyEnd--
+		}
+	}
+
+	nameStart := bodyStart
+	if nameStart >= bodyEnd || !isTagNameStart(rune(p.source[nameStart])) {
+		return openTag{}, Diagnostic{
+			Message: "malformed opening tag",
+			Span:    p.span(start, end),
+		}, false
+	}
+
+	nameEnd := nameStart + 1
+	for nameEnd < bodyEnd && isTagNameChar(rune(p.source[nameEnd])) {
+		nameEnd++
+	}
+
+	attrs, attrDiagnostics := p.parseAttrs(nameEnd, bodyEnd)
+	p.diagnostics = append(p.diagnostics, attrDiagnostics...)
+
+	return openTag{
+		name:        p.source[nameStart:nameEnd],
+		attrs:       attrs,
+		span:        p.span(start, end),
+		nameSpan:    p.span(nameStart, nameEnd),
+		contentFrom: end,
+		selfClosing: selfClosing,
+	}, Diagnostic{}, true
+}
+
+func (p *parser) parseCloseTag(start int) (closeTag, int, bool) {
+	end := p.advancePastTag(start)
+	if end == len(p.source) && (end == start || p.source[end-1] != '>') {
+		p.addDiagnostic("unterminated closing tag", p.span(start, end))
+		return closeTag{}, end, false
+	}
+
+	bodyStart := start + 2
+	bodyEnd := end - 1
+	bodyStart = skipSpaces(p.source, bodyStart, bodyEnd)
+	bodyEnd = trimRightSpaces(p.source, bodyStart, bodyEnd)
+	if bodyStart >= bodyEnd || !isTagNameStart(rune(p.source[bodyStart])) {
+		p.addDiagnostic("malformed closing tag", p.span(start, end))
+		return closeTag{}, end, false
+	}
+
+	nameEnd := bodyStart + 1
+	for nameEnd < bodyEnd && isTagNameChar(rune(p.source[nameEnd])) {
+		nameEnd++
+	}
+	if skipSpaces(p.source, nameEnd, bodyEnd) != bodyEnd {
+		p.addDiagnostic("malformed closing tag", p.span(start, end))
+		return closeTag{}, end, false
+	}
+
+	return closeTag{
+		name: p.source[bodyStart:nameEnd],
+		span: p.span(start, end),
+	}, end, true
+}
+
+func (p *parser) findOpenTagEnd(start int) (int, Diagnostic, bool) {
+	var quote byte
+	for offset := start + 1; offset < len(p.source); offset++ {
+		current := p.source[offset]
+		if quote != 0 {
+			if current == quote {
+				quote = 0
+			}
+			continue
+		}
+
+		switch current {
+		case '\'', '"':
+			quote = current
+		case '>':
+			return offset + 1, Diagnostic{}, true
+		}
+	}
+
+	message := "unterminated opening tag"
+	if quote != 0 {
+		message = "unterminated quoted attribute in opening tag"
+	}
+
+	return len(p.source), Diagnostic{
+		Message: message,
+		Span:    p.span(start, len(p.source)),
+	}, false
+}
+
+func (p *parser) parseAttrs(start int, end int) ([]Attr, []Diagnostic) {
+	var attrs []Attr
+	var diagnostics []Diagnostic
+
+	for offset := skipSpaces(p.source, start, end); offset < end; offset = skipSpaces(p.source, offset, end) {
+		syntax, next, diagnostic, ok := p.parseAttr(offset, end)
+		if !ok {
+			diagnostics = append(diagnostics, diagnostic)
+			break
+		}
+
+		attr, attrDiagnostics := p.classifyAttr(syntax)
+		diagnostics = append(diagnostics, attrDiagnostics...)
+		attrs = append(attrs, attr)
+		offset = next
+	}
+
+	return attrs, diagnostics
+}
+
+func (p *parser) parseAttr(start int, end int) (attrSyntax, int, Diagnostic, bool) {
+	if !isAttrNameStart(rune(p.source[start])) {
+		return attrSyntax{}, end, Diagnostic{
+			Message: "malformed attribute",
+			Span:    p.span(start, end),
+		}, false
+	}
+
+	nameEnd := start + 1
+	for nameEnd < end && isAttrNameChar(rune(p.source[nameEnd])) {
+		nameEnd++
+	}
+
+	syntax := attrSyntax{
+		rawName:  p.source[start:nameEnd],
+		span:     p.span(start, nameEnd),
+		nameSpan: p.span(start, nameEnd),
+	}
+
+	offset := skipSpaces(p.source, nameEnd, end)
+	if offset >= end || p.source[offset] != '=' {
+		return syntax, nameEnd, Diagnostic{}, true
+	}
+
+	syntax.hasValue = true
+	valueStart := skipSpaces(p.source, offset+1, end)
+	if valueStart >= end {
+		return attrSyntax{}, end, Diagnostic{
+			Message: "missing attribute value",
+			Span:    p.span(start, end),
+		}, false
+	}
+
+	var valueEnd int
+	var spanEnd int
+	if p.source[valueStart] == '"' || p.source[valueStart] == '\'' {
+		quote := p.source[valueStart]
+		valueStart++
+		valueEnd = valueStart
+		for valueEnd < end && p.source[valueEnd] != quote {
+			valueEnd++
+		}
+		if valueEnd >= end {
+			return attrSyntax{}, end, Diagnostic{
+				Message: "unterminated quoted attribute",
+				Span:    p.span(start, end),
+			}, false
+		}
+		spanEnd = valueEnd + 1
+	} else {
+		valueEnd = valueStart
+		for valueEnd < end && !isSpace(p.source[valueEnd]) {
+			valueEnd++
+		}
+		spanEnd = valueEnd
+	}
+
+	syntax.value = p.source[valueStart:valueEnd]
+	syntax.valueSpan = p.span(valueStart, valueEnd)
+	syntax.span = p.span(start, spanEnd)
+	return syntax, spanEnd, Diagnostic{}, true
+}
+
+func (p *parser) classifyAttr(syntax attrSyntax) (Attr, []Diagnostic) {
+	attr := Attr{
+		Kind:      AttrStatic,
+		RawName:   syntax.rawName,
+		Name:      syntax.rawName,
+		Value:     syntax.value,
+		HasValue:  syntax.hasValue,
+		Span:      syntax.span,
+		NameSpan:  syntax.nameSpan,
+		ValueSpan: syntax.valueSpan,
+	}
+
+	var diagnostics []Diagnostic
+	if strings.HasPrefix(syntax.rawName, ":") {
+		attr.Kind = AttrBind
+		attr.Name = strings.TrimPrefix(syntax.rawName, ":")
+		attr.Argument = attr.Name
+		nameStart := p.relativeOffset(syntax.nameSpan.Start)
+		nameEnd := p.relativeOffset(syntax.nameSpan.End)
+		attr.DirectiveSpan = p.span(nameStart, nameStart+1)
+		attr.ArgumentSpan = p.span(nameStart+1, nameEnd)
+		if attr.Argument == "" {
+			diagnostics = append(diagnostics, Diagnostic{
+				Message: "bound attribute name cannot be empty",
+				Span:    syntax.nameSpan,
+			})
+		}
+		diagnostics = append(diagnostics, p.requireExpression(&attr, "bound attribute requires an expression")...)
+		return attr, diagnostics
+	}
+
+	if strings.HasPrefix(syntax.rawName, "@") {
+		attr.Kind = AttrEvent
+		attr.Name = strings.TrimPrefix(syntax.rawName, "@")
+		attr.Argument = attr.Name
+		nameStart := p.relativeOffset(syntax.nameSpan.Start)
+		nameEnd := p.relativeOffset(syntax.nameSpan.End)
+		attr.DirectiveSpan = p.span(nameStart, nameStart+1)
+		attr.ArgumentSpan = p.span(nameStart+1, nameEnd)
+		if attr.Argument == "" {
+			diagnostics = append(diagnostics, Diagnostic{
+				Message: "event name cannot be empty",
+				Span:    syntax.nameSpan,
+			})
+		}
+		diagnostics = append(diagnostics, p.requireExpression(&attr, "event handler requires an expression")...)
+		return attr, diagnostics
+	}
+
+	if strings.HasPrefix(syntax.rawName, "v-") {
+		attr.Kind = AttrDirective
+		attr.Name = strings.TrimPrefix(syntax.rawName, "v-")
+		attr.DirectiveSpan = syntax.nameSpan
+
+		switch DirectiveKind(attr.Name) {
+		case DirectiveIf:
+			attr.Directive = DirectiveIf
+			diagnostics = append(diagnostics, p.requireExpression(&attr, "v-if requires an expression")...)
+		case DirectiveElse:
+			attr.Directive = DirectiveElse
+			if attr.HasValue {
+				diagnostics = append(diagnostics, Diagnostic{
+					Message: "v-else must not have a value",
+					Span:    attr.ValueSpan,
+				})
+			}
+		case DirectiveFor:
+			attr.Directive = DirectiveFor
+			diagnostics = append(diagnostics, p.requireExpression(&attr, "v-for requires an expression")...)
+		case DirectiveModel:
+			attr.Directive = DirectiveModel
+			diagnostics = append(diagnostics, p.requireExpression(&attr, "v-model requires an expression")...)
+		case DirectiveHTML:
+			attr.Directive = DirectiveHTML
+			diagnostics = append(diagnostics, p.requireExpression(&attr, "v-html requires an expression")...)
+		default:
+			diagnostics = append(diagnostics, Diagnostic{
+				Message: fmt.Sprintf("unsupported directive %q", syntax.rawName),
+				Span:    syntax.nameSpan,
+			})
+		}
+
+		return attr, diagnostics
+	}
+
+	return attr, diagnostics
+}
+
+func (p *parser) requireExpression(attr *Attr, message string) []Diagnostic {
+	if !attr.HasValue {
+		return []Diagnostic{{
+			Message: message,
+			Span:    attr.NameSpan,
+		}}
+	}
+
+	start, end := trimSpaceRange(p.source, p.relativeOffset(attr.ValueSpan.Start), p.relativeOffset(attr.ValueSpan.End))
+	attr.Expression = p.source[start:end]
+	attr.ExpressionSpan = p.span(start, end)
+	if start == end {
+		return []Diagnostic{{
+			Message: message,
+			Span:    attr.ValueSpan,
+		}}
+	}
+	return nil
+}
+
+func findNextTagStart(source string, start int) int {
+	for offset := start; offset < len(source); offset++ {
+		if source[offset] != '<' {
+			continue
+		}
+		if strings.HasPrefix(source[offset:], "<!--") {
+			return offset
+		}
+		if offset+1 < len(source) && (source[offset+1] == '/' || isTagNameStart(rune(source[offset+1]))) {
+			return offset
+		}
+	}
+	return -1
+}
+
+func (p *parser) advancePastTag(start int) int {
+	if end := strings.IndexByte(p.source[start:], '>'); end != -1 {
+		return start + end + 1
+	}
+	return len(p.source)
+}
+
+func (p *parser) addDiagnostic(message string, span sfc.Span) {
+	p.diagnostics = append(p.diagnostics, Diagnostic{
+		Message: message,
+		Span:    span,
+	})
+}
+
+func trimSpaceRange(source string, start int, end int) (int, int) {
+	for start < end && isSpace(source[start]) {
+		start++
+	}
+	for end > start && isSpace(source[end-1]) {
+		end--
+	}
+	return start, end
+}
+
+func skipSpaces(source string, start int, end int) int {
+	for start < end && isSpace(source[start]) {
+		start++
+	}
+	return start
+}
+
+func trimRightSpaces(source string, start int, end int) int {
+	for end > start && isSpace(source[end-1]) {
+		end--
+	}
+	return end
+}
+
+func isTagNameStart(r rune) bool {
+	return unicode.IsLetter(r)
+}
+
+func isTagNameChar(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '_' || r == ':'
+}
+
+func isAttrNameStart(r rune) bool {
+	return unicode.IsLetter(r) || r == ':' || r == '@'
+}
+
+func isAttrNameChar(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '_' || r == ':' || r == '@' || r == '.'
+}
+
+func isComponentTag(tag string) bool {
+	r, _ := utf8.DecodeRuneInString(tag)
+	return unicode.IsUpper(r)
+}
+
+func isSpace(b byte) bool {
+	switch b {
+	case ' ', '\n', '\r', '\t', '\f':
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *parser) span(start int, end int) sfc.Span {
+	return sfc.Span{
+		Start: p.position(start),
+		End:   p.position(end),
+	}
+}
+
+func (p *parser) relativeOffset(position sfc.Position) int {
+	return position.Offset - p.base.Offset
+}
+
+func (p *parser) position(offset int) sfc.Position {
+	lineIndex := sort.Search(len(p.lineStarts), func(i int) bool {
+		return p.lineStarts[i] > offset
+	}) - 1
+	if lineIndex < 0 {
+		lineIndex = 0
+	}
+
+	position := sfc.Position{
+		Offset: p.base.Offset + offset,
+		Line:   p.base.Line + lineIndex,
+		Column: offset - p.lineStarts[lineIndex] + 1,
+	}
+	if lineIndex == 0 {
+		position.Column = p.base.Column + offset
+	}
+	return position
+}

--- a/internal/compiler/template/parse_test.go
+++ b/internal/compiler/template/parse_test.go
@@ -1,0 +1,350 @@
+package template
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/norunners/tue/internal/compiler/sfc"
+)
+
+func TestParseElementsAttributesInterpolationAndComponents(t *testing.T) {
+	source := `<main class="page"><p>{{ greeting }}, {{ name }}!</p><button type="button" @click="increment">Increment</button><UserBadge :name="name" :isAdmin='role == "admin"' /></main>`
+
+	tree, diagnostics := Parse([]byte(source))
+	if len(diagnostics) != 0 {
+		t.Fatalf("Parse diagnostics = %#v, want none", diagnosticMessages(diagnostics))
+	}
+
+	want := strings.TrimSpace(`
+element main component=false selfClosing=false
+  attr static class value="page"
+  element p component=false selfClosing=false
+    interpolation "greeting"
+    text ", "
+    interpolation "name"
+    text "!"
+  element button component=false selfClosing=false
+    attr static type value="button"
+    attr event click expr="increment"
+    text "Increment"
+  element UserBadge component=true selfClosing=true
+    attr bind name expr="name"
+    attr bind isAdmin expr="role == \"admin\""
+`)
+
+	if got := dumpNodes(tree.Nodes); got != want {
+		t.Fatalf("AST dump mismatch\ngot:\n%s\nwant:\n%s", got, want)
+	}
+
+	main := tree.Nodes[0]
+	if main.TagSpan.Start.Offset != 1 || main.TagSpan.End.Offset != 5 {
+		t.Fatalf("main tag span = %#v, want offsets 1..5", main.TagSpan)
+	}
+
+	userBadge := main.Children[2]
+	isAdmin := attrByRawName(t, userBadge, ":isAdmin")
+	exprOffset := strings.Index(source, `role == "admin"`)
+	if isAdmin.ExpressionSpan.Start.Offset != exprOffset {
+		t.Fatalf(":isAdmin expression offset = %d, want %d", isAdmin.ExpressionSpan.Start.Offset, exprOffset)
+	}
+	if isAdmin.Expression != `role == "admin"` {
+		t.Fatalf(":isAdmin expression = %q", isAdmin.Expression)
+	}
+
+	button := main.Children[1]
+	click := attrByRawName(t, button, "@click")
+	clickOffset := strings.Index(source, "click")
+	if click.ArgumentSpan.Start.Offset != clickOffset {
+		t.Fatalf("@click argument offset = %d, want %d", click.ArgumentSpan.Start.Offset, clickOffset)
+	}
+	incrementOffset := strings.Index(source, "increment")
+	if click.ExpressionSpan.Start.Offset != incrementOffset {
+		t.Fatalf("@click expression offset = %d, want %d", click.ExpressionSpan.Start.Offset, incrementOffset)
+	}
+}
+
+func TestParseDirectivesAndComments(t *testing.T) {
+	source := `<section><!-- note --><p v-if="user.Admin">Admin</p><p v-else>Member</p><ul><li v-for="todo in todos" :key="todo.ID">{{ todo.Text }}</li></ul><input v-model="query" /><div v-html="trusted"></div></section>`
+
+	tree, diagnostics := Parse([]byte(source))
+	if len(diagnostics) != 0 {
+		t.Fatalf("Parse diagnostics = %#v, want none", diagnosticMessages(diagnostics))
+	}
+
+	want := strings.TrimSpace(`
+element section component=false selfClosing=false
+  comment " note "
+  element p component=false selfClosing=false
+    directive if expr="user.Admin"
+    text "Admin"
+  element p component=false selfClosing=false
+    directive else
+    text "Member"
+  element ul component=false selfClosing=false
+    element li component=false selfClosing=false
+      directive for expr="todo in todos"
+      attr bind key expr="todo.ID"
+      interpolation "todo.Text"
+  element input component=false selfClosing=true
+    directive model expr="query"
+  element div component=false selfClosing=false
+    directive html expr="trusted"
+`)
+
+	if got := dumpNodes(tree.Nodes); got != want {
+		t.Fatalf("AST dump mismatch\ngot:\n%s\nwant:\n%s", got, want)
+	}
+
+	section := tree.Nodes[0]
+	admin := childElement(t, section, "p", 0)
+	vif := attrByRawName(t, admin, "v-if")
+	vifOffset := strings.Index(source, "v-if")
+	if vif.DirectiveSpan.Start.Offset != vifOffset || vif.DirectiveSpan.End.Offset != vifOffset+len("v-if") {
+		t.Fatalf("v-if directive span = %#v, want offsets %d..%d", vif.DirectiveSpan, vifOffset, vifOffset+len("v-if"))
+	}
+}
+
+func TestParseBlockUsesSFCSourceSpans(t *testing.T) {
+	source := `<template>
+<p>{{ name }}</p>
+</template>
+<script lang="go"></script>
+`
+
+	file, sfcDiagnostics := sfc.Parse("component.tue", []byte(source))
+	if len(sfcDiagnostics) != 0 {
+		t.Fatalf("sfc.Parse diagnostics = %#v, want none", sfcDiagnostics)
+	}
+
+	tree, diagnostics := ParseBlock(file.Template)
+	if len(diagnostics) != 0 {
+		t.Fatalf("ParseBlock diagnostics = %#v, want none", diagnosticMessages(diagnostics))
+	}
+
+	paragraph := firstElement(t, tree.Nodes, "p")
+	interpolation := paragraph.Children[0]
+	nameOffset := strings.Index(source, "name")
+	if interpolation.ExpressionSpan.Start.Offset != nameOffset {
+		t.Fatalf("expression offset = %d, want %d", interpolation.ExpressionSpan.Start.Offset, nameOffset)
+	}
+	if interpolation.ExpressionSpan.Start.Line != 2 || interpolation.ExpressionSpan.Start.Column != 7 {
+		t.Fatalf("expression position = %#v, want line 2 column 7", interpolation.ExpressionSpan.Start)
+	}
+}
+
+func TestParseFixtures(t *testing.T) {
+	root := filepath.Join("..", "..", "..", "testdata", "fixtures")
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || filepath.Ext(path) != ".tue" {
+			return nil
+		}
+
+		t.Run(filepath.ToSlash(path), func(t *testing.T) {
+			source, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read fixture: %v", err)
+			}
+
+			file, sfcDiagnostics := sfc.Parse(path, source)
+			if len(sfcDiagnostics) != 0 {
+				t.Fatalf("sfc.Parse diagnostics = %#v, want none", sfcDiagnostics)
+			}
+
+			_, diagnostics := ParseBlock(file.Template)
+			if len(diagnostics) != 0 {
+				t.Fatalf("ParseBlock diagnostics = %#v, want none", diagnosticMessages(diagnostics))
+			}
+		})
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk fixtures: %v", err)
+	}
+}
+
+func TestParseDiagnostics(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "empty interpolation",
+			src:  `<p>{{ }}</p>`,
+			want: []string{"empty interpolation expression"},
+		},
+		{
+			name: "unterminated interpolation",
+			src:  `<p>{{ name</p>`,
+			want: []string{"unterminated interpolation"},
+		},
+		{
+			name: "unexpected interpolation close",
+			src:  `<p>name }}</p>`,
+			want: []string{"unexpected interpolation closing braces"},
+		},
+		{
+			name: "empty bound attr",
+			src:  `<p :="name"></p>`,
+			want: []string{"bound attribute name cannot be empty"},
+		},
+		{
+			name: "empty event",
+			src:  `<p @="click"></p>`,
+			want: []string{"event name cannot be empty"},
+		},
+		{
+			name: "v-if without expression",
+			src:  `<p v-if></p>`,
+			want: []string{"v-if requires an expression"},
+		},
+		{
+			name: "v-else with value",
+			src:  `<p v-else="ok"></p>`,
+			want: []string{"v-else must not have a value"},
+		},
+		{
+			name: "unsupported directive",
+			src:  `<p v-show="ok"></p>`,
+			want: []string{`unsupported directive "v-show"`},
+		},
+		{
+			name: "mismatched close",
+			src:  `<p></div>`,
+			want: []string{"unexpected closing </div> tag; expected </p>", "missing closing </p> tag"},
+		},
+		{
+			name: "unterminated comment",
+			src:  `<p><!-- broken</p>`,
+			want: []string{"unterminated comment", "missing closing </p> tag"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, diagnostics := Parse([]byte(tt.src))
+			assertDiagnosticMessages(t, diagnostics, tt.want)
+		})
+	}
+}
+
+func attrByRawName(t *testing.T, node *Node, rawName string) Attr {
+	t.Helper()
+
+	for _, attr := range node.Attrs {
+		if attr.RawName == rawName {
+			return attr
+		}
+	}
+	t.Fatalf("attribute %q not found on <%s>", rawName, node.Tag)
+	return Attr{}
+}
+
+func firstElement(t *testing.T, nodes []*Node, tag string) *Node {
+	t.Helper()
+
+	for _, node := range nodes {
+		if node.Kind == NodeElement && node.Tag == tag {
+			return node
+		}
+	}
+	t.Fatalf("element <%s> not found", tag)
+	return nil
+}
+
+func childElement(t *testing.T, parent *Node, tag string, index int) *Node {
+	t.Helper()
+
+	seen := 0
+	for _, child := range parent.Children {
+		if child.Kind == NodeElement && child.Tag == tag {
+			if seen == index {
+				return child
+			}
+			seen++
+		}
+	}
+	t.Fatalf("child element <%s> index %d not found under <%s>", tag, index, parent.Tag)
+	return nil
+}
+
+func assertDiagnosticMessages(t *testing.T, diagnostics []Diagnostic, want []string) {
+	t.Helper()
+
+	got := diagnosticMessages(diagnostics)
+	if len(got) != len(want) {
+		t.Fatalf("diagnostics = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("diagnostic %d = %q, want %q; all = %#v", i, got[i], want[i], got)
+		}
+	}
+}
+
+func diagnosticMessages(diagnostics []Diagnostic) []string {
+	messages := make([]string, len(diagnostics))
+	for i, diagnostic := range diagnostics {
+		messages[i] = diagnostic.Message
+	}
+	return messages
+}
+
+func dumpNodes(nodes []*Node) string {
+	var builder strings.Builder
+	for _, node := range nodes {
+		dumpNode(&builder, node, 0)
+	}
+	return strings.TrimRight(builder.String(), "\n")
+}
+
+func dumpNode(builder *strings.Builder, node *Node, depth int) {
+	indent := strings.Repeat("  ", depth)
+	switch node.Kind {
+	case NodeElement:
+		fmt.Fprintf(builder, "%selement %s component=%t selfClosing=%t\n", indent, node.Tag, node.IsComponent, node.SelfClosing)
+		for _, attr := range node.Attrs {
+			dumpAttr(builder, attr, depth+1)
+		}
+		for _, child := range node.Children {
+			dumpNode(builder, child, depth+1)
+		}
+	case NodeText:
+		fmt.Fprintf(builder, "%stext %q\n", indent, node.Text)
+	case NodeInterpolation:
+		fmt.Fprintf(builder, "%sinterpolation %q\n", indent, node.Expression)
+	case NodeComment:
+		fmt.Fprintf(builder, "%scomment %q\n", indent, node.Text)
+	default:
+		fmt.Fprintf(builder, "%sunknown %q\n", indent, node.Kind)
+	}
+}
+
+func dumpAttr(builder *strings.Builder, attr Attr, depth int) {
+	indent := strings.Repeat("  ", depth)
+	switch attr.Kind {
+	case AttrStatic:
+		if attr.HasValue {
+			fmt.Fprintf(builder, "%sattr static %s value=%q\n", indent, attr.Name, attr.Value)
+		} else {
+			fmt.Fprintf(builder, "%sattr static %s\n", indent, attr.Name)
+		}
+	case AttrBind:
+		fmt.Fprintf(builder, "%sattr bind %s expr=%q\n", indent, attr.Argument, attr.Expression)
+	case AttrEvent:
+		fmt.Fprintf(builder, "%sattr event %s expr=%q\n", indent, attr.Argument, attr.Expression)
+	case AttrDirective:
+		if attr.Expression != "" {
+			fmt.Fprintf(builder, "%sdirective %s expr=%q\n", indent, attr.Directive, attr.Expression)
+		} else {
+			fmt.Fprintf(builder, "%sdirective %s\n", indent, attr.Directive)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Added `internal/compiler/template` with concrete AST types for template trees, nodes, attributes, directives, spans, and diagnostics.
- Implemented parsing for elements, text, comments, interpolation, static attributes, `:prop` bindings, `@event` handlers, component-looking uppercase tags, and MVP directives.
- Preserved expression, directive, argument, value, tag, node, and content spans using the SFC parser source-position model.
- Added AST golden-style tests, fixture parsing tests, SFC span-mapping tests, and syntax diagnostic tests.

## Scope

This is the template AST parser slice only. It does not type-check expressions, generate render code, or wire parser diagnostics into `tue check` yet.

## Verification

- `go fmt ./...`
- `go test ./...`
- `go test ./internal/compiler/template -run TestParseFixtures -count=1`
- `git diff --check`
- lint config discovery found no configured linter
- `tokensave sync`