### PR TITLE
Replaced runtime foundation.

### DIFF
--- a/mount.go
+++ b/mount.go
@@ -4,12 +4,9 @@ package tue
 
 import "fmt"
 
-func mount(target string, component *Comp) error {
-	if target == "" {
-		return fmt.Errorf("mount target is required")
+func mount(target string, component *Comp) (*Mounted, error) {
+	if err := validateMount(target, component); err != nil {
+		return nil, err
 	}
-	if component == nil {
-		return fmt.Errorf("component is required")
-	}
-	return fmt.Errorf("mount is only supported under js/wasm")
+	return nil, fmt.Errorf("mount is only supported under js/wasm")
 }

--- a/mount_js.go
+++ b/mount_js.go
@@ -7,19 +7,29 @@ import (
 	"syscall/js"
 )
 
-func mount(target string, component *Comp) error {
-	if target == "" {
-		return fmt.Errorf("mount target is required")
-	}
-	if component == nil {
-		return fmt.Errorf("component is required")
+func mount(target string, component *Comp) (*Mounted, error) {
+	if err := validateMount(target, component); err != nil {
+		return nil, err
 	}
 
 	document := js.Global().Get("document")
 	element := document.Call("querySelector", target)
 	if element.IsNull() || element.IsUndefined() {
-		return fmt.Errorf("mount target %q not found", target)
+		return nil, fmt.Errorf("mount target %q not found", target)
 	}
-	element.Set("innerHTML", RenderHTML(component.Render()))
+	return mountComponent(component, jsMountTarget{element: element})
+}
+
+type jsMountTarget struct {
+	element js.Value
+}
+
+func (t jsMountTarget) render(node VNode) error {
+	t.element.Set("innerHTML", RenderHTML(node))
+	return nil
+}
+
+func (t jsMountTarget) clear() error {
+	t.element.Set("innerHTML", "")
 	return nil
 }

--- a/mount_test.go
+++ b/mount_test.go
@@ -1,0 +1,21 @@
+//go:build !js || !wasm
+
+package tue
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestMountReportsUnsupportedPlatform(t *testing.T) {
+	component := CompOf(&initFixture{}, func(*initFixture) VNode {
+		return Text("value")
+	})
+
+	_, err := Mount("#app", component)
+
+	if err == nil || err.Error() != "mount is only supported under js/wasm" {
+		t.Errorf("mismatch Mount error (-expected, +actual):\n%s", cmp.Diff("mount is only supported under js/wasm", errorString(err)))
+	}
+}

--- a/mounting.go
+++ b/mounting.go
@@ -1,0 +1,74 @@
+package tue
+
+import "fmt"
+
+// Mounted is a live component mounted into a runtime target.
+type Mounted struct {
+	component *Comp
+	target    mountTarget
+
+	unmounted bool
+}
+
+type mountTarget interface {
+	render(VNode) error
+	clear() error
+}
+
+func validateMount(target string, component *Comp) error {
+	if target == "" {
+		return fmt.Errorf("mount target is required")
+	}
+	if component == nil {
+		return fmt.Errorf("component is required")
+	}
+	return nil
+}
+
+func mountComponent(component *Comp, target mountTarget) (*Mounted, error) {
+	if component == nil {
+		return nil, fmt.Errorf("component is required")
+	}
+	if target == nil {
+		return nil, fmt.Errorf("mount target is required")
+	}
+	if err := target.render(component.renderVNode()); err != nil {
+		return nil, fmt.Errorf("render mount target: %w", err)
+	}
+	component.mounted()
+	return &Mounted{component: component, target: target}, nil
+}
+
+// Update renders the component again and then calls optional OnUpdated.
+func (m *Mounted) Update() error {
+	if m == nil {
+		return fmt.Errorf("mounted component is required")
+	}
+	if m.unmounted {
+		return fmt.Errorf("mounted component is unmounted")
+	}
+	if err := m.target.render(m.component.renderVNode()); err != nil {
+		return fmt.Errorf("render mount target: %w", err)
+	}
+	m.component.updated()
+	return nil
+}
+
+// Unmount calls cleanup functions, clears the target, and calls optional OnUnmounted.
+func (m *Mounted) Unmount() error {
+	if m == nil {
+		return fmt.Errorf("mounted component is required")
+	}
+	if m.unmounted {
+		return nil
+	}
+	m.unmounted = true
+
+	m.component.runCleanups()
+	err := m.target.clear()
+	m.component.unmounted()
+	if err != nil {
+		return fmt.Errorf("clear mount target: %w", err)
+	}
+	return nil
+}

--- a/runtime.go
+++ b/runtime.go
@@ -7,9 +7,21 @@ import (
 )
 
 // Context is passed to optional component Init methods.
-type Context interface{}
+type Context interface {
+	OnCleanup(func())
+}
 
-type contextValue struct{}
+type contextValue struct {
+	component *Comp
+}
+
+// OnCleanup registers a function to run before OnUnmounted.
+func (c *contextValue) OnCleanup(cleanup func()) {
+	if c == nil || c.component == nil {
+		return
+	}
+	c.component.addCleanup(cleanup)
+}
 
 // Prop is the read interface exposed to component code.
 type Prop[T any] interface {
@@ -162,27 +174,94 @@ func Fragment(children []VNode) VNode {
 type Comp struct {
 	Component any
 	Render    func() VNode
+
+	cleanups []func()
 }
 
 type initComponent interface {
 	Init(Context)
 }
 
+type mountedComponent interface {
+	OnMounted()
+}
+
+type updatedComponent interface {
+	OnUpdated()
+}
+
+type unmountedComponent interface {
+	OnUnmounted()
+}
+
 // CompOf returns a component wrapper for generated code.
 func CompOf[C any](component *C, render func(*C) VNode) *Comp {
-	if initializable, ok := any(component).(initComponent); ok {
-		initializable.Init(contextValue{})
-	}
-	return &Comp{
-		Component: component,
-		Render: func() VNode {
+	comp := &Comp{Component: component}
+	if render != nil {
+		comp.Render = func() VNode {
 			return render(component)
-		},
+		}
+	}
+	if initializable, ok := any(component).(initComponent); ok {
+		initializable.Init(&contextValue{component: comp})
+	}
+	return comp
+}
+
+func (c *Comp) renderVNode() VNode {
+	if c == nil || c.Render == nil {
+		return Fragment(nil)
+	}
+	return c.Render()
+}
+
+func (c *Comp) addCleanup(cleanup func()) {
+	if c == nil || cleanup == nil {
+		return
+	}
+	c.cleanups = append(c.cleanups, cleanup)
+}
+
+func (c *Comp) runCleanups() {
+	if c == nil {
+		return
+	}
+	cleanups := c.cleanups
+	c.cleanups = nil
+	for _, cleanup := range cleanups {
+		cleanup()
+	}
+}
+
+func (c *Comp) mounted() {
+	if c == nil {
+		return
+	}
+	if component, ok := c.Component.(mountedComponent); ok {
+		component.OnMounted()
+	}
+}
+
+func (c *Comp) updated() {
+	if c == nil {
+		return
+	}
+	if component, ok := c.Component.(updatedComponent); ok {
+		component.OnUpdated()
+	}
+}
+
+func (c *Comp) unmounted() {
+	if c == nil {
+		return
+	}
+	if component, ok := c.Component.(unmountedComponent); ok {
+		component.OnUnmounted()
 	}
 }
 
 // Mount renders a component into a browser target under js/wasm.
-func Mount(target string, component *Comp) error {
+func Mount(target string, component *Comp) (*Mounted, error) {
 	return mount(target, component)
 }
 

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -1,6 +1,7 @@
 package tue
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -34,10 +35,158 @@ func TestCompOfCallsOptionalInit(t *testing.T) {
 	}
 }
 
+func TestMountComponentRunsLifecycleInOrder(t *testing.T) {
+	events := []string{}
+	component := &lifecycleFixture{events: &events, value: "first"}
+	comp := CompOf(component, func(fixture *lifecycleFixture) VNode {
+		*fixture.events = append(*fixture.events, "render:"+fixture.value)
+		return Text(fixture.value)
+	})
+	target := &recordingMountTarget{}
+
+	mounted, err := mountComponent(comp, target)
+	if err != nil {
+		t.Fatalf("mountComponent returned error: %v", err)
+	}
+	if diff := cmp.Diff([]string{"first"}, target.rendered); diff != "" {
+		t.Errorf("mismatch mounted target renders (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff([]string{"init", "render:first", "mounted"}, events); diff != "" {
+		t.Errorf("mismatch lifecycle after mount (-expected, +actual):\n%s", diff)
+	}
+
+	component.value = "second"
+	if err := mounted.Update(); err != nil {
+		t.Fatalf("Update returned error: %v", err)
+	}
+	if diff := cmp.Diff([]string{"first", "second"}, target.rendered); diff != "" {
+		t.Errorf("mismatch mounted target renders after update (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff([]string{"init", "render:first", "mounted", "render:second", "updated"}, events); diff != "" {
+		t.Errorf("mismatch lifecycle after update (-expected, +actual):\n%s", diff)
+	}
+
+	if err := mounted.Unmount(); err != nil {
+		t.Fatalf("Unmount returned error: %v", err)
+	}
+	if diff := cmp.Diff(1, target.cleared); diff != "" {
+		t.Errorf("mismatch target clear count (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff([]string{"init", "render:first", "mounted", "render:second", "updated", "cleanup", "unmounted"}, events); diff != "" {
+		t.Errorf("mismatch lifecycle after unmount (-expected, +actual):\n%s", diff)
+	}
+
+	if err := mounted.Unmount(); err != nil {
+		t.Errorf("second Unmount returned error: %v", err)
+	}
+	if diff := cmp.Diff(1, target.cleared); diff != "" {
+		t.Errorf("mismatch target clear count after second unmount (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff([]string{"init", "render:first", "mounted", "render:second", "updated", "cleanup", "unmounted"}, events); diff != "" {
+		t.Errorf("mismatch lifecycle after second unmount (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestMountedUpdateRejectsUnmountedComponent(t *testing.T) {
+	mounted, err := mountComponent(CompOf(&initFixture{}, func(*initFixture) VNode {
+		return Text("value")
+	}), &recordingMountTarget{})
+	if err != nil {
+		t.Fatalf("mountComponent returned error: %v", err)
+	}
+	if err := mounted.Unmount(); err != nil {
+		t.Fatalf("Unmount returned error: %v", err)
+	}
+
+	err = mounted.Update()
+
+	if err == nil || err.Error() != "mounted component is unmounted" {
+		t.Errorf("mismatch update error (-expected, +actual):\n%s", cmp.Diff("mounted component is unmounted", errorString(err)))
+	}
+}
+
+func TestMountValidatesInputBeforePlatformBoundary(t *testing.T) {
+	component := CompOf(&initFixture{}, func(*initFixture) VNode {
+		return Text("value")
+	})
+	tests := []struct {
+		name      string
+		target    string
+		component *Comp
+		expected  string
+	}{
+		{
+			name:      "missing target",
+			component: component,
+			expected:  "mount target is required",
+		},
+		{
+			name:     "missing component",
+			target:   "#app",
+			expected: "component is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Mount(tt.target, tt.component)
+			if err == nil || err.Error() != tt.expected {
+				t.Errorf("mismatch Mount error (-expected, +actual):\n%s", cmp.Diff(tt.expected, errorString(err)))
+			}
+		})
+	}
+}
+
 type initFixture struct {
 	value string
 }
 
 func (f *initFixture) Init(Context) {
 	f.value = "initialized"
+}
+
+type lifecycleFixture struct {
+	events *[]string
+	value  string
+}
+
+func (f *lifecycleFixture) Init(ctx Context) {
+	*f.events = append(*f.events, "init")
+	ctx.OnCleanup(func() {
+		*f.events = append(*f.events, "cleanup")
+	})
+}
+
+func (f *lifecycleFixture) OnMounted() {
+	*f.events = append(*f.events, "mounted")
+}
+
+func (f *lifecycleFixture) OnUpdated() {
+	*f.events = append(*f.events, "updated")
+}
+
+func (f *lifecycleFixture) OnUnmounted() {
+	*f.events = append(*f.events, "unmounted")
+}
+
+type recordingMountTarget struct {
+	rendered []string
+	cleared  int
+}
+
+func (t *recordingMountTarget) render(node VNode) error {
+	t.rendered = append(t.rendered, RenderHTML(node))
+	return nil
+}
+
+func (t *recordingMountTarget) clear() error {
+	t.cleared++
+	return nil
+}
+
+func errorString(err error) string {
+	if err == nil {
+		return "<nil>"
+	}
+	return fmt.Sprint(err)
 }


### PR DESCRIPTION
## Summary

- Added a mounted component handle with `Update` and `Unmount` lifecycle boundaries.
- Made `Mount` return `(*Mounted, error)` and routed js/wasm mounting through the shared mount target path.
- Added component cleanup registration through `Context.OnCleanup` and optional `OnMounted`, `OnUpdated`, and `OnUnmounted` method hooks.
- Covered lifecycle ordering, non-js mount behavior, validation, update-after-unmount, and cleanup idempotency with runtime tests.

## Validation

- `go fmt ./...`
- `go test ./...`
- `git diff --check`
- js/wasm compile-only: `GOOS=js GOARCH=wasm go test -c` for every package
- static fixture smoke build into a temporary module plus js/wasm compile of generated `.tue-cache`
- `tokensave sync`