### PR TITLE
[codex] Added script component contracts.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/norunners/tue
 
 go 1.26.4
+
+require github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=

--- a/internal/compiler/script/contract.go
+++ b/internal/compiler/script/contract.go
@@ -1,0 +1,91 @@
+package script
+
+import "github.com/norunners/tue/internal/compiler/sfc"
+
+// File is the extracted contract view of one Go script block.
+type File struct {
+	Path        string
+	PackageName string
+	PackageSpan sfc.Span
+	Imports     []Import
+	Component   *Component
+}
+
+// Import is a Go import declaration used by the script block.
+type Import struct {
+	Name     string
+	Path     string
+	Span     sfc.Span
+	NameSpan sfc.Span
+	PathSpan sfc.Span
+}
+
+// Component is the contract extracted from the expected component struct.
+type Component struct {
+	Name       string
+	Span       sfc.Span
+	NameSpan   sfc.Span
+	Props      []Prop
+	State      []Field
+	Refs       []Field
+	Computed   []Field
+	Resources  []Field
+	Methods    []Method
+	Init       *Method
+	Allocation Allocation
+}
+
+// Allocation describes the generated-code construction shape for a component.
+type Allocation struct {
+	ComponentName string
+	PropFields    []string
+	CallsInit     bool
+}
+
+// Prop is a component prop field plus prop-specific metadata.
+type Prop struct {
+	Field    Field
+	Name     string
+	Required bool
+}
+
+// Field is a named field on the component struct.
+type Field struct {
+	Kind      FieldKind
+	Name      string
+	Exported  bool
+	Type      string
+	ValueType string
+	Tag       string
+	Span      sfc.Span
+	NameSpan  sfc.Span
+	TypeSpan  sfc.Span
+	TagSpan   sfc.Span
+}
+
+// Method is a method declared on the component type.
+type Method struct {
+	Name            string
+	ReceiverName    string
+	PointerReceiver bool
+	Parameters      []Parameter
+	Results         []Parameter
+	Span            sfc.Span
+	NameSpan        sfc.Span
+	ReceiverSpan    sfc.Span
+}
+
+// Parameter is a method parameter or result.
+type Parameter struct {
+	Name     string
+	Type     string
+	Span     sfc.Span
+	NameSpan sfc.Span
+	TypeSpan sfc.Span
+}
+
+// Diagnostic is a source-mapped script extraction diagnostic.
+type Diagnostic struct {
+	Message string
+	Span    sfc.Span
+}

--- a/internal/compiler/script/enum.go
+++ b/internal/compiler/script/enum.go
@@ -1,0 +1,12 @@
+package script
+
+// FieldKind identifies how a component field participates in the contract.
+type FieldKind string
+
+const (
+	FieldKindState    FieldKind = "state"
+	FieldKindProp     FieldKind = "prop"
+	FieldKindRef      FieldKind = "ref"
+	FieldKindComputed FieldKind = "computed"
+	FieldKindResource FieldKind = "resource"
+)

