### PR TITLE
[codex] Added template checking.

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -9,6 +9,11 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+
+	"github.com/norunners/tue/internal/compiler/checker"
+	"github.com/norunners/tue/internal/compiler/script"
+	"github.com/norunners/tue/internal/compiler/sfc"
+	compilerTemplate "github.com/norunners/tue/internal/compiler/template"
 )
 
 const (
@@ -51,7 +56,23 @@ func runCheck(args []string, stdout, stderr io.Writer) int {
 		return exitError
 	}
 
-	fmt.Fprintf(stdout, "tue check: found %d .tue file(s) in %s\n", len(files), filepath.Clean(root))
+	parsedFiles, parseDiagnostics, err := parseTueFiles(root, files)
+	if err != nil {
+		fmt.Fprintf(stderr, "tue check: %v\n", err)
+		return exitError
+	}
+	if len(parseDiagnostics) != 0 {
+		printDiagnostics(stderr, parseDiagnostics)
+		return exitError
+	}
+
+	checkDiagnostics := checker.CheckProject(checker.Project{Files: parsedFiles})
+	if len(checkDiagnostics) != 0 {
+		printDiagnostics(stderr, checkDiagnostics)
+		return exitError
+	}
+
+	fmt.Fprintf(stdout, "tue check: checked %d .tue file(s) in %s\n", len(files), filepath.Clean(root))
 	for _, file := range files {
 		fmt.Fprintf(stdout, "%s\n", file)
 	}
@@ -137,6 +158,101 @@ func discoverTueFiles(root string) ([]string, error) {
 	return files, nil
 }
 
+func parseTueFiles(root string, paths []string) ([]checker.File, []checker.Diagnostic, error) {
+	files := make([]checker.File, 0, len(paths))
+	var diagnostics []checker.Diagnostic
+
+	for _, path := range paths {
+		file, fileDiagnostics, err := parseTueFile(root, path)
+		if err != nil {
+			return nil, nil, err
+		}
+		diagnostics = append(diagnostics, fileDiagnostics...)
+		if len(fileDiagnostics) == 0 {
+			files = append(files, file)
+		}
+	}
+
+	return files, diagnostics, nil
+}
+
+func parseTueFile(root string, path string) (checker.File, []checker.Diagnostic, error) {
+	source, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(path)))
+	if err != nil {
+		return checker.File{}, nil, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	sfcFile, sfcDiagnostics := sfc.Parse(path, source)
+	if len(sfcDiagnostics) != 0 {
+		return checker.File{}, sfcDiagnosticsFor(path, sfcDiagnostics), nil
+	}
+
+	templateTree, templateDiagnostics := compilerTemplate.ParseBlock(sfcFile.Template)
+	scriptFile, scriptDiagnostics := script.ParseSFC(sfcFile)
+	diagnostics := make([]checker.Diagnostic, 0, len(templateDiagnostics)+len(scriptDiagnostics))
+	diagnostics = append(diagnostics, templateDiagnosticsFor(path, templateDiagnostics)...)
+	diagnostics = append(diagnostics, scriptDiagnosticsFor(path, scriptDiagnostics)...)
+	if len(diagnostics) != 0 {
+		return checker.File{}, diagnostics, nil
+	}
+
+	return checker.File{
+		Path:     path,
+		Template: templateTree,
+		Script:   scriptFile,
+	}, nil, nil
+}
+
+func sfcDiagnosticsFor(path string, diagnostics []sfc.Diagnostic) []checker.Diagnostic {
+	converted := make([]checker.Diagnostic, len(diagnostics))
+	for i, diagnostic := range diagnostics {
+		converted[i] = checker.Diagnostic{
+			Path:    path,
+			Message: diagnostic.Message,
+			Span:    diagnostic.Span,
+		}
+	}
+	return converted
+}
+
+func templateDiagnosticsFor(path string, diagnostics []compilerTemplate.Diagnostic) []checker.Diagnostic {
+	converted := make([]checker.Diagnostic, len(diagnostics))
+	for i, diagnostic := range diagnostics {
+		converted[i] = checker.Diagnostic{
+			Path:    path,
+			Message: diagnostic.Message,
+			Span:    diagnostic.Span,
+		}
+	}
+	return converted
+}
+
+func scriptDiagnosticsFor(path string, diagnostics []script.Diagnostic) []checker.Diagnostic {
+	converted := make([]checker.Diagnostic, len(diagnostics))
+	for i, diagnostic := range diagnostics {
+		converted[i] = checker.Diagnostic{
+			Path:    path,
+			Message: diagnostic.Message,
+			Span:    diagnostic.Span,
+		}
+	}
+	return converted
+}
+
+func printDiagnostics(stderr io.Writer, diagnostics []checker.Diagnostic) {
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Span.Start.Line > 0 && diagnostic.Span.Start.Column > 0 {
+			fmt.Fprintf(stderr, "%s:%d:%d: %s\n", diagnostic.Path, diagnostic.Span.Start.Line, diagnostic.Span.Start.Column, diagnostic.Message)
+			continue
+		}
+		if diagnostic.Path != "" {
+			fmt.Fprintf(stderr, "%s: %s\n", diagnostic.Path, diagnostic.Message)
+			continue
+		}
+		fmt.Fprintf(stderr, "%s\n", diagnostic.Message)
+	}
+}
+
 func shouldSkipDir(name string) bool {
 	switch name {
 	case ".git", ".tue-cache", "node_modules":
@@ -151,7 +267,7 @@ func printUsage(out io.Writer) {
   tue <command> [project-root]
 
 Commands:
-  check [project-root]  Discover .tue files under a project root.
+  check [project-root]  Parse and check .tue files under a project root.
   build [project-root]  Build a Tue project. Not implemented yet.
   dev [project-root]    Start the Tue dev server. Not implemented yet.
   fmt [project-root]    Format Tue source files. Not implemented yet.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2,11 +2,16 @@ package cli
 
 import (
 	"bytes"
+	"embed"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+//go:embed testdata/*.tue
+var testFixtures embed.FS
 
 func TestRunRequiresCommand(t *testing.T) {
 	var stdout bytes.Buffer
@@ -15,13 +20,13 @@ func TestRunRequiresCommand(t *testing.T) {
 	code := Run(nil, &stdout, &stderr)
 
 	if code != exitUsage {
-		t.Fatalf("Run(nil) exit code = %d, want %d", code, exitUsage)
+		t.Errorf("Run(nil) exit code = %d, want %d", code, exitUsage)
 	}
 	if stdout.Len() != 0 {
-		t.Fatalf("stdout = %q, want empty", stdout.String())
+		t.Errorf("stdout = %q, want empty", stdout.String())
 	}
 	if !strings.Contains(stderr.String(), "Usage:") {
-		t.Fatalf("stderr = %q, want usage", stderr.String())
+		t.Errorf("stderr = %q, want usage", stderr.String())
 	}
 }
 
@@ -32,13 +37,13 @@ func TestRunPrintsHelp(t *testing.T) {
 	code := Run([]string{"--help"}, &stdout, &stderr)
 
 	if code != exitOK {
-		t.Fatalf("Run(--help) exit code = %d, want %d", code, exitOK)
+		t.Errorf("Run(--help) exit code = %d, want %d", code, exitOK)
 	}
 	if !strings.Contains(stdout.String(), "tue <command>") {
-		t.Fatalf("stdout = %q, want top-level usage", stdout.String())
+		t.Errorf("stdout = %q, want top-level usage", stdout.String())
 	}
 	if stderr.Len() != 0 {
-		t.Fatalf("stderr = %q, want empty", stderr.String())
+		t.Errorf("stderr = %q, want empty", stderr.String())
 	}
 }
 
@@ -49,13 +54,13 @@ func TestRunPrintsCommandHelp(t *testing.T) {
 	code := Run([]string{"check", "--help"}, &stdout, &stderr)
 
 	if code != exitOK {
-		t.Fatalf("Run(check --help) exit code = %d, want %d", code, exitOK)
+		t.Errorf("Run(check --help) exit code = %d, want %d", code, exitOK)
 	}
 	if !strings.Contains(stdout.String(), "tue check [project-root]") {
-		t.Fatalf("stdout = %q, want command usage", stdout.String())
+		t.Errorf("stdout = %q, want command usage", stdout.String())
 	}
 	if stderr.Len() != 0 {
-		t.Fatalf("stderr = %q, want empty", stderr.String())
+		t.Errorf("stderr = %q, want empty", stderr.String())
 	}
 }
 
@@ -66,13 +71,13 @@ func TestRunRejectsUnknownCommand(t *testing.T) {
 	code := Run([]string{"create"}, &stdout, &stderr)
 
 	if code != exitUsage {
-		t.Fatalf("Run(create) exit code = %d, want %d", code, exitUsage)
+		t.Errorf("Run(create) exit code = %d, want %d", code, exitUsage)
 	}
 	if stdout.Len() != 0 {
-		t.Fatalf("stdout = %q, want empty", stdout.String())
+		t.Errorf("stdout = %q, want empty", stdout.String())
 	}
 	if !strings.Contains(stderr.String(), `unknown command "create"`) {
-		t.Fatalf("stderr = %q, want unknown command", stderr.String())
+		t.Errorf("stderr = %q, want unknown command", stderr.String())
 	}
 }
 
@@ -85,14 +90,14 @@ func TestRunStubCommandsReturnNotImplemented(t *testing.T) {
 			code := Run([]string{command}, &stdout, &stderr)
 
 			if code != exitError {
-				t.Fatalf("Run(%s) exit code = %d, want %d", command, code, exitError)
+				t.Errorf("Run(%s) exit code = %d, want %d", command, code, exitError)
 			}
 			if stdout.Len() != 0 {
-				t.Fatalf("stdout = %q, want empty", stdout.String())
+				t.Errorf("stdout = %q, want empty", stdout.String())
 			}
 			want := "tue " + command + ": not implemented yet"
 			if !strings.Contains(stderr.String(), want) {
-				t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+				t.Errorf("stderr = %q, want %q", stderr.String(), want)
 			}
 		})
 	}
@@ -100,12 +105,24 @@ func TestRunStubCommandsReturnNotImplemented(t *testing.T) {
 
 func TestRunCheckDiscoversTueFiles(t *testing.T) {
 	root := t.TempDir()
-	writeFile(t, filepath.Join(root, "App.tue"), "<template></template>")
-	writeFile(t, filepath.Join(root, "notes.txt"), "not a component")
-	writeFile(t, filepath.Join(root, "components", "UserBadge.tue"), "<template></template>")
-	writeFile(t, filepath.Join(root, ".git", "ignored.tue"), "<template></template>")
-	writeFile(t, filepath.Join(root, ".tue-cache", "generated.tue"), "<template></template>")
-	writeFile(t, filepath.Join(root, "node_modules", "ignored.tue"), "<template></template>")
+	if err := writeFixture(filepath.Join(root, "App.tue"), "testdata/App.tue"); err != nil {
+		t.Fatalf("setup App.tue: %v", err)
+	}
+	if err := writeFile(filepath.Join(root, "notes.txt"), "not a component"); err != nil {
+		t.Fatalf("setup notes.txt: %v", err)
+	}
+	if err := writeFixture(filepath.Join(root, "components", "UserBadge.tue"), "testdata/UserBadge.tue"); err != nil {
+		t.Fatalf("setup UserBadge.tue: %v", err)
+	}
+	if err := writeFixture(filepath.Join(root, ".git", "ignored.tue"), "testdata/App.tue"); err != nil {
+		t.Fatalf("setup ignored .git fixture: %v", err)
+	}
+	if err := writeFixture(filepath.Join(root, ".tue-cache", "generated.tue"), "testdata/App.tue"); err != nil {
+		t.Fatalf("setup ignored .tue-cache fixture: %v", err)
+	}
+	if err := writeFixture(filepath.Join(root, "node_modules", "ignored.tue"), "testdata/App.tue"); err != nil {
+		t.Fatalf("setup ignored node_modules fixture: %v", err)
+	}
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -113,27 +130,29 @@ func TestRunCheckDiscoversTueFiles(t *testing.T) {
 	code := Run([]string{"check", root}, &stdout, &stderr)
 
 	if code != exitOK {
-		t.Fatalf("Run(check) exit code = %d, want %d; stderr = %q", code, exitOK, stderr.String())
+		t.Errorf("Run(check) exit code = %d, want %d; stderr = %q", code, exitOK, stderr.String())
 	}
 	if stderr.Len() != 0 {
-		t.Fatalf("stderr = %q, want empty", stderr.String())
+		t.Errorf("stderr = %q, want empty", stderr.String())
 	}
 
 	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
 	if len(lines) != 3 {
-		t.Fatalf("stdout lines = %#v, want summary plus 2 files", lines)
+		t.Errorf("stdout lines = %#v, want summary plus 2 files", lines)
 	}
-	if !strings.Contains(lines[0], "found 2 .tue file(s)") {
-		t.Fatalf("summary = %q, want discovered count", lines[0])
+	if len(lines) > 0 && !strings.Contains(lines[0], "checked 2 .tue file(s)") {
+		t.Errorf("summary = %q, want checked count", lines[0])
 	}
-	if lines[1] != "App.tue" || lines[2] != "components/UserBadge.tue" {
-		t.Fatalf("file lines = %#v, want sorted relative paths", lines[1:])
+	if len(lines) > 2 && (lines[1] != "App.tue" || lines[2] != "components/UserBadge.tue") {
+		t.Errorf("file lines = %#v, want sorted relative paths", lines[1:])
 	}
 }
 
 func TestRunCheckDefaultsToWorkingDirectory(t *testing.T) {
 	root := t.TempDir()
-	writeFile(t, filepath.Join(root, "App.tue"), "<template></template>")
+	if err := writeFixture(filepath.Join(root, "App.tue"), "testdata/App.tue"); err != nil {
+		t.Fatalf("setup App.tue: %v", err)
+	}
 	t.Chdir(root)
 
 	var stdout bytes.Buffer
@@ -142,10 +161,36 @@ func TestRunCheckDefaultsToWorkingDirectory(t *testing.T) {
 	code := Run([]string{"check"}, &stdout, &stderr)
 
 	if code != exitOK {
-		t.Fatalf("Run(check) exit code = %d, want %d; stderr = %q", code, exitOK, stderr.String())
+		t.Errorf("Run(check) exit code = %d, want %d; stderr = %q", code, exitOK, stderr.String())
 	}
 	if !strings.Contains(stdout.String(), "App.tue") {
-		t.Fatalf("stdout = %q, want default-root file", stdout.String())
+		t.Errorf("stdout = %q, want default-root file", stdout.String())
+	}
+}
+
+func TestRunCheckReportsDiagnostics(t *testing.T) {
+	root := t.TempDir()
+	if err := writeFixture(filepath.Join(root, "InvalidParent.tue"), "testdata/InvalidParent.tue"); err != nil {
+		t.Fatalf("setup InvalidParent.tue: %v", err)
+	}
+	if err := writeFixture(filepath.Join(root, "UserBadge.tue"), "testdata/UserBadge.tue"); err != nil {
+		t.Fatalf("setup UserBadge.tue: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := Run([]string{"check", root}, &stdout, &stderr)
+
+	if code != exitError {
+		t.Errorf("Run(check invalid) exit code = %d, want %d", code, exitError)
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("stdout = %q, want empty", stdout.String())
+	}
+	want := `InvalidParent.tue:2:3: component "UserBadge" requires prop "name"`
+	if !strings.Contains(stderr.String(), want) {
+		t.Errorf("stderr = %q, want %q", stderr.String(), want)
 	}
 }
 
@@ -156,13 +201,13 @@ func TestRunCheckRejectsInvalidProjectRoot(t *testing.T) {
 	code := Run([]string{"check", filepath.Join(t.TempDir(), "missing")}, &stdout, &stderr)
 
 	if code != exitError {
-		t.Fatalf("Run(check missing) exit code = %d, want %d", code, exitError)
+		t.Errorf("Run(check missing) exit code = %d, want %d", code, exitError)
 	}
 	if stdout.Len() != 0 {
-		t.Fatalf("stdout = %q, want empty", stdout.String())
+		t.Errorf("stdout = %q, want empty", stdout.String())
 	}
 	if !strings.Contains(stderr.String(), "stat project root") {
-		t.Fatalf("stderr = %q, want stat error", stderr.String())
+		t.Errorf("stderr = %q, want stat error", stderr.String())
 	}
 }
 
@@ -173,23 +218,38 @@ func TestRunCheckRejectsExtraProjectRoots(t *testing.T) {
 	code := Run([]string{"check", "one", "two"}, &stdout, &stderr)
 
 	if code != exitUsage {
-		t.Fatalf("Run(check one two) exit code = %d, want %d", code, exitUsage)
+		t.Errorf("Run(check one two) exit code = %d, want %d", code, exitUsage)
 	}
 	if stdout.Len() != 0 {
-		t.Fatalf("stdout = %q, want empty", stdout.String())
+		t.Errorf("stdout = %q, want empty", stdout.String())
 	}
 	if !strings.Contains(stderr.String(), "expected at most one project root") {
-		t.Fatalf("stderr = %q, want arity error", stderr.String())
+		t.Errorf("stderr = %q, want arity error", stderr.String())
 	}
 }
 
-func writeFile(t *testing.T, path string, contents string) {
-	t.Helper()
+func writeFixture(path string, fixture string) error {
+	contents, err := cliFixture(fixture)
+	if err != nil {
+		return err
+	}
+	return writeFile(path, contents)
+}
 
+func writeFile(path string, contents string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
 	}
 	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
-		t.Fatalf("write %s: %v", path, err)
+		return fmt.Errorf("write %s: %w", path, err)
 	}
+	return nil
+}
+
+func cliFixture(path string) (string, error) {
+	source, err := testFixtures.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read embedded fixture %s: %w", path, err)
+	}
+	return string(source), nil
 }

--- a/internal/cli/testdata/App.tue
+++ b/internal/cli/testdata/App.tue
@@ -1,0 +1,11 @@
+<template>
+	<p>{{ name }}</p>
+</template>
+
+<script lang="go">
+package app
+
+type App struct {
+	name string
+}
+</script>

--- a/internal/cli/testdata/InvalidParent.tue
+++ b/internal/cli/testdata/InvalidParent.tue
@@ -1,0 +1,9 @@
+<template>
+	<UserBadge />
+</template>
+
+<script lang="go">
+package app
+
+type InvalidParent struct{}
+</script>

--- a/internal/cli/testdata/UserBadge.tue
+++ b/internal/cli/testdata/UserBadge.tue
@@ -1,0 +1,13 @@
+<template>
+	<span>{{ name }}</span>
+</template>
+
+<script lang="go">
+package app
+
+import tue "github.com/norunners/tue"
+
+type UserBadge struct {
+	name tue.Prop[string] `prop:"name,required"`
+}
+</script>

--- a/internal/compiler/checker/checker_test.go
+++ b/internal/compiler/checker/checker_test.go
@@ -1,0 +1,196 @@
+package checker
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/norunners/tue/internal/compiler/script"
+	"github.com/norunners/tue/internal/compiler/sfc"
+	gotemplate "github.com/norunners/tue/internal/compiler/template"
+)
+
+//go:embed testdata/valid/*.tue testdata/invalid/*.tue testdata/missing_required_prop/*.tue
+var testFixtures embed.FS
+
+func TestCheckProjectAcceptsValidProject(t *testing.T) {
+	project, err := parseProjectFixture("testdata/valid")
+	if err != nil {
+		t.Fatalf("parse project fixture: %v", err)
+	}
+
+	diagnostics := CheckProject(project)
+	if diff := cmp.Diff([]diagnosticSummary{}, summarizeDiagnostics(diagnostics)); diff != "" {
+		t.Errorf("mismatch diagnostics (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestCheckProjectReportsTemplateDiagnostics(t *testing.T) {
+	project, err := parseProjectFixture("testdata/invalid")
+	if err != nil {
+		t.Fatalf("parse project fixture: %v", err)
+	}
+
+	diagnostics := CheckProject(project)
+	if diff := cmp.Diff([]diagnosticSummary{
+		{Path: "testdata/invalid/Parent.tue", Message: `unknown identifier "missing"`, Line: 3, Column: 21},
+		{Path: "testdata/invalid/Parent.tue", Message: `component "UserBadge" prop "isAdmin" expects bool, got string`, Line: 3, Column: 40},
+		{Path: "testdata/invalid/Parent.tue", Message: `component "UserBadge" has no prop "extra"`, Line: 3, Column: 48},
+		{Path: "testdata/invalid/Parent.tue", Message: `component "UnknownCard" is not registered`, Line: 4, Column: 4},
+		{Path: "testdata/invalid/Parent.tue", Message: `event handler "missingHandler" is not a method on Parent`, Line: 5, Column: 33},
+		{Path: "testdata/invalid/Parent.tue", Message: `v-model target "title" is not writable`, Line: 6, Column: 19},
+		{Path: "testdata/invalid/Parent.tue", Message: `v-for requires a :key attribute`, Line: 8, Column: 8},
+		{Path: "testdata/invalid/Parent.tue", Message: `unknown identifier "missing"`, Line: 10, Column: 9},
+		{Path: "testdata/invalid/Parent.tue", Message: `v-if expects bool, got string`, Line: 11, Column: 12},
+	}, summarizeDiagnostics(diagnostics)); diff != "" {
+		t.Errorf("mismatch diagnostics (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestCheckProjectReportsMissingRequiredComponentProp(t *testing.T) {
+	project, err := parseProjectFixture("testdata/missing_required_prop")
+	if err != nil {
+		t.Fatalf("parse project fixture: %v", err)
+	}
+
+	diagnostics := CheckProject(project)
+	if diff := cmp.Diff([]diagnosticSummary{
+		{Path: "testdata/missing_required_prop/Parent.tue", Message: `component "UserBadge" requires prop "name"`, Line: 3, Column: 4},
+	}, summarizeDiagnostics(diagnostics)); diff != "" {
+		t.Errorf("mismatch diagnostics (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestCheckProjectUsesExpressionSourceSpans(t *testing.T) {
+	source, err := testFixture("testdata/invalid/Parent.tue")
+	if err != nil {
+		t.Fatalf("read span fixture: %v", err)
+	}
+	project, err := parseProjectFixture("testdata/invalid")
+	if err != nil {
+		t.Fatalf("parse project fixture: %v", err)
+	}
+
+	diagnostics := CheckProject(project)
+	diagnostic, ok := findDiagnostic(diagnostics, `component "UserBadge" prop "isAdmin" expects bool, got string`)
+	if !ok {
+		t.Fatalf("diagnostic not found in %#v", summarizeDiagnostics(diagnostics))
+	}
+
+	expectedOffset := bytes.Index(source, []byte(`"yes"`))
+	if expectedOffset == -1 {
+		t.Fatal(`embedded fixture does not contain ""yes""`)
+	}
+	if diff := cmp.Diff(expectedOffset, diagnostic.Span.Start.Offset); diff != "" {
+		t.Errorf("mismatch diagnostic start offset (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff(sfc.Position{Offset: expectedOffset, Line: 3, Column: 40}, diagnostic.Span.Start); diff != "" {
+		t.Errorf("mismatch diagnostic start position (-expected, +actual):\n%s", diff)
+	}
+}
+
+func parseProjectFixture(dir string) (Project, error) {
+	entries, err := fs.ReadDir(testFixtures, dir)
+	if err != nil {
+		return Project{}, fmt.Errorf("read embedded fixture dir %s: %w", dir, err)
+	}
+
+	project := Project{Files: make([]File, 0, len(entries))}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".tue" {
+			continue
+		}
+
+		path := filepath.ToSlash(filepath.Join(dir, entry.Name()))
+		source, err := testFixture(path)
+		if err != nil {
+			return Project{}, err
+		}
+		sfcFile, sfcDiagnostics := sfc.Parse(path, source)
+		if len(sfcDiagnostics) != 0 {
+			return Project{}, fmt.Errorf("sfc.Parse(%s) diagnostics = %#v, want none", path, sfcDiagnosticMessages(sfcDiagnostics))
+		}
+
+		templateTree, templateDiagnostics := gotemplate.ParseBlock(sfcFile.Template)
+		if len(templateDiagnostics) != 0 {
+			return Project{}, fmt.Errorf("template.ParseBlock(%s) diagnostics = %#v, want none", path, templateDiagnosticMessages(templateDiagnostics))
+		}
+
+		scriptFile, scriptDiagnostics := script.ParseSFC(sfcFile)
+		if len(scriptDiagnostics) != 0 {
+			return Project{}, fmt.Errorf("script.ParseSFC(%s) diagnostics = %#v, want none", path, scriptDiagnosticMessages(scriptDiagnostics))
+		}
+
+		project.Files = append(project.Files, File{
+			Path:     path,
+			Template: templateTree,
+			Script:   scriptFile,
+		})
+	}
+	return project, nil
+}
+
+func testFixture(path string) ([]byte, error) {
+	source, err := testFixtures.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read embedded fixture %s: %w", path, err)
+	}
+	return source, nil
+}
+
+func findDiagnostic(diagnostics []Diagnostic, message string) (Diagnostic, bool) {
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Message == message {
+			return diagnostic, true
+		}
+	}
+	return Diagnostic{}, false
+}
+
+type diagnosticSummary struct {
+	Path    string
+	Message string
+	Line    int
+	Column  int
+}
+
+func summarizeDiagnostics(diagnostics []Diagnostic) []diagnosticSummary {
+	summaries := make([]diagnosticSummary, len(diagnostics))
+	for i, diagnostic := range diagnostics {
+		summaries[i] = diagnosticSummary{
+			Path:    diagnostic.Path,
+			Message: diagnostic.Message,
+			Line:    diagnostic.Span.Start.Line,
+			Column:  diagnostic.Span.Start.Column,
+		}
+	}
+	return summaries
+}
+
+func sfcDiagnosticMessages(diagnostics []sfc.Diagnostic) []string {
+	messages := make([]string, len(diagnostics))
+	for i, diagnostic := range diagnostics {
+		messages[i] = diagnostic.Message
+	}
+	return messages
+}
+
+func templateDiagnosticMessages(diagnostics []gotemplate.Diagnostic) []string {
+	messages := make([]string, len(diagnostics))
+	for i, diagnostic := range diagnostics {
+		messages[i] = diagnostic.Message
+	}
+	return messages
+}
+
+func scriptDiagnosticMessages(diagnostics []script.Diagnostic) []string {
+	messages := make([]string, len(diagnostics))
+	for i, diagnostic := range diagnostics {
+		messages[i] = diagnostic.Message
+	}
+	return messages
+}

--- a/internal/compiler/checker/contract.go
+++ b/internal/compiler/checker/contract.go
@@ -1,0 +1,26 @@
+package checker
+
+import (
+	"github.com/norunners/tue/internal/compiler/script"
+	"github.com/norunners/tue/internal/compiler/sfc"
+	gotemplate "github.com/norunners/tue/internal/compiler/template"
+)
+
+// Project is the parsed compiler input for template checking.
+type Project struct {
+	Files []File
+}
+
+// File is one parsed .tue source file.
+type File struct {
+	Path     string
+	Template *gotemplate.Tree
+	Script   *script.File
+}
+
+// Diagnostic is a source-mapped template checker diagnostic.
+type Diagnostic struct {
+	Path    string
+	Message string
+	Span    sfc.Span
+}

--- a/internal/compiler/checker/directive.go
+++ b/internal/compiler/checker/directive.go
@@ -1,0 +1,227 @@
+package checker
+
+import (
+	"fmt"
+	"go/ast"
+	"strings"
+	"unicode"
+
+	"github.com/norunners/tue/internal/compiler/sfc"
+	gotemplate "github.com/norunners/tue/internal/compiler/template"
+)
+
+func (c *fileChecker) checkCommonAttrs(node *gotemplate.Node, scope *scope) {
+	for _, attr := range node.Attrs {
+		switch attr.Kind {
+		case gotemplate.AttrEvent:
+			c.checkEvent(attr, scope)
+		case gotemplate.AttrDirective:
+			switch attr.Directive {
+			case gotemplate.DirectiveIf:
+				value := c.checkExpression(attr.Expression, attr.ExpressionSpan, scope)
+				c.expectType("bool", value.Type, "v-if", attr.ExpressionSpan)
+			case gotemplate.DirectiveHTML:
+				value := c.checkExpression(attr.Expression, attr.ExpressionSpan, scope)
+				c.expectType("string", value.Type, "v-html", attr.ExpressionSpan)
+			case gotemplate.DirectiveModel:
+				c.checkModel(attr, scope)
+			case gotemplate.DirectiveFor, gotemplate.DirectiveElse:
+			}
+		}
+	}
+}
+
+func (c *fileChecker) checkEvent(attr gotemplate.Attr, scope *scope) {
+	expr, exprChecker, ok := c.parseExpression(attr.Expression, attr.ExpressionSpan, scope)
+	if !ok {
+		return
+	}
+
+	switch typed := expr.(type) {
+	case *ast.Ident:
+		c.expectMethod(typed.Name, exprChecker.nodeSpan(typed), scope)
+	case *ast.CallExpr:
+		c.checkCallEvent(typed, exprChecker, scope)
+	default:
+		value := exprChecker.eval(expr)
+		if value.Type != unknownType && value.Type != funcType {
+			c.add(fmt.Sprintf("event handler must be a method, got %s", displayType(value.Type)), exprChecker.nodeSpan(expr))
+		}
+	}
+}
+
+func (c *fileChecker) checkCallEvent(call *ast.CallExpr, exprChecker *exprChecker, scope *scope) {
+	for _, arg := range call.Args {
+		exprChecker.eval(arg)
+	}
+
+	switch callee := call.Fun.(type) {
+	case *ast.Ident:
+		c.expectMethod(callee.Name, exprChecker.nodeSpan(callee), scope)
+	case *ast.SelectorExpr:
+		exprChecker.eval(callee)
+	default:
+		value := exprChecker.eval(call.Fun)
+		if value.Type != unknownType && value.Type != funcType {
+			c.add(fmt.Sprintf("event handler must be a method, got %s", displayType(value.Type)), exprChecker.nodeSpan(call.Fun))
+		}
+	}
+}
+
+func (c *fileChecker) checkFor(node *gotemplate.Node, attr gotemplate.Attr, scope *scope) *scope {
+	clause, ok := parseForClause(attr.Expression)
+	if !ok {
+		c.add("v-for must use '<item> in <items>'", attr.ExpressionSpan)
+		return scope
+	}
+
+	sourceSpan := spanWithin(attr.ExpressionSpan, attr.Expression, clause.sourceStart, clause.sourceEnd)
+	source := c.checkExpression(clause.source, sourceSpan, scope)
+	elementType, iterable := iterableElementType(source.Type)
+	if !iterable {
+		c.add(fmt.Sprintf("v-for source must be iterable, got %s", displayType(source.Type)), sourceSpan)
+		elementType = unknownType
+	}
+
+	if !hasBoundKey(node) {
+		c.add("v-for requires a :key attribute", attr.DirectiveSpan)
+	}
+
+	next := newScope(scope)
+	next.add(symbol{Name: clause.item, Type: elementType, Writable: false})
+	if clause.index != "" {
+		next.add(symbol{Name: clause.index, Type: "int", Writable: false})
+	}
+	return next
+}
+
+func (c *fileChecker) checkModel(attr gotemplate.Attr, scope *scope) {
+	expr, exprChecker, ok := c.parseExpression(attr.Expression, attr.ExpressionSpan, scope)
+	if !ok {
+		return
+	}
+
+	value := exprChecker.eval(expr)
+	if value.Type == unknownType {
+		return
+	}
+
+	target := modelTarget(expr, scope)
+	if target == nil || !target.Writable {
+		c.add(fmt.Sprintf("v-model target %q is not writable", attr.Expression), attr.ExpressionSpan)
+	}
+}
+
+func (c *fileChecker) expectMethod(name string, span sfc.Span, scope *scope) {
+	symbol, ok := scope.lookup(name)
+	if !ok || !symbol.Method {
+		c.add(fmt.Sprintf("event handler %q is not a method on %s", name, c.component.Name), span)
+	}
+}
+
+type forClause struct {
+	item        string
+	index       string
+	source      string
+	sourceStart int
+	sourceEnd   int
+}
+
+func parseForClause(expression string) (forClause, bool) {
+	in := strings.Index(expression, " in ")
+	if in == -1 {
+		return forClause{}, false
+	}
+
+	target := strings.TrimSpace(expression[:in])
+	if strings.HasPrefix(target, "(") && strings.HasSuffix(target, ")") {
+		target = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(target, "("), ")"))
+	}
+
+	sourceStart := in + len(" in ")
+	sourceEnd := len(expression)
+	for sourceStart < sourceEnd && isSpace(rune(expression[sourceStart])) {
+		sourceStart++
+	}
+	for sourceEnd > sourceStart && isSpace(rune(expression[sourceEnd-1])) {
+		sourceEnd--
+	}
+
+	source := expression[sourceStart:sourceEnd]
+	parts := strings.Split(target, ",")
+	if len(parts) == 0 || len(parts) > 2 || source == "" {
+		return forClause{}, false
+	}
+
+	clause := forClause{
+		item:        strings.TrimSpace(parts[0]),
+		source:      source,
+		sourceStart: sourceStart,
+		sourceEnd:   sourceEnd,
+	}
+	if len(parts) == 2 {
+		clause.index = strings.TrimSpace(parts[1])
+	}
+	if !isIdentifier(clause.item) || (clause.index != "" && !isIdentifier(clause.index)) {
+		return forClause{}, false
+	}
+	return clause, true
+}
+
+func modelTarget(expr ast.Expr, scope *scope) *symbol {
+	switch typed := expr.(type) {
+	case *ast.Ident:
+		symbol, ok := scope.lookup(typed.Name)
+		if !ok {
+			return nil
+		}
+		return &symbol
+	default:
+		return nil
+	}
+}
+
+func directiveAttr(node *gotemplate.Node, kind gotemplate.DirectiveKind) (gotemplate.Attr, bool) {
+	for _, attr := range node.Attrs {
+		if attr.Kind == gotemplate.AttrDirective && attr.Directive == kind {
+			return attr, true
+		}
+	}
+	return gotemplate.Attr{}, false
+}
+
+func hasBoundKey(node *gotemplate.Node) bool {
+	for _, attr := range node.Attrs {
+		if attr.Kind == gotemplate.AttrBind && attr.Argument == "key" {
+			return true
+		}
+	}
+	return false
+}
+
+func isIdentifier(name string) bool {
+	if name == "" {
+		return false
+	}
+	for index, r := range name {
+		if index == 0 {
+			if r != '_' && !unicode.IsLetter(r) {
+				return false
+			}
+			continue
+		}
+		if r != '_' && !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func isSpace(r rune) bool {
+	switch r {
+	case ' ', '\n', '\r', '\t', '\f':
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/compiler/checker/expression.go
+++ b/internal/compiler/checker/expression.go
@@ -1,0 +1,231 @@
+package checker
+
+import (
+	"fmt"
+	"go/ast"
+	goparser "go/parser"
+	"go/token"
+	"strconv"
+	"strings"
+
+	"github.com/norunners/tue/internal/compiler/sfc"
+)
+
+func (c *fileChecker) checkExpression(expression string, span sfc.Span, scope *scope) value {
+	expr, exprChecker, ok := c.parseExpression(expression, span, scope)
+	if !ok {
+		return value{Type: unknownType}
+	}
+	return exprChecker.eval(expr)
+}
+
+func (c *fileChecker) parseExpression(expression string, span sfc.Span, scope *scope) (ast.Expr, *exprChecker, bool) {
+	fset := token.NewFileSet()
+	expr, err := goparser.ParseExprFrom(fset, "", expression, 0)
+	exprChecker := &exprChecker{
+		fileChecker: c,
+		fset:        fset,
+		source:      expression,
+		base:        span,
+		scope:       scope,
+	}
+	if err != nil {
+		c.add(fmt.Sprintf("invalid expression: %s", err), span)
+		return nil, exprChecker, false
+	}
+	return expr, exprChecker, true
+}
+
+type exprChecker struct {
+	fileChecker *fileChecker
+	fset        *token.FileSet
+	source      string
+	base        sfc.Span
+	scope       *scope
+}
+
+type value struct {
+	Type   string
+	Symbol *symbol
+}
+
+func (c *exprChecker) eval(expr ast.Expr) value {
+	switch typed := expr.(type) {
+	case *ast.Ident:
+		return c.ident(typed)
+	case *ast.BasicLit:
+		return c.basicLit(typed)
+	case *ast.BinaryExpr:
+		return c.binary(typed)
+	case *ast.UnaryExpr:
+		return c.unary(typed)
+	case *ast.ParenExpr:
+		return c.eval(typed.X)
+	case *ast.SelectorExpr:
+		return c.selector(typed)
+	case *ast.CallExpr:
+		return c.call(typed)
+	case *ast.IndexExpr:
+		return c.index(typed)
+	case *ast.SliceExpr:
+		c.eval(typed.X)
+		if typed.Low != nil {
+			c.eval(typed.Low)
+		}
+		if typed.High != nil {
+			c.eval(typed.High)
+		}
+		if typed.Max != nil {
+			c.eval(typed.Max)
+		}
+		return value{Type: unknownType}
+	default:
+		return value{Type: unknownType}
+	}
+}
+
+func (c *exprChecker) ident(ident *ast.Ident) value {
+	switch ident.Name {
+	case "true", "false":
+		return value{Type: "bool"}
+	case "nil":
+		return value{Type: unknownType}
+	}
+
+	symbol, ok := c.scope.lookup(ident.Name)
+	if !ok {
+		c.fileChecker.add(fmt.Sprintf("unknown identifier %q", ident.Name), c.nodeSpan(ident))
+		return value{Type: unknownType}
+	}
+	return value{Type: symbol.Type, Symbol: &symbol}
+}
+
+func (c *exprChecker) basicLit(lit *ast.BasicLit) value {
+	switch lit.Kind {
+	case token.STRING:
+		if _, err := strconv.Unquote(lit.Value); err != nil {
+			c.fileChecker.add("invalid string literal", c.nodeSpan(lit))
+		}
+		return value{Type: "string"}
+	case token.INT:
+		return value{Type: "int"}
+	case token.FLOAT:
+		return value{Type: "float64"}
+	case token.CHAR:
+		return value{Type: "rune"}
+	default:
+		return value{Type: unknownType}
+	}
+}
+
+func (c *exprChecker) binary(binary *ast.BinaryExpr) value {
+	left := c.eval(binary.X)
+	right := c.eval(binary.Y)
+
+	switch binary.Op {
+	case token.LAND, token.LOR:
+		c.expectOperand("bool", left, binary.X)
+		c.expectOperand("bool", right, binary.Y)
+		return value{Type: "bool"}
+	case token.EQL, token.NEQ, token.LSS, token.LEQ, token.GTR, token.GEQ:
+		if !assignable(left.Type, right.Type) && !assignable(right.Type, left.Type) {
+			c.fileChecker.add(
+				fmt.Sprintf("cannot compare %s and %s", displayType(left.Type), displayType(right.Type)),
+				c.nodeSpan(binary),
+			)
+		}
+		return value{Type: "bool"}
+	case token.ADD:
+		if left.Type == "string" || right.Type == "string" {
+			if !assignable("string", left.Type) || !assignable("string", right.Type) {
+				c.fileChecker.add("operator + requires both operands to be strings or numbers", c.nodeSpan(binary))
+				return value{Type: unknownType}
+			}
+			return value{Type: "string"}
+		}
+		if isNumeric(left.Type) && isNumeric(right.Type) {
+			return value{Type: left.Type}
+		}
+	case token.SUB, token.MUL, token.QUO, token.REM:
+		if isNumeric(left.Type) && isNumeric(right.Type) {
+			return value{Type: left.Type}
+		}
+	}
+
+	if left.Type == unknownType || right.Type == unknownType {
+		return value{Type: unknownType}
+	}
+	c.fileChecker.add(fmt.Sprintf("operator %s is not defined for %s and %s", binary.Op, displayType(left.Type), displayType(right.Type)), c.nodeSpan(binary))
+	return value{Type: unknownType}
+}
+
+func (c *exprChecker) unary(unary *ast.UnaryExpr) value {
+	operand := c.eval(unary.X)
+	switch unary.Op {
+	case token.NOT:
+		c.expectOperand("bool", operand, unary.X)
+		return value{Type: "bool"}
+	case token.ADD, token.SUB:
+		if operand.Type == unknownType || isNumeric(operand.Type) {
+			return operand
+		}
+		c.fileChecker.add(fmt.Sprintf("operator %s is not defined for %s", unary.Op, displayType(operand.Type)), c.nodeSpan(unary))
+	}
+	return value{Type: unknownType}
+}
+
+func (c *exprChecker) selector(selector *ast.SelectorExpr) value {
+	base := c.eval(selector.X)
+	if base.Type == unknownType {
+		return value{Type: unknownType}
+	}
+	if isScalar(base.Type) || strings.HasPrefix(normalizeType(base.Type), "[]") {
+		c.fileChecker.add(fmt.Sprintf("type %s has no field %q", displayType(base.Type), selector.Sel.Name), c.nodeSpan(selector.Sel))
+	}
+	return value{Type: unknownType}
+}
+
+func (c *exprChecker) call(call *ast.CallExpr) value {
+	c.eval(call.Fun)
+	for _, arg := range call.Args {
+		c.eval(arg)
+	}
+	return value{Type: unknownType}
+}
+
+func (c *exprChecker) index(index *ast.IndexExpr) value {
+	base := c.eval(index.X)
+	c.eval(index.Index)
+	if element, ok := iterableElementType(base.Type); ok {
+		return value{Type: element}
+	}
+	return value{Type: unknownType}
+}
+
+func (c *exprChecker) expectOperand(expected string, actual value, expr ast.Expr) {
+	if assignable(expected, actual.Type) {
+		return
+	}
+	c.fileChecker.add(fmt.Sprintf("operand expects %s, got %s", displayType(expected), displayType(actual.Type)), c.nodeSpan(expr))
+}
+
+func (c *exprChecker) nodeSpan(node ast.Node) sfc.Span {
+	start := c.offset(node.Pos())
+	end := c.offset(node.End())
+	return spanWithin(c.base, c.source, start, end)
+}
+
+func (c *exprChecker) offset(position token.Pos) int {
+	file := c.fset.File(position)
+	if file == nil || !position.IsValid() {
+		return len(c.source)
+	}
+	offset := file.Offset(position)
+	if offset < 0 {
+		return 0
+	}
+	if offset > len(c.source) {
+		return len(c.source)
+	}
+	return offset
+}

--- a/internal/compiler/checker/file.go
+++ b/internal/compiler/checker/file.go
@@ -1,0 +1,135 @@
+package checker
+
+import (
+	"fmt"
+
+	"github.com/norunners/tue/internal/compiler/script"
+	"github.com/norunners/tue/internal/compiler/sfc"
+	gotemplate "github.com/norunners/tue/internal/compiler/template"
+)
+
+type fileChecker struct {
+	path        string
+	component   *script.Component
+	components  map[string]componentBinding
+	diagnostics []Diagnostic
+}
+
+func (c *fileChecker) checkNodes(nodes []*gotemplate.Node, scope *scope) {
+	for _, node := range nodes {
+		c.checkNode(node, scope)
+	}
+}
+
+func (c *fileChecker) checkNode(node *gotemplate.Node, scope *scope) {
+	if node == nil {
+		return
+	}
+
+	switch node.Kind {
+	case gotemplate.NodeElement:
+		c.checkElement(node, scope)
+	case gotemplate.NodeInterpolation:
+		c.checkExpression(node.Expression, node.ExpressionSpan, scope)
+	}
+}
+
+func (c *fileChecker) checkElement(node *gotemplate.Node, scope *scope) {
+	elementScope := scope
+	if attr, ok := directiveAttr(node, gotemplate.DirectiveFor); ok {
+		elementScope = c.checkFor(node, attr, scope)
+	}
+
+	c.checkCommonAttrs(node, elementScope)
+	if node.IsComponent {
+		c.checkComponent(node, elementScope)
+	} else {
+		c.checkNativeAttrs(node, elementScope)
+	}
+	c.checkNodes(node.Children, elementScope)
+}
+
+func (c *fileChecker) checkNativeAttrs(node *gotemplate.Node, scope *scope) {
+	for _, attr := range node.Attrs {
+		if attr.Kind == gotemplate.AttrBind {
+			c.checkExpression(attr.Expression, attr.ExpressionSpan, scope)
+		}
+	}
+}
+
+func (c *fileChecker) checkComponent(node *gotemplate.Node, scope *scope) {
+	child, ok := c.components[node.Tag]
+	if !ok {
+		c.add(fmt.Sprintf("component %q is not registered", node.Tag), node.TagSpan)
+		return
+	}
+
+	seen := make(map[string]bool)
+	for _, attr := range node.Attrs {
+		switch attr.Kind {
+		case gotemplate.AttrStatic:
+			c.checkStaticComponentProp(node, child, attr, seen)
+		case gotemplate.AttrBind:
+			c.checkBoundComponentProp(node, child, attr, scope, seen)
+		}
+	}
+
+	for _, prop := range child.component.Props {
+		if prop.Required && !seen[prop.Name] {
+			c.add(fmt.Sprintf("component %q requires prop %q", node.Tag, prop.Name), node.TagSpan)
+		}
+	}
+}
+
+func (c *fileChecker) checkStaticComponentProp(node *gotemplate.Node, child componentBinding, attr gotemplate.Attr, seen map[string]bool) {
+	prop, ok := child.props[attr.Name]
+	if !ok {
+		c.add(fmt.Sprintf("component %q has no prop %q", node.Tag, attr.Name), attr.NameSpan)
+		return
+	}
+
+	seen[prop.Name] = true
+	actual := "string"
+	if !attr.HasValue {
+		actual = "bool"
+	}
+	c.expectComponentPropType(node.Tag, prop, actual, attr.ValueSpan)
+}
+
+func (c *fileChecker) checkBoundComponentProp(node *gotemplate.Node, child componentBinding, attr gotemplate.Attr, scope *scope, seen map[string]bool) {
+	prop, ok := child.props[attr.Argument]
+	if !ok {
+		c.add(fmt.Sprintf("component %q has no prop %q", node.Tag, attr.Argument), attr.ArgumentSpan)
+		return
+	}
+
+	seen[prop.Name] = true
+	value := c.checkExpression(attr.Expression, attr.ExpressionSpan, scope)
+	c.expectComponentPropType(node.Tag, prop, value.Type, attr.ExpressionSpan)
+}
+
+func (c *fileChecker) expectType(expected string, actual string, subject string, span sfc.Span) {
+	if assignable(expected, actual) {
+		return
+	}
+	c.add(fmt.Sprintf("%s expects %s, got %s", subject, displayType(expected), displayType(actual)), span)
+}
+
+func (c *fileChecker) expectComponentPropType(componentName string, prop script.Prop, actual string, span sfc.Span) {
+	expected := propType(prop)
+	if assignable(expected, actual) {
+		return
+	}
+	c.add(
+		fmt.Sprintf("component %q prop %q expects %s, got %s", componentName, prop.Name, displayType(expected), displayType(actual)),
+		span,
+	)
+}
+
+func (c *fileChecker) add(message string, span sfc.Span) {
+	c.diagnostics = append(c.diagnostics, Diagnostic{
+		Path:    c.path,
+		Message: message,
+		Span:    span,
+	})
+}

--- a/internal/compiler/checker/project.go
+++ b/internal/compiler/checker/project.go
@@ -1,0 +1,95 @@
+package checker
+
+import (
+	"fmt"
+
+	"github.com/norunners/tue/internal/compiler/script"
+	"github.com/norunners/tue/internal/compiler/sfc"
+)
+
+// CheckProject validates template expressions and component references across a
+// parsed project.
+func CheckProject(project Project) []Diagnostic {
+	checker := projectChecker{
+		components: make(map[string]componentBinding),
+	}
+	checker.indexComponents(project.Files)
+	for _, file := range project.Files {
+		checker.checkFile(file)
+	}
+	return checker.diagnostics
+}
+
+type projectChecker struct {
+	components  map[string]componentBinding
+	diagnostics []Diagnostic
+}
+
+type componentBinding struct {
+	path      string
+	component *script.Component
+	props     map[string]script.Prop
+}
+
+func (c *projectChecker) indexComponents(files []File) {
+	for _, file := range files {
+		path := filePath(file)
+		if file.Script == nil || file.Script.Component == nil {
+			continue
+		}
+
+		component := file.Script.Component
+		if previous, ok := c.components[component.Name]; ok {
+			c.add(path, fmt.Sprintf("duplicate component %q; first declared in %s", component.Name, previous.path), component.NameSpan)
+			continue
+		}
+
+		props := make(map[string]script.Prop, len(component.Props))
+		for _, prop := range component.Props {
+			props[prop.Name] = prop
+		}
+		c.components[component.Name] = componentBinding{
+			path:      path,
+			component: component,
+			props:     props,
+		}
+	}
+}
+
+func (c *projectChecker) checkFile(file File) {
+	path := filePath(file)
+	if file.Template == nil {
+		c.add(path, "missing parsed template", sfc.Span{})
+		return
+	}
+	if file.Script == nil || file.Script.Component == nil {
+		c.add(path, "missing component contract", file.Template.Span)
+		return
+	}
+
+	fileChecker := fileChecker{
+		path:       path,
+		component:  file.Script.Component,
+		components: c.components,
+	}
+	fileChecker.checkNodes(file.Template.Nodes, componentScope(file.Script.Component))
+	c.diagnostics = append(c.diagnostics, fileChecker.diagnostics...)
+}
+
+func (c *projectChecker) add(path string, message string, span sfc.Span) {
+	c.diagnostics = append(c.diagnostics, Diagnostic{
+		Path:    path,
+		Message: message,
+		Span:    span,
+	})
+}
+
+func filePath(file File) string {
+	if file.Path != "" {
+		return file.Path
+	}
+	if file.Script != nil && file.Script.Path != "" {
+		return file.Script.Path
+	}
+	return ""
+}

--- a/internal/compiler/checker/scope.go
+++ b/internal/compiler/checker/scope.go
@@ -1,0 +1,150 @@
+package checker
+
+import (
+	"strings"
+
+	"github.com/norunners/tue/internal/compiler/script"
+)
+
+const (
+	unknownType = "unknown"
+	funcType    = "func"
+)
+
+type scope struct {
+	parent  *scope
+	symbols map[string]symbol
+}
+
+type symbol struct {
+	Name     string
+	Type     string
+	Writable bool
+	Method   bool
+}
+
+func componentScope(component *script.Component) *scope {
+	scope := newScope(nil)
+	for _, prop := range component.Props {
+		fieldType := propType(prop)
+		scope.add(symbol{Name: prop.Field.Name, Type: fieldType})
+	}
+	for _, field := range component.State {
+		scope.add(symbol{Name: field.Name, Type: fieldType(field), Writable: true})
+	}
+	for _, field := range component.Refs {
+		scope.add(symbol{Name: field.Name, Type: fieldType(field), Writable: true})
+	}
+	for _, field := range component.Computed {
+		scope.add(symbol{Name: field.Name, Type: fieldType(field)})
+	}
+	for _, field := range component.Resources {
+		scope.add(symbol{Name: field.Name, Type: fieldType(field)})
+	}
+	for _, method := range component.Methods {
+		scope.add(symbol{Name: method.Name, Type: funcType, Method: true})
+	}
+	return scope
+}
+
+func newScope(parent *scope) *scope {
+	return &scope{
+		parent:  parent,
+		symbols: make(map[string]symbol),
+	}
+}
+
+func (s *scope) add(symbol symbol) {
+	s.symbols[symbol.Name] = symbol
+}
+
+func (s *scope) lookup(name string) (symbol, bool) {
+	for current := s; current != nil; current = current.parent {
+		if symbol, ok := current.symbols[name]; ok {
+			return symbol, true
+		}
+	}
+	return symbol{}, false
+}
+
+func propType(prop script.Prop) string {
+	return fieldType(prop.Field)
+}
+
+func fieldType(field script.Field) string {
+	if field.ValueType != "" {
+		return field.ValueType
+	}
+	if field.Type != "" {
+		return field.Type
+	}
+	return unknownType
+}
+
+func iterableElementType(typ string) (string, bool) {
+	typ = normalizeType(typ)
+	if typ == unknownType || typ == "" {
+		return unknownType, true
+	}
+	if strings.HasPrefix(typ, "[]") {
+		return strings.TrimSpace(strings.TrimPrefix(typ, "[]")), true
+	}
+	if strings.HasPrefix(typ, "[") {
+		close := strings.IndexByte(typ, ']')
+		if close != -1 && close+1 < len(typ) {
+			return strings.TrimSpace(typ[close+1:]), true
+		}
+	}
+	if strings.HasPrefix(typ, "map[") {
+		close := strings.IndexByte(typ, ']')
+		if close != -1 && close+1 < len(typ) {
+			return strings.TrimSpace(typ[close+1:]), true
+		}
+	}
+	if typ == "string" {
+		return "rune", true
+	}
+	return "", false
+}
+
+func assignable(expected string, actual string) bool {
+	expected = normalizeType(expected)
+	actual = normalizeType(actual)
+	if expected == "" || actual == "" || expected == unknownType || actual == unknownType {
+		return true
+	}
+	return expected == actual
+}
+
+func normalizeType(typ string) string {
+	typ = strings.TrimSpace(typ)
+	for strings.HasPrefix(typ, "*") {
+		typ = strings.TrimSpace(strings.TrimPrefix(typ, "*"))
+	}
+	return typ
+}
+
+func displayType(typ string) string {
+	if typ == "" {
+		return unknownType
+	}
+	return typ
+}
+
+func isNumeric(typ string) bool {
+	switch normalizeType(typ) {
+	case "int", "int8", "int16", "int32", "int64", "uint", "uint8", "uint16", "uint32", "uint64", "uintptr", "float32", "float64", "rune", "byte":
+		return true
+	default:
+		return false
+	}
+}
+
+func isScalar(typ string) bool {
+	switch normalizeType(typ) {
+	case "string", "bool":
+		return true
+	default:
+		return isNumeric(typ)
+	}
+}

--- a/internal/compiler/checker/span.go
+++ b/internal/compiler/checker/span.go
@@ -1,0 +1,47 @@
+package checker
+
+import "github.com/norunners/tue/internal/compiler/sfc"
+
+func spanWithin(base sfc.Span, source string, start int, end int) sfc.Span {
+	if start < 0 {
+		start = 0
+	}
+	if end < start {
+		end = start
+	}
+	if start > len(source) {
+		start = len(source)
+	}
+	if end > len(source) {
+		end = len(source)
+	}
+
+	return sfc.Span{
+		Start: positionWithin(base.Start, source, start),
+		End:   positionWithin(base.Start, source, end),
+	}
+}
+
+func positionWithin(base sfc.Position, source string, offset int) sfc.Position {
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > len(source) {
+		offset = len(source)
+	}
+
+	position := sfc.Position{
+		Offset: base.Offset + offset,
+		Line:   base.Line,
+		Column: base.Column,
+	}
+	for index := 0; index < offset; index++ {
+		if source[index] == '\n' {
+			position.Line++
+			position.Column = 1
+			continue
+		}
+		position.Column++
+	}
+	return position
+}

--- a/internal/compiler/checker/testdata/invalid/Parent.tue
+++ b/internal/compiler/checker/testdata/invalid/Parent.tue
@@ -1,0 +1,30 @@
+<template>
+	<main>
+		<UserBadge :name="missing" :isAdmin='"yes"' :extra="name" />
+		<UnknownCard />
+		<button type="button" @click="missingHandler">Save</button>
+		<input v-model="title" />
+		<ul>
+			<li v-for="todo in todos">{{ todo.Text }}</li>
+		</ul>
+		<p>{{ missing }}</p>
+		<p v-if="name">Bad condition</p>
+	</main>
+</template>
+
+<script lang="go">
+package fixtures
+
+import tue "github.com/norunners/tue"
+
+type Todo struct {
+	ID   int
+	Text string
+}
+
+type Parent struct {
+	title tue.Prop[string]
+	name  string
+	todos []Todo
+}
+</script>

--- a/internal/compiler/checker/testdata/invalid/UserBadge.tue
+++ b/internal/compiler/checker/testdata/invalid/UserBadge.tue
@@ -1,0 +1,17 @@
+<template>
+	<span class="badge">
+		{{ name }}
+		<strong v-if="isAdmin">Admin</strong>
+	</span>
+</template>
+
+<script lang="go">
+package fixtures
+
+import tue "github.com/norunners/tue"
+
+type UserBadge struct {
+	name    tue.Prop[string] `prop:"name,required"`
+	isAdmin tue.Prop[bool]   `prop:"isAdmin"`
+}
+</script>

--- a/internal/compiler/checker/testdata/missing_required_prop/Parent.tue
+++ b/internal/compiler/checker/testdata/missing_required_prop/Parent.tue
@@ -1,0 +1,13 @@
+<template>
+	<main>
+		<UserBadge :isAdmin="enabled" />
+	</main>
+</template>
+
+<script lang="go">
+package fixtures
+
+type Parent struct {
+	enabled bool
+}
+</script>

--- a/internal/compiler/checker/testdata/missing_required_prop/UserBadge.tue
+++ b/internal/compiler/checker/testdata/missing_required_prop/UserBadge.tue
@@ -1,0 +1,14 @@
+<template>
+	<span>{{ name }}</span>
+</template>
+
+<script lang="go">
+package fixtures
+
+import tue "github.com/norunners/tue"
+
+type UserBadge struct {
+	name    tue.Prop[string] `prop:"name,required"`
+	isAdmin tue.Prop[bool]   `prop:"isAdmin"`
+}
+</script>

--- a/internal/compiler/checker/testdata/valid/Parent.tue
+++ b/internal/compiler/checker/testdata/valid/Parent.tue
@@ -1,0 +1,35 @@
+<template>
+	<main>
+		<UserBadge :name="name" :isAdmin='role == "admin"' @select="selectUser" />
+		<ul>
+			<li v-for="todo in todos" :key="todo.ID">{{ todo.Text }}</li>
+		</ul>
+		<input v-model="query" />
+		<button type="button" @click="increment">Increment</button>
+		<p v-if="ready">Count: {{ count }}</p>
+	</main>
+</template>
+
+<script lang="go">
+package fixtures
+
+import tue "github.com/norunners/tue"
+
+type Todo struct {
+	ID   int
+	Text string
+}
+
+type Parent struct {
+	name  string
+	role  string
+	todos []Todo
+	query string
+	ready bool
+	count tue.Ref[int]
+}
+
+func (p *Parent) increment() {}
+
+func (p *Parent) selectUser() {}
+</script>

--- a/internal/compiler/checker/testdata/valid/UserBadge.tue
+++ b/internal/compiler/checker/testdata/valid/UserBadge.tue
@@ -1,0 +1,17 @@
+<template>
+	<span class="badge">
+		{{ name }}
+		<strong v-if="isAdmin">Admin</strong>
+	</span>
+</template>
+
+<script lang="go">
+package fixtures
+
+import tue "github.com/norunners/tue"
+
+type UserBadge struct {
+	name    tue.Prop[string] `prop:"name,required"`
+	isAdmin tue.Prop[bool]   `prop:"isAdmin"`
+}
+</script>


### PR DESCRIPTION
## Summary

- Added `internal/compiler/checker` to validate parsed template ASTs against script component contracts.
- Wired `tue check` to parse SFC/template/script inputs first, then run checker diagnostics only after parsing succeeds.
- Added embedded checker and CLI fixtures covering valid projects, missing required props, prop type mismatches, unknown identifiers, events, `v-model`, and `v-for` keys.

## Validation

- `go fmt ./...`
- `go test ./...`
- `git diff --check`
- `git diff --cached --check`
- `go run ./cmd/tue check internal/compiler/checker/testdata/valid`
- `go run ./cmd/tue check internal/compiler/checker/testdata/invalid` returned the expected diagnostics and nonzero exit.