--- a/internal/compiler/script/parse.go
+++ b/internal/compiler/script/parse.go
@@ -1,0 +1,605 @@
+package script
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/format"
+	goparser "go/parser"
+	"go/scanner"
+	"go/token"
+	"go/types"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/norunners/tue/internal/compiler/sfc"
+)
+
+const tueImportPath = "github.com/norunners/tue"
+
+// Parse parses Go script source with positions relative to the start of source.
+func Parse(source []byte, componentName string) (*File, []Diagnostic) {
+	return parseSource("", string(source), componentName, sfc.Position{Line: 1, Column: 1})
+}
+
+// ParseBlock parses a script block returned by the SFC parser.
+func ParseBlock(block *sfc.Block, componentName string) (*File, []Diagnostic) {
+	if block == nil {
+		return &File{}, []Diagnostic{{
+			Message: "missing script block",
+		}}
+	}
+	return parseSource("", block.Content, componentName, block.ContentSpan.Start)
+}
+
+// ParseSFC parses the script block from an SFC file and derives the component
+// name from the file basename.
+func ParseSFC(file *sfc.File) (*File, []Diagnostic) {
+	if file == nil {
+		return &File{}, []Diagnostic{{
+			Message: "missing SFC file",
+		}}
+	}
+
+	script, diagnostics := ParseBlock(file.Script, ComponentNameFromPath(file.Path))
+	script.Path = file.Path
+	return script, diagnostics
+}
+
+// ComponentNameFromPath returns the PascalCase component name for a .tue path.
+func ComponentNameFromPath(path string) string {
+	base := path
+	if index := strings.LastIndexAny(base, `/\`); index != -1 {
+		base = base[index+1:]
+	}
+	if index := strings.LastIndexByte(base, '.'); index != -1 {
+		base = base[:index]
+	}
+
+	var builder strings.Builder
+	upperNext := true
+	for _, r := range base {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			upperNext = true
+			continue
+		}
+		if upperNext {
+			r = unicode.ToUpper(r)
+			upperNext = false
+		}
+		builder.WriteRune(r)
+	}
+	return builder.String()
+}
+
+type extractor struct {
+	path        string
+	source      string
+	lineStarts  []int
+	base        sfc.Position
+	fset        *token.FileSet
+	tokenFile   *token.File
+	tueNames    map[string]bool
+	tueDot      bool
+	diagnostics []Diagnostic
+}
+
+func parseSource(path string, source string, componentName string, base sfc.Position) (*File, []Diagnostic) {
+	extractor := newExtractor(path, source, base)
+	return extractor.parse(componentName)
+}
+
+func newExtractor(path string, source string, base sfc.Position) *extractor {
+	if base.Line == 0 {
+		base.Line = 1
+	}
+	if base.Column == 0 {
+		base.Column = 1
+	}
+
+	lineStarts := []int{0}
+	for offset, r := range source {
+		if r == '\n' {
+			lineStarts = append(lineStarts, offset+1)
+		}
+	}
+
+	return &extractor{
+		path:       path,
+		source:     source,
+		lineStarts: lineStarts,
+		base:       base,
+		fset:       token.NewFileSet(),
+		tueNames:   make(map[string]bool),
+	}
+}
+
+func (e *extractor) parse(componentName string) (*File, []Diagnostic) {
+	file := &File{Path: e.path}
+	if componentName == "" {
+		e.addDiagnostic("component name is required", e.span(len(e.source), len(e.source)))
+	}
+
+	astFile, ok := e.parseGo()
+	if !ok {
+		return file, e.diagnostics
+	}
+
+	file.PackageName = astFile.Name.Name
+	file.PackageSpan = e.posSpan(astFile.Pos(), astFile.Name.End())
+	file.Imports = e.extractImports(astFile)
+	e.typeCheck(astFile)
+
+	if componentName != "" {
+		e.extractComponent(file, astFile, componentName)
+	}
+	return file, e.diagnostics
+}
+
+func (e *extractor) parseGo() (*ast.File, bool) {
+	file, err := goparser.ParseFile(e.fset, e.path, e.source, goparser.ParseComments|goparser.AllErrors)
+	if file != nil {
+		e.tokenFile = e.fset.File(file.Pos())
+	}
+	if err != nil {
+		e.addParseDiagnostics(err)
+	}
+	return file, file != nil
+}
+
+func (e *extractor) addParseDiagnostics(err error) {
+	if list, ok := err.(scanner.ErrorList); ok {
+		for _, parseErr := range list {
+			offset := parseErr.Pos.Offset
+			if offset < 0 || offset > len(e.source) {
+				offset = len(e.source)
+			}
+			e.addDiagnostic(parseErr.Msg, e.span(offset, offset))
+		}
+		return
+	}
+	e.addDiagnostic(err.Error(), e.span(len(e.source), len(e.source)))
+}
+
+func (e *extractor) extractImports(file *ast.File) []Import {
+	imports := make([]Import, 0, len(file.Imports))
+	for _, spec := range file.Imports {
+		path, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			e.addDiagnostic("invalid import path", e.nodeSpan(spec.Path))
+			path = spec.Path.Value
+		}
+
+		importName := defaultImportName(path)
+		var nameSpan sfc.Span
+		if spec.Name != nil {
+			importName = spec.Name.Name
+			nameSpan = e.nodeSpan(spec.Name)
+		}
+
+		if path == tueImportPath {
+			switch importName {
+			case ".":
+				e.tueDot = true
+			case "_":
+			default:
+				e.tueNames[importName] = true
+			}
+		}
+
+		imports = append(imports, Import{
+			Name:     importName,
+			Path:     path,
+			Span:     e.nodeSpan(spec),
+			NameSpan: nameSpan,
+			PathSpan: e.nodeSpan(spec.Path),
+		})
+	}
+	return imports
+}
+
+func (e *extractor) typeCheck(file *ast.File) {
+	var diagnostics []Diagnostic
+	config := types.Config{
+		GoVersion:                "go1.26",
+		IgnoreFuncBodies:         true,
+		DisableUnusedImportCheck: true,
+		Importer:                 newTueImporter(),
+		Error: func(err error) {
+			diagnostic := Diagnostic{
+				Message: err.Error(),
+				Span:    e.span(len(e.source), len(e.source)),
+			}
+			if typeErr, ok := err.(types.Error); ok && typeErr.Pos.IsValid() {
+				diagnostic.Message = typeErr.Msg
+				diagnostic.Span = e.posSpan(typeErr.Pos, typeErr.Pos)
+			}
+			diagnostics = append(diagnostics, diagnostic)
+		},
+	}
+	_, _ = config.Check(e.path, e.fset, []*ast.File{file}, nil)
+	e.diagnostics = append(e.diagnostics, diagnostics...)
+}
+
+func (e *extractor) extractComponent(file *File, astFile *ast.File, componentName string) {
+	spec, ok := findTypeSpec(astFile, componentName)
+	if !ok {
+		e.addDiagnostic(fmt.Sprintf("component %q struct not found", componentName), e.span(len(e.source), len(e.source)))
+		return
+	}
+
+	structType, ok := spec.Type.(*ast.StructType)
+	if !ok {
+		e.addDiagnostic(fmt.Sprintf("component %q must be a struct", componentName), e.nodeSpan(spec.Type))
+		return
+	}
+
+	component := &Component{
+		Name:     componentName,
+		Span:     e.nodeSpan(spec),
+		NameSpan: e.nodeSpan(spec.Name),
+	}
+	e.extractFields(component, structType)
+	e.extractMethods(component, astFile)
+	component.Allocation = allocationFor(component)
+	file.Component = component
+}
+
+func findTypeSpec(file *ast.File, name string) (*ast.TypeSpec, bool) {
+	for _, declaration := range file.Decls {
+		general, ok := declaration.(*ast.GenDecl)
+		if !ok || general.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range general.Specs {
+			typeSpec, ok := spec.(*ast.TypeSpec)
+			if ok && typeSpec.Name.Name == name {
+				return typeSpec, true
+			}
+		}
+	}
+	return nil, false
+}
+
+func (e *extractor) extractFields(component *Component, structType *ast.StructType) {
+	for _, astField := range structType.Fields.List {
+		if len(astField.Names) == 0 {
+			continue
+		}
+
+		for _, name := range astField.Names {
+			field := e.fieldFromAST(name, astField)
+			switch field.Kind {
+			case FieldKindProp:
+				component.Props = append(component.Props, e.propFromField(field))
+			case FieldKindRef:
+				component.Refs = append(component.Refs, field)
+			case FieldKindComputed:
+				component.Computed = append(component.Computed, field)
+			case FieldKindResource:
+				component.Resources = append(component.Resources, field)
+			default:
+				component.State = append(component.State, field)
+			}
+		}
+	}
+}
+
+func (e *extractor) fieldFromAST(name *ast.Ident, astField *ast.Field) Field {
+	kind, valueType := e.classifyField(name.Name, astField.Type)
+	tag, tagSpan := e.fieldTag(astField)
+	return Field{
+		Kind:      kind,
+		Name:      name.Name,
+		Exported:  name.IsExported(),
+		Type:      e.nodeString(astField.Type),
+		ValueType: valueType,
+		Tag:       tag,
+		Span:      e.posSpan(name.Pos(), astField.End()),
+		NameSpan:  e.nodeSpan(name),
+		TypeSpan:  e.nodeSpan(astField.Type),
+		TagSpan:   tagSpan,
+	}
+}
+
+func (e *extractor) classifyField(fieldName string, expr ast.Expr) (FieldKind, string) {
+	typeName, args, ok := e.tueGenericType(expr)
+	if !ok {
+		return FieldKindState, ""
+	}
+
+	kind, ok := fieldKindForTueType(typeName)
+	if !ok {
+		return FieldKindState, ""
+	}
+	if len(args) != 1 {
+		e.addDiagnostic(
+			fmt.Sprintf("field %q must use tue.%s[T] with exactly one type argument", fieldName, typeName),
+			e.nodeSpan(expr),
+		)
+		return kind, ""
+	}
+	return kind, e.nodeString(args[0])
+}
+
+func (e *extractor) tueGenericType(expr ast.Expr) (string, []ast.Expr, bool) {
+	switch typed := expr.(type) {
+	case *ast.IndexExpr:
+		name, ok := e.tueTypeName(typed.X)
+		if !ok {
+			return "", nil, false
+		}
+		return name, []ast.Expr{typed.Index}, true
+	case *ast.IndexListExpr:
+		name, ok := e.tueTypeName(typed.X)
+		if !ok {
+			return "", nil, false
+		}
+		return name, typed.Indices, true
+	default:
+		name, ok := e.tueTypeName(expr)
+		return name, nil, ok
+	}
+}
+
+func (e *extractor) tueTypeName(expr ast.Expr) (string, bool) {
+	switch typed := expr.(type) {
+	case *ast.SelectorExpr:
+		ident, ok := typed.X.(*ast.Ident)
+		if !ok || !e.tueNames[ident.Name] {
+			return "", false
+		}
+		return typed.Sel.Name, true
+	case *ast.Ident:
+		if e.tueDot {
+			return typed.Name, true
+		}
+		return "", false
+	default:
+		return "", false
+	}
+}
+
+func fieldKindForTueType(name string) (FieldKind, bool) {
+	switch name {
+	case "Prop":
+		return FieldKindProp, true
+	case "Ref":
+		return FieldKindRef, true
+	case "Computed":
+		return FieldKindComputed, true
+	case "Resource":
+		return FieldKindResource, true
+	default:
+		return FieldKindState, false
+	}
+}
+
+func (e *extractor) fieldTag(field *ast.Field) (string, sfc.Span) {
+	if field.Tag == nil {
+		return "", sfc.Span{}
+	}
+	tag, err := strconv.Unquote(field.Tag.Value)
+	if err != nil {
+		e.addDiagnostic("invalid struct tag", e.nodeSpan(field.Tag))
+		return "", e.nodeSpan(field.Tag)
+	}
+	return tag, e.nodeSpan(field.Tag)
+}
+
+func (e *extractor) propFromField(field Field) Prop {
+	prop := Prop{
+		Field: field,
+		Name:  field.Name,
+	}
+	if value, ok := reflect.StructTag(field.Tag).Lookup("prop"); ok {
+		parts := strings.Split(value, ",")
+		if len(parts) > 0 && strings.TrimSpace(parts[0]) != "" {
+			prop.Name = strings.TrimSpace(parts[0])
+		}
+		for _, option := range parts[1:] {
+			if strings.TrimSpace(option) == "required" {
+				prop.Required = true
+			}
+		}
+	}
+	return prop
+}
+
+func (e *extractor) extractMethods(component *Component, file *ast.File) {
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok || function.Recv == nil {
+			continue
+		}
+
+		receiverName, pointerReceiver, receiverSpan, ok := e.receiver(function)
+		if !ok || receiverName != component.Name {
+			continue
+		}
+
+		method := e.methodFromAST(function, receiverName, pointerReceiver, receiverSpan)
+		if method.Name == "Init" {
+			if !e.validInit(function, component.Name, pointerReceiver) {
+				e.addDiagnostic(
+					fmt.Sprintf("Init must have signature func (c *%s) Init(tue.Context)", component.Name),
+					method.NameSpan,
+				)
+				continue
+			}
+			component.Init = &method
+			continue
+		}
+		component.Methods = append(component.Methods, method)
+	}
+}
+
+func (e *extractor) receiver(function *ast.FuncDecl) (string, bool, sfc.Span, bool) {
+	if function.Recv == nil || len(function.Recv.List) != 1 {
+		return "", false, sfc.Span{}, false
+	}
+
+	receiverType := function.Recv.List[0].Type
+	pointerReceiver := false
+	if star, ok := receiverType.(*ast.StarExpr); ok {
+		pointerReceiver = true
+		receiverType = star.X
+	}
+
+	ident, ok := receiverType.(*ast.Ident)
+	if !ok {
+		return "", false, sfc.Span{}, false
+	}
+	return ident.Name, pointerReceiver, e.nodeSpan(function.Recv.List[0].Type), true
+}
+
+func (e *extractor) methodFromAST(function *ast.FuncDecl, receiverName string, pointerReceiver bool, receiverSpan sfc.Span) Method {
+	return Method{
+		Name:            function.Name.Name,
+		ReceiverName:    receiverName,
+		PointerReceiver: pointerReceiver,
+		Parameters:      e.parameters(function.Type.Params),
+		Results:         e.parameters(function.Type.Results),
+		Span:            e.nodeSpan(function),
+		NameSpan:        e.nodeSpan(function.Name),
+		ReceiverSpan:    receiverSpan,
+	}
+}
+
+func (e *extractor) parameters(fields *ast.FieldList) []Parameter {
+	if fields == nil {
+		return nil
+	}
+
+	var parameters []Parameter
+	for _, field := range fields.List {
+		if len(field.Names) == 0 {
+			parameters = append(parameters, Parameter{
+				Type:     e.nodeString(field.Type),
+				Span:     e.nodeSpan(field),
+				TypeSpan: e.nodeSpan(field.Type),
+			})
+			continue
+		}
+		for _, name := range field.Names {
+			parameters = append(parameters, Parameter{
+				Name:     name.Name,
+				Type:     e.nodeString(field.Type),
+				Span:     e.posSpan(name.Pos(), field.End()),
+				NameSpan: e.nodeSpan(name),
+				TypeSpan: e.nodeSpan(field.Type),
+			})
+		}
+	}
+	return parameters
+}
+
+func (e *extractor) validInit(function *ast.FuncDecl, componentName string, pointerReceiver bool) bool {
+	if !pointerReceiver {
+		return false
+	}
+	if function.Type.Results != nil && len(function.Type.Results.List) != 0 {
+		return false
+	}
+	if function.Type.Params == nil || len(function.Type.Params.List) != 1 {
+		return false
+	}
+
+	parameter := function.Type.Params.List[0]
+	if len(parameter.Names) > 1 {
+		return false
+	}
+	return e.isTueContext(parameter.Type)
+}
+
+func (e *extractor) isTueContext(expr ast.Expr) bool {
+	name, ok := e.tueTypeName(expr)
+	return ok && name == "Context"
+}
+
+func allocationFor(component *Component) Allocation {
+	allocation := Allocation{
+		ComponentName: component.Name,
+		CallsInit:     component.Init != nil,
+	}
+	for _, prop := range component.Props {
+		allocation.PropFields = append(allocation.PropFields, prop.Field.Name)
+	}
+	return allocation
+}
+
+func defaultImportName(path string) string {
+	if index := strings.LastIndexByte(path, '/'); index != -1 {
+		return path[index+1:]
+	}
+	return path
+}
+
+func (e *extractor) addDiagnostic(message string, span sfc.Span) {
+	e.diagnostics = append(e.diagnostics, Diagnostic{
+		Message: message,
+		Span:    span,
+	})
+}
+
+func (e *extractor) nodeString(node any) string {
+	var buffer bytes.Buffer
+	if err := format.Node(&buffer, e.fset, node); err != nil {
+		return ""
+	}
+	return buffer.String()
+}
+
+func (e *extractor) nodeSpan(node interface {
+	Pos() token.Pos
+	End() token.Pos
+}) sfc.Span {
+	return e.posSpan(node.Pos(), node.End())
+}
+
+func (e *extractor) posSpan(start token.Pos, end token.Pos) sfc.Span {
+	return e.span(e.offset(start), e.offset(end))
+}
+
+func (e *extractor) offset(position token.Pos) int {
+	if e.tokenFile == nil || !position.IsValid() {
+		return len(e.source)
+	}
+	offset := e.tokenFile.Offset(position)
+	if offset < 0 {
+		return 0
+	}
+	if offset > len(e.source) {
+		return len(e.source)
+	}
+	return offset
+}
+
+func (e *extractor) span(start int, end int) sfc.Span {
+	return sfc.Span{
+		Start: e.position(start),
+		End:   e.position(end),
+	}
+}
+
+func (e *extractor) position(offset int) sfc.Position {
+	lineIndex := sort.Search(len(e.lineStarts), func(i int) bool {
+		return e.lineStarts[i] > offset
+	}) - 1
+	if lineIndex < 0 {
+		lineIndex = 0
+	}
+
+	position := sfc.Position{
+		Offset: e.base.Offset + offset,
+		Line:   e.base.Line + lineIndex,
+		Column: offset - e.lineStarts[lineIndex] + 1,
+	}
+	if lineIndex == 0 {
+		position.Column = e.base.Column + offset
+	}
+	return position
+}

--- a/internal/compiler/script/parse_test.go
+++ b/internal/compiler/script/parse_test.go
@@ -1,0 +1,498 @@
+package script
+
+import (
+	"bytes"
+	"embed"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/norunners/tue/internal/compiler/sfc"
+)
+
+//go:embed testdata/contracts/*.go testdata/diagnostics/*.go testdata/sfc/*.tue
+var testFixtures embed.FS
+
+func TestParseExtractsComponentContract(t *testing.T) {
+	file, diagnostics := Parse(testFixture(t, "testdata/contracts/dashboard.go"), "Dashboard")
+	if len(diagnostics) != 0 {
+		t.Errorf("Parse diagnostics = %#v, want none", diagnosticMessages(diagnostics))
+	}
+
+	if diff := cmp.Diff("fixtures", file.PackageName); diff != "" {
+		t.Errorf("mismatch package name (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff([]importSummary{{
+		Name: "tue",
+		Path: "github.com/norunners/tue",
+	}}, summarizeImports(file.Imports)); diff != "" {
+		t.Errorf("mismatch imports (-expected, +actual):\n%s", diff)
+	}
+
+	component := requireComponent(t, file)
+	if diff := cmp.Diff("Dashboard", component.Name); diff != "" {
+		t.Errorf("mismatch component name (-expected, +actual):\n%s", diff)
+	}
+
+	props := requireProps(t, component, 1)
+	if len(props) == 1 {
+		prop := props[0]
+		if diff := cmp.Diff(propSummary{
+			FieldName:  "name",
+			Name:       "name",
+			Required:   true,
+			Exported:   false,
+			Type:       "tue.Prop[string]",
+			ValueType:  "string",
+			FieldKind:  FieldKindProp,
+			StructTag:  `prop:"name,required"`,
+			HasTagSpan: true,
+		}, summarizeProp(prop)); diff != "" {
+			t.Errorf("mismatch prop: %q (-expected, +actual):\n%s", prop.Field.Name, diff)
+		}
+	}
+
+	assertField(t, component.Refs, "count", FieldKindRef, "tue.Ref[int]", "int")
+	assertField(t, component.Computed, "total", FieldKindComputed, "tue.Computed[int]", "int")
+	assertField(t, component.Resources, "user", FieldKindResource, "tue.Resource[User]", "User")
+	assertField(t, component.State, "label", FieldKindState, "string", "")
+
+	init := requireInit(t, component)
+	if diff := cmp.Diff(methodSummary{
+		Name:            "Init",
+		ReceiverName:    "Dashboard",
+		PointerReceiver: true,
+		Parameters: []parameterSummary{{
+			Name: "ctx",
+			Type: "tue.Context",
+		}},
+	}, summarizeMethod(init)); diff != "" {
+		t.Errorf("mismatch method: %q (-expected, +actual):\n%s", init.Name, diff)
+	}
+
+	if diff := cmp.Diff([]methodSummary{
+		{
+			Name:            "increment",
+			ReceiverName:    "Dashboard",
+			PointerReceiver: true,
+		},
+		{
+			Name:            "snapshot",
+			ReceiverName:    "Dashboard",
+			PointerReceiver: false,
+			Results: []parameterSummary{{
+				Type: "string",
+			}},
+		},
+	}, summarizeMethods(component.Methods)); diff != "" {
+		t.Errorf("mismatch methods (-expected, +actual):\n%s", diff)
+	}
+
+	if diff := cmp.Diff(allocationSummary{
+		ComponentName: "Dashboard",
+		PropFields:    []string{"name"},
+		CallsInit:     true,
+	}, summarizeAllocation(component.Allocation)); diff != "" {
+		t.Errorf("mismatch allocation (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestParseAcceptsDotImportedTueContracts(t *testing.T) {
+	file, diagnostics := Parse(testFixture(t, "testdata/contracts/dot_import.go"), "DotImport")
+	if len(diagnostics) != 0 {
+		t.Errorf("Parse diagnostics = %#v, want none", diagnosticMessages(diagnostics))
+	}
+
+	component := requireComponent(t, file)
+	if diff := cmp.Diff([]propSummary{{
+		FieldName: "name",
+		Name:      "name",
+		Type:      "Prop[string]",
+		ValueType: "string",
+		FieldKind: FieldKindProp,
+	}}, summarizeProps(component.Props)); diff != "" {
+		t.Errorf("mismatch props (-expected, +actual):\n%s", diff)
+	}
+	if component.Init == nil {
+		t.Error("Init is nil")
+	}
+}
+
+func TestParseBlockUsesSFCSourceSpans(t *testing.T) {
+	source := testFixture(t, "testdata/sfc/user_badge.tue")
+	sfcFile, sfcDiagnostics := sfc.Parse("UserBadge.tue", source)
+	if len(sfcDiagnostics) != 0 {
+		t.Fatalf("sfc.Parse diagnostics = %#v, want none", sfcDiagnostics)
+	}
+
+	file, diagnostics := ParseBlock(sfcFile.Script, "UserBadge")
+	if len(diagnostics) != 0 {
+		t.Errorf("ParseBlock diagnostics = %#v, want none", diagnosticMessages(diagnostics))
+	}
+
+	component := requireComponent(t, file)
+	props := requireProps(t, component, 1)
+	if len(props) != 1 {
+		return
+	}
+
+	prop := props[0]
+	nameOffset := bytes.Index(source, []byte("name tue.Prop"))
+	if nameOffset == -1 {
+		t.Fatal(`embedded SFC fixture does not contain "name tue.Prop"`)
+	}
+	if diff := cmp.Diff(sfc.Position{Offset: nameOffset, Line: 8, Column: 2}, prop.Field.NameSpan.Start); diff != "" {
+		t.Errorf("mismatch prop name start: %q (-expected, +actual):\n%s", prop.Field.Name, diff)
+	}
+	packageOffset := bytes.Index(source, []byte("package fixtures"))
+	if packageOffset == -1 {
+		t.Fatal(`embedded SFC fixture does not contain "package fixtures"`)
+	}
+	if diff := cmp.Diff(sfc.Position{Offset: packageOffset, Line: 3, Column: 1}, file.PackageSpan.Start); diff != "" {
+		t.Errorf("mismatch package start (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestParseSFCFixtures(t *testing.T) {
+	root := filepath.Join("..", "..", "..", "testdata", "fixtures")
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || filepath.Ext(path) != ".tue" {
+			return nil
+		}
+
+		t.Run(filepath.ToSlash(path), func(t *testing.T) {
+			source, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read fixture: %v", err)
+			}
+
+			sfcFile, sfcDiagnostics := sfc.Parse(path, source)
+			if len(sfcDiagnostics) != 0 {
+				t.Fatalf("sfc.Parse diagnostics = %#v, want none", sfcDiagnostics)
+			}
+
+			file, diagnostics := ParseSFC(sfcFile)
+			if len(diagnostics) != 0 {
+				t.Errorf("ParseSFC diagnostics = %#v, want none", diagnosticMessages(diagnostics))
+			}
+			component := requireComponent(t, file)
+			if diff := cmp.Diff(ComponentNameFromPath(path), component.Name); diff != "" {
+				t.Errorf("mismatch component name (-expected, +actual):\n%s", diff)
+			}
+		})
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk fixtures: %v", err)
+	}
+}
+
+func TestParseDiagnostics(t *testing.T) {
+	tests := []struct {
+		name      string
+		fixture   string
+		component string
+		want      []string
+	}{
+		{
+			name:      "missing component",
+			fixture:   "testdata/diagnostics/missing_component.go",
+			component: "Missing",
+			want:      []string{`component "Missing" struct not found`},
+		},
+		{
+			name:      "component must be struct",
+			fixture:   "testdata/diagnostics/component_must_be_struct.go",
+			component: "App",
+			want:      []string{`component "App" must be a struct`},
+		},
+		{
+			name:      "prop without type argument",
+			fixture:   "testdata/diagnostics/prop_without_type_argument.go",
+			component: "App",
+			want:      []string{`field "name" must use tue.Prop[T] with exactly one type argument`},
+		},
+		{
+			name:      "prop with too many type arguments",
+			fixture:   "testdata/diagnostics/prop_with_too_many_type_arguments.go",
+			component: "App",
+			want:      []string{`field "name" must use tue.Prop[T] with exactly one type argument`},
+		},
+		{
+			name:      "invalid Init value receiver",
+			fixture:   "testdata/diagnostics/invalid_init_value_receiver.go",
+			component: "App",
+			want:      []string{`Init must have signature func (c *App) Init(tue.Context)`},
+		},
+		{
+			name:      "invalid Init params",
+			fixture:   "testdata/diagnostics/invalid_init_params.go",
+			component: "App",
+			want:      []string{`Init must have signature func (c *App) Init(tue.Context)`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, diagnostics := Parse(testFixture(t, tt.fixture), tt.component)
+			assertDiagnosticContains(t, diagnostics, tt.want)
+		})
+	}
+}
+
+func TestParseBlockDiagnostics(t *testing.T) {
+	_, diagnostics := ParseBlock(nil, "App")
+	assertDiagnosticMessages(t, diagnostics, []string{"missing script block"})
+}
+
+func TestComponentNameFromPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{path: "counter.tue", want: "Counter"},
+		{path: "static_hello.tue", want: "StaticHello"},
+		{path: "components/user-badge.tue", want: "UserBadge"},
+		{path: `windows\path\UserBadge.tue`, want: "UserBadge"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if diff := cmp.Diff(tt.want, ComponentNameFromPath(tt.path)); diff != "" {
+				t.Errorf("mismatch component name from path: %q (-expected, +actual):\n%s", tt.path, diff)
+			}
+		})
+	}
+}
+
+func testFixture(t *testing.T, path string) []byte {
+	t.Helper()
+
+	source, err := testFixtures.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read embedded fixture %s: %v", path, err)
+	}
+	return source
+}
+
+func requireComponent(t *testing.T, file *File) *Component {
+	t.Helper()
+
+	if file.Component == nil {
+		t.Fatal("Component is nil")
+	}
+	return file.Component
+}
+
+func requireProps(t *testing.T, component *Component, want int) []Prop {
+	t.Helper()
+
+	if diff := cmp.Diff(want, len(component.Props)); diff != "" {
+		t.Errorf("mismatch props length (-expected, +actual):\n%s", diff)
+	}
+	return component.Props
+}
+
+func requireInit(t *testing.T, component *Component) *Method {
+	t.Helper()
+
+	if component.Init == nil {
+		t.Fatal("Init is nil")
+	}
+	return component.Init
+}
+
+func assertField(t *testing.T, fields []Field, name string, kind FieldKind, fieldType string, valueType string) {
+	t.Helper()
+
+	for _, field := range fields {
+		if field.Name == name {
+			if diff := cmp.Diff(fieldSummary{
+				Kind:      kind,
+				Name:      name,
+				Type:      fieldType,
+				ValueType: valueType,
+				Exported:  false,
+			}, summarizeField(field)); diff != "" {
+				t.Errorf("mismatch field: %q (-expected, +actual):\n%s", name, diff)
+			}
+			return
+		}
+	}
+	t.Errorf("field %q not found in %#v", name, summarizeFields(fields))
+}
+
+func assertDiagnosticMessages(t *testing.T, diagnostics []Diagnostic, want []string) {
+	t.Helper()
+
+	if diff := cmp.Diff(want, diagnosticMessages(diagnostics)); diff != "" {
+		t.Errorf("mismatch diagnostics (-expected, +actual):\n%s", diff)
+	}
+}
+
+func assertDiagnosticContains(t *testing.T, diagnostics []Diagnostic, want []string) {
+	t.Helper()
+
+	got := diagnosticMessages(diagnostics)
+	for _, message := range want {
+		found := false
+		for _, gotMessage := range got {
+			if gotMessage == message {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("diagnostics = %#v, want message %q", got, message)
+		}
+	}
+}
+
+func diagnosticMessages(diagnostics []Diagnostic) []string {
+	messages := make([]string, len(diagnostics))
+	for i, diagnostic := range diagnostics {
+		messages[i] = diagnostic.Message
+	}
+	return messages
+}
+
+type importSummary struct {
+	Name string
+	Path string
+}
+
+type propSummary struct {
+	FieldName  string
+	Name       string
+	Required   bool
+	Exported   bool
+	Type       string
+	ValueType  string
+	FieldKind  FieldKind
+	StructTag  string
+	HasTagSpan bool
+}
+
+type fieldSummary struct {
+	Kind      FieldKind
+	Name      string
+	Exported  bool
+	Type      string
+	ValueType string
+}
+
+type methodSummary struct {
+	Name            string
+	ReceiverName    string
+	PointerReceiver bool
+	Parameters      []parameterSummary
+	Results         []parameterSummary
+}
+
+type parameterSummary struct {
+	Name string
+	Type string
+}
+
+type allocationSummary struct {
+	ComponentName string
+	PropFields    []string
+	CallsInit     bool
+}
+
+func summarizeImports(imports []Import) []importSummary {
+	summaries := make([]importSummary, len(imports))
+	for i, item := range imports {
+		summaries[i] = importSummary{
+			Name: item.Name,
+			Path: item.Path,
+		}
+	}
+	return summaries
+}
+
+func summarizeProps(props []Prop) []propSummary {
+	summaries := make([]propSummary, len(props))
+	for i, prop := range props {
+		summaries[i] = summarizeProp(prop)
+	}
+	return summaries
+}
+
+func summarizeProp(prop Prop) propSummary {
+	return propSummary{
+		FieldName:  prop.Field.Name,
+		Name:       prop.Name,
+		Required:   prop.Required,
+		Exported:   prop.Field.Exported,
+		Type:       prop.Field.Type,
+		ValueType:  prop.Field.ValueType,
+		FieldKind:  prop.Field.Kind,
+		StructTag:  prop.Field.Tag,
+		HasTagSpan: prop.Field.TagSpan.Start.Offset != 0 || prop.Field.TagSpan.End.Offset != 0,
+	}
+}
+
+func summarizeFields(fields []Field) []fieldSummary {
+	summaries := make([]fieldSummary, len(fields))
+	for i, field := range fields {
+		summaries[i] = summarizeField(field)
+	}
+	return summaries
+}
+
+func summarizeField(field Field) fieldSummary {
+	return fieldSummary{
+		Kind:      field.Kind,
+		Name:      field.Name,
+		Exported:  field.Exported,
+		Type:      field.Type,
+		ValueType: field.ValueType,
+	}
+}
+
+func summarizeMethods(methods []Method) []methodSummary {
+	summaries := make([]methodSummary, len(methods))
+	for i, method := range methods {
+		summaries[i] = summarizeMethod(&method)
+	}
+	return summaries
+}
+
+func summarizeMethod(method *Method) methodSummary {
+	return methodSummary{
+		Name:            method.Name,
+		ReceiverName:    method.ReceiverName,
+		PointerReceiver: method.PointerReceiver,
+		Parameters:      summarizeParameters(method.Parameters),
+		Results:         summarizeParameters(method.Results),
+	}
+}
+
+func summarizeParameters(parameters []Parameter) []parameterSummary {
+	if len(parameters) == 0 {
+		return nil
+	}
+
+	summaries := make([]parameterSummary, len(parameters))
+	for i, parameter := range parameters {
+		summaries[i] = parameterSummary{
+			Name: parameter.Name,
+			Type: parameter.Type,
+		}
+	}
+	return summaries
+}
+
+func summarizeAllocation(allocation Allocation) allocationSummary {
+	return allocationSummary{
+		ComponentName: allocation.ComponentName,
+		PropFields:    allocation.PropFields,
+		CallsInit:     allocation.CallsInit,
+	}
+}

--- a/internal/compiler/script/testdata/contracts/dashboard.go
+++ b/internal/compiler/script/testdata/contracts/dashboard.go
@@ -1,0 +1,19 @@
+package fixtures
+
+import tue "github.com/norunners/tue"
+
+type User struct{}
+
+type Dashboard struct {
+	name  tue.Prop[string] `prop:"name,required"`
+	count tue.Ref[int]
+	total tue.Computed[int]
+	user  tue.Resource[User]
+	label string
+}
+
+func (d *Dashboard) Init(ctx tue.Context) {}
+
+func (d *Dashboard) increment() {}
+
+func (d Dashboard) snapshot() string { return "" }

--- a/internal/compiler/script/testdata/contracts/dot_import.go
+++ b/internal/compiler/script/testdata/contracts/dot_import.go
@@ -1,0 +1,9 @@
+package fixtures
+
+import . "github.com/norunners/tue"
+
+type DotImport struct {
+	name Prop[string]
+}
+
+func (d *DotImport) Init(ctx Context) {}

--- a/internal/compiler/script/testdata/diagnostics/component_must_be_struct.go
+++ b/internal/compiler/script/testdata/diagnostics/component_must_be_struct.go
@@ -1,0 +1,3 @@
+package fixtures
+
+type App int

--- a/internal/compiler/script/testdata/diagnostics/invalid_init_params.go
+++ b/internal/compiler/script/testdata/diagnostics/invalid_init_params.go
@@ -1,0 +1,7 @@
+package fixtures
+
+import tue "github.com/norunners/tue"
+
+type App struct{}
+
+func (a *App) Init() {}

--- a/internal/compiler/script/testdata/diagnostics/invalid_init_value_receiver.go
+++ b/internal/compiler/script/testdata/diagnostics/invalid_init_value_receiver.go
@@ -1,0 +1,7 @@
+package fixtures
+
+import tue "github.com/norunners/tue"
+
+type App struct{}
+
+func (a App) Init(ctx tue.Context) {}

--- a/internal/compiler/script/testdata/diagnostics/missing_component.go
+++ b/internal/compiler/script/testdata/diagnostics/missing_component.go
@@ -1,0 +1,1 @@
+package fixtures

--- a/internal/compiler/script/testdata/diagnostics/prop_with_too_many_type_arguments.go
+++ b/internal/compiler/script/testdata/diagnostics/prop_with_too_many_type_arguments.go
@@ -1,0 +1,7 @@
+package fixtures
+
+import tue "github.com/norunners/tue"
+
+type App struct {
+	name tue.Prop[string, int]
+}

--- a/internal/compiler/script/testdata/diagnostics/prop_without_type_argument.go
+++ b/internal/compiler/script/testdata/diagnostics/prop_without_type_argument.go
@@ -1,0 +1,7 @@
+package fixtures
+
+import tue "github.com/norunners/tue"
+
+type App struct {
+	name tue.Prop
+}

--- a/internal/compiler/script/testdata/sfc/user_badge.tue
+++ b/internal/compiler/script/testdata/sfc/user_badge.tue
@@ -1,0 +1,10 @@
+<template></template>
+<script lang="go">
+package fixtures
+
+import tue "github.com/norunners/tue"
+
+type UserBadge struct {
+	name tue.Prop[string] `prop:"name,required"`
+}
+</script>

--- a/internal/compiler/script/types.go
+++ b/internal/compiler/script/types.go
@@ -1,0 +1,63 @@
+package script
+
+import (
+	"fmt"
+	"go/importer"
+	"go/token"
+	"go/types"
+)
+
+type tueImporter struct {
+	fallback types.Importer
+	tue      *types.Package
+}
+
+func newTueImporter() *tueImporter {
+	return &tueImporter{
+		fallback: importer.Default(),
+		tue:      fakeTuePackage(),
+	}
+}
+
+func (i *tueImporter) Import(path string) (*types.Package, error) {
+	if path == tueImportPath {
+		return i.tue, nil
+	}
+	if i.fallback == nil {
+		return nil, fmt.Errorf("import %q: no fallback importer", path)
+	}
+	return i.fallback.Import(path)
+}
+
+func (i *tueImporter) ImportFrom(path string, dir string, mode types.ImportMode) (*types.Package, error) {
+	if path == tueImportPath {
+		return i.tue, nil
+	}
+	if from, ok := i.fallback.(types.ImporterFrom); ok {
+		return from.ImportFrom(path, dir, mode)
+	}
+	return i.Import(path)
+}
+
+func fakeTuePackage() *types.Package {
+	pkg := types.NewPackage(tueImportPath, "tue")
+	scope := pkg.Scope()
+	emptyInterface := types.NewInterfaceType(nil, nil).Complete()
+	anyType := types.Universe.Lookup("any").Type()
+
+	for _, name := range []string{"Prop", "Ref", "Computed", "Resource"} {
+		typeName := types.NewTypeName(token.NoPos, pkg, name, nil)
+		named := types.NewNamed(typeName, emptyInterface, nil)
+		typeParamName := types.NewTypeName(token.NoPos, pkg, "T", nil)
+		typeParam := types.NewTypeParam(typeParamName, anyType)
+		named.SetTypeParams([]*types.TypeParam{typeParam})
+		scope.Insert(typeName)
+	}
+
+	contextName := types.NewTypeName(token.NoPos, pkg, "Context", nil)
+	types.NewNamed(contextName, emptyInterface, nil)
+	scope.Insert(contextName)
+
+	pkg.MarkComplete()
+	return pkg
+}


### PR DESCRIPTION
## Summary

- Added `internal/compiler/script` with a concrete component contract model for script package/imports, component structs, props, state fields, refs, computed values, resources, methods, optional `Init`, and generated allocation shape.
- Added script parsing entry points for raw source, SFC script blocks, and full SFC files, including component-name derivation from `.tue` paths and source spans mapped back to `.tue` coordinates.
- Added declaration-only Go type checking with a fake internal Tue package so field and signature declarations can be validated before the runtime API lands.
- Covered unexported props, prop tags, dot imports, optional props, fixture scripts, span mapping, missing component contracts, prop arity diagnostics, and invalid `Init` signatures.
- Addressed review feedback by moving inline script/SFC test sources into embedded fixtures, changing test assertions to use `cmp.Diff` with nonfatal `t.Errorf` where continuing is safe, normalizing diff failure messages to `mismatch ... (-expected, +actual)`, and moving the `FieldKind` enum into its own file with `FieldKind...` constants.

## Validation

- `go fmt ./...`
- `go test ./...`
- `go test ./internal/compiler/script -count=1`
- `git diff --check`
- `git diff --cached --check`
- `tokensave sync`