### PR TITLE
Implemented the reactivity core.

### DIFF
--- a/reactivity.go
+++ b/reactivity.go
@@ -1,0 +1,406 @@
+package tue
+
+// Prop is the read interface exposed to component code.
+type Prop[T any] interface {
+	Get() T
+	Watch(func(T)) func()
+}
+
+// PropValue is the concrete runtime storage for a prop.
+type PropValue[T any] struct {
+	get func() T
+	dep dependency
+}
+
+// PropOf returns a prop with a fixed value.
+func PropOf[T any](value T) *PropValue[T] {
+	return PropOfFunc(func() T {
+		return value
+	})
+}
+
+// PropOfFunc returns a prop backed by a getter function.
+func PropOfFunc[T any](get func() T) *PropValue[T] {
+	return &PropValue[T]{get: get}
+}
+
+// Get returns the current prop value.
+func (p *PropValue[T]) Get() T {
+	if p == nil || p.get == nil {
+		var zero T
+		return zero
+	}
+	p.dep.track()
+	return p.get()
+}
+
+// Watch observes prop changes and returns a stop function.
+func (p *PropValue[T]) Watch(effect func(T)) func() {
+	if effect == nil {
+		return func() {}
+	}
+	return Watch(func() {
+		effect(p.Get())
+	})
+}
+
+// Ref is the read/write interface exposed to component code.
+type Ref[T any] interface {
+	Get() T
+	Set(T)
+	Watch(func(T)) func()
+}
+
+// RefValue is the concrete runtime storage for a ref.
+type RefValue[T any] struct {
+	value T
+	dep   dependency
+}
+
+// RefOf returns a ref with an initial value.
+func RefOf[T any](value T) *RefValue[T] {
+	return &RefValue[T]{value: value}
+}
+
+// Get returns the current ref value.
+func (r *RefValue[T]) Get() T {
+	if r == nil {
+		var zero T
+		return zero
+	}
+	r.dep.track()
+	return r.value
+}
+
+// Set updates the ref value and invalidates dependents.
+func (r *RefValue[T]) Set(value T) {
+	if r == nil {
+		return
+	}
+	r.value = value
+	r.dep.notify()
+}
+
+// Watch observes ref changes and returns a stop function.
+func (r *RefValue[T]) Watch(effect func(T)) func() {
+	if effect == nil {
+		return func() {}
+	}
+	return Watch(func() {
+		effect(r.Get())
+	})
+}
+
+// Computed is the read interface exposed to component code.
+type Computed[T any] interface {
+	Get() T
+	Watch(func(T)) func()
+}
+
+// ComputedValue is the concrete runtime storage for a computed value.
+type ComputedValue[T any] struct {
+	compute func() T
+	value   T
+	dirty   bool
+	dep     dependency
+	deps    map[*dependency]struct{}
+}
+
+// ComputedOfFunc returns a lazy, cached computed value backed by a function.
+func ComputedOfFunc[T any](compute func() T) *ComputedValue[T] {
+	computed := &ComputedValue[T]{
+		compute: compute,
+		dirty:   true,
+		deps:    make(map[*dependency]struct{}),
+	}
+	registerEffectCleanup(computed.dispose)
+	return computed
+}
+
+// Get returns the current computed value, recomputing only when dirty.
+func (c *ComputedValue[T]) Get() T {
+	if c == nil || c.compute == nil {
+		var zero T
+		return zero
+	}
+	c.dep.track()
+	if c.dirty {
+		c.dispose()
+		pushSubscriber(c)
+		defer popSubscriber()
+
+		c.value = c.compute()
+		c.dirty = false
+	}
+	return c.value
+}
+
+// Watch observes computed changes and returns a stop function.
+func (c *ComputedValue[T]) Watch(effect func(T)) func() {
+	if effect == nil {
+		return func() {}
+	}
+	return Watch(func() {
+		effect(c.Get())
+	})
+}
+
+func (c *ComputedValue[T]) addDependency(dep *dependency) {
+	if c == nil || dep == nil {
+		return
+	}
+	if c.deps == nil {
+		c.deps = make(map[*dependency]struct{})
+	}
+	if _, ok := c.deps[dep]; ok {
+		return
+	}
+	c.deps[dep] = struct{}{}
+	dep.addSubscriber(c)
+}
+
+func (c *ComputedValue[T]) invalidate() {
+	if c == nil || c.dirty {
+		return
+	}
+	c.dirty = true
+	c.dep.notify()
+}
+
+func (c *ComputedValue[T]) dispose() {
+	if c == nil {
+		return
+	}
+	for dep := range c.deps {
+		dep.removeSubscriber(c)
+		delete(c.deps, dep)
+	}
+}
+
+// Batch deduplicates watcher reruns until the outermost batch returns.
+func Batch(fn func()) {
+	if fn == nil {
+		return
+	}
+	scheduler.batchDepth++
+	defer func() {
+		scheduler.batchDepth--
+		if scheduler.batchDepth == 0 {
+			flushWatchers()
+		}
+	}()
+	fn()
+}
+
+// Watch runs effect immediately, tracks reactive reads, and returns a stop function.
+func Watch(effect func()) func() {
+	if effect == nil {
+		return func() {}
+	}
+
+	watcher := &watcher{
+		effect: effect,
+		deps:   make(map[*dependency]struct{}),
+	}
+	registerEffectCleanup(watcher.stop)
+	watcher.run()
+	return watcher.stop
+}
+
+type reactiveSubscriber interface {
+	addDependency(*dependency)
+	invalidate()
+}
+
+type dependency struct {
+	subscribers map[reactiveSubscriber]struct{}
+}
+
+func (d *dependency) track() {
+	subscriber := currentSubscriber()
+	if d == nil || subscriber == nil {
+		return
+	}
+	subscriber.addDependency(d)
+}
+
+func (d *dependency) addSubscriber(subscriber reactiveSubscriber) {
+	if d == nil || subscriber == nil {
+		return
+	}
+	if d.subscribers == nil {
+		d.subscribers = make(map[reactiveSubscriber]struct{})
+	}
+	d.subscribers[subscriber] = struct{}{}
+}
+
+func (d *dependency) removeSubscriber(subscriber reactiveSubscriber) {
+	if d == nil || d.subscribers == nil || subscriber == nil {
+		return
+	}
+	delete(d.subscribers, subscriber)
+}
+
+func (d *dependency) notify() {
+	if d == nil || len(d.subscribers) == 0 {
+		return
+	}
+	subscribers := make([]reactiveSubscriber, 0, len(d.subscribers))
+	for subscriber := range d.subscribers {
+		subscribers = append(subscribers, subscriber)
+	}
+	for _, subscriber := range subscribers {
+		subscriber.invalidate()
+	}
+}
+
+type watcher struct {
+	effect  func()
+	deps    map[*dependency]struct{}
+	stopped bool
+	queued  bool
+}
+
+func (w *watcher) run() {
+	if w == nil || w.stopped {
+		return
+	}
+	w.dispose()
+	pushSubscriber(w)
+	defer popSubscriber()
+	w.effect()
+}
+
+func (w *watcher) addDependency(dep *dependency) {
+	if w == nil || dep == nil {
+		return
+	}
+	if w.deps == nil {
+		w.deps = make(map[*dependency]struct{})
+	}
+	if _, ok := w.deps[dep]; ok {
+		return
+	}
+	w.deps[dep] = struct{}{}
+	dep.addSubscriber(w)
+}
+
+func (w *watcher) invalidate() {
+	if w == nil || w.stopped {
+		return
+	}
+	queueWatcher(w)
+}
+
+func (w *watcher) stop() {
+	if w == nil || w.stopped {
+		return
+	}
+	w.stopped = true
+	w.dispose()
+	removeQueuedWatcher(w)
+}
+
+func (w *watcher) dispose() {
+	if w == nil {
+		return
+	}
+	for dep := range w.deps {
+		dep.removeSubscriber(w)
+		delete(w.deps, dep)
+	}
+}
+
+var subscriberStack []reactiveSubscriber
+
+func pushSubscriber(subscriber reactiveSubscriber) {
+	subscriberStack = append(subscriberStack, subscriber)
+}
+
+func popSubscriber() {
+	if len(subscriberStack) == 0 {
+		return
+	}
+	subscriberStack = subscriberStack[:len(subscriberStack)-1]
+}
+
+func currentSubscriber() reactiveSubscriber {
+	if len(subscriberStack) == 0 {
+		return nil
+	}
+	return subscriberStack[len(subscriberStack)-1]
+}
+
+type schedulerState struct {
+	batchDepth int
+	flushing   bool
+	pending    []*watcher
+}
+
+var scheduler schedulerState
+
+func queueWatcher(w *watcher) {
+	if w == nil || w.stopped || w.queued {
+		return
+	}
+	w.queued = true
+	scheduler.pending = append(scheduler.pending, w)
+	if scheduler.batchDepth == 0 {
+		flushWatchers()
+	}
+}
+
+func removeQueuedWatcher(w *watcher) {
+	if w == nil || !w.queued {
+		return
+	}
+	for i, pending := range scheduler.pending {
+		if pending == w {
+			scheduler.pending = append(scheduler.pending[:i], scheduler.pending[i+1:]...)
+			break
+		}
+	}
+	w.queued = false
+}
+
+func flushWatchers() {
+	if scheduler.flushing {
+		return
+	}
+	scheduler.flushing = true
+	defer func() {
+		scheduler.flushing = false
+	}()
+
+	for len(scheduler.pending) > 0 {
+		pending := scheduler.pending
+		scheduler.pending = nil
+		for _, watcher := range pending {
+			watcher.queued = false
+			watcher.run()
+		}
+	}
+}
+
+var componentScopeStack []*Comp
+
+func withComponentScope(component *Comp, fn func()) {
+	componentScopeStack = append(componentScopeStack, component)
+	defer func() {
+		componentScopeStack = componentScopeStack[:len(componentScopeStack)-1]
+	}()
+	fn()
+}
+
+func currentComponentScope() *Comp {
+	if len(componentScopeStack) == 0 {
+		return nil
+	}
+	return componentScopeStack[len(componentScopeStack)-1]
+}
+
+func registerEffectCleanup(cleanup func()) {
+	if component := currentComponentScope(); component != nil {
+		component.addEffectCleanup(cleanup)
+	}
+}

--- a/reactivity_test.go
+++ b/reactivity_test.go
@@ -1,0 +1,201 @@
+package tue
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRefWatchRunsImmediatelyAndStops(t *testing.T) {
+	count := RefOf(0)
+	values := []int{}
+
+	stop := count.Watch(func(value int) {
+		values = append(values, value)
+	})
+	if diff := cmp.Diff([]int{0}, values); diff != "" {
+		t.Errorf("mismatch ref watch initial values (-expected, +actual):\n%s", diff)
+	}
+
+	count.Set(1)
+	if diff := cmp.Diff([]int{0, 1}, values); diff != "" {
+		t.Errorf("mismatch ref watch values after set (-expected, +actual):\n%s", diff)
+	}
+
+	stop()
+	count.Set(2)
+	if diff := cmp.Diff([]int{0, 1}, values); diff != "" {
+		t.Errorf("mismatch ref watch values after stop (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestWatchTracksOnlyCurrentDependencies(t *testing.T) {
+	enabled := RefOf(true)
+	first := RefOf("first")
+	second := RefOf("second")
+	values := []string{}
+
+	Watch(func() {
+		if enabled.Get() {
+			values = append(values, first.Get())
+			return
+		}
+		values = append(values, second.Get())
+	})
+
+	first.Set("first updated")
+	second.Set("second before switch")
+	enabled.Set(false)
+	first.Set("first after switch")
+	second.Set("second after switch")
+
+	if diff := cmp.Diff([]string{
+		"first",
+		"first updated",
+		"second before switch",
+		"second after switch",
+	}, values); diff != "" {
+		t.Errorf("mismatch dynamic watch dependency values (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestBatchDeduplicatesNestedWatcherFlushes(t *testing.T) {
+	count := RefOf(0)
+	values := []int{}
+	Watch(func() {
+		values = append(values, count.Get())
+	})
+
+	Batch(func() {
+		count.Set(1)
+		count.Set(2)
+		Batch(func() {
+			count.Set(3)
+		})
+		if diff := cmp.Diff([]int{0}, values); diff != "" {
+			t.Errorf("mismatch batched values before flush (-expected, +actual):\n%s", diff)
+		}
+	})
+
+	if diff := cmp.Diff([]int{0, 3}, values); diff != "" {
+		t.Errorf("mismatch batched values after flush (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestComputedIsLazyCachedAndInvalidated(t *testing.T) {
+	count := RefOf(1)
+	computeCount := 0
+	double := ComputedOfFunc(func() int {
+		computeCount++
+		return count.Get() * 2
+	})
+
+	if diff := cmp.Diff(0, computeCount); diff != "" {
+		t.Errorf("mismatch compute count before read (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff(2, double.Get()); diff != "" {
+		t.Errorf("mismatch first computed value (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff(1, computeCount); diff != "" {
+		t.Errorf("mismatch compute count after first read (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff(2, double.Get()); diff != "" {
+		t.Errorf("mismatch cached computed value (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff(1, computeCount); diff != "" {
+		t.Errorf("mismatch compute count after cached read (-expected, +actual):\n%s", diff)
+	}
+
+	count.Set(2)
+	if diff := cmp.Diff(1, computeCount); diff != "" {
+		t.Errorf("mismatch compute count after invalidation before read (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff(4, double.Get()); diff != "" {
+		t.Errorf("mismatch recomputed value (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff(2, computeCount); diff != "" {
+		t.Errorf("mismatch compute count after recompute (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestComputedInvalidatesWatchers(t *testing.T) {
+	count := RefOf(1)
+	computeCount := 0
+	double := ComputedOfFunc(func() int {
+		computeCount++
+		return count.Get() * 2
+	})
+	values := []int{}
+
+	Watch(func() {
+		values = append(values, double.Get())
+	})
+	count.Set(2)
+
+	if diff := cmp.Diff([]int{2, 4}, values); diff != "" {
+		t.Errorf("mismatch computed watcher values (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff(2, computeCount); diff != "" {
+		t.Errorf("mismatch compute count for watcher (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestPropWatchTracksReactiveGetter(t *testing.T) {
+	name := RefOf("Ada")
+	prop := PropOfFunc(func() string {
+		return name.Get()
+	})
+	values := []string{}
+
+	stop := prop.Watch(func(value string) {
+		values = append(values, value)
+	})
+	name.Set("Lin")
+	stop()
+	name.Set("Grace")
+
+	if diff := cmp.Diff([]string{"Ada", "Lin"}, values); diff != "" {
+		t.Errorf("mismatch prop watch values (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestComponentScopedEffectsStopBeforeUserCleanup(t *testing.T) {
+	events := []string{}
+	component := &reactiveCleanupFixture{events: &events}
+	comp := CompOf(component, func(*reactiveCleanupFixture) VNode {
+		return Text("cleanup")
+	})
+
+	mounted, err := mountComponent(comp, &recordingMountTarget{})
+	if err != nil {
+		t.Fatalf("mountComponent returned error: %v", err)
+	}
+	if err := mounted.Unmount(); err != nil {
+		t.Fatalf("Unmount returned error: %v", err)
+	}
+
+	if diff := cmp.Diff([]string{"watch:0", "cleanup", "unmounted"}, events); diff != "" {
+		t.Errorf("mismatch scoped cleanup events (-expected, +actual):\n%s", diff)
+	}
+}
+
+type reactiveCleanupFixture struct {
+	count  *RefValue[int]
+	events *[]string
+}
+
+func (f *reactiveCleanupFixture) Init(ctx Context) {
+	f.count = RefOf(0)
+	ctx.OnCleanup(func() {
+		*f.events = append(*f.events, "cleanup")
+		f.count.Set(1)
+	})
+	Watch(func() {
+		*f.events = append(*f.events, fmt.Sprintf("watch:%d", f.count.Get()))
+	})
+}
+
+func (f *reactiveCleanupFixture) OnUnmounted() {
+	*f.events = append(*f.events, "unmounted")
+}

--- a/runtime.go
+++ b/runtime.go
@@ -23,112 +23,6 @@ func (c *contextValue) OnCleanup(cleanup func()) {
 	c.component.addCleanup(cleanup)
 }
 
-// Prop is the read interface exposed to component code.
-type Prop[T any] interface {
-	Get() T
-	Watch(func(T)) func()
-}
-
-// PropValue is the concrete runtime storage for a prop.
-type PropValue[T any] struct {
-	get func() T
-}
-
-// PropOf returns a prop with a fixed value.
-func PropOf[T any](value T) *PropValue[T] {
-	return PropOfFunc(func() T {
-		return value
-	})
-}
-
-// PropOfFunc returns a prop backed by a getter function.
-func PropOfFunc[T any](get func() T) *PropValue[T] {
-	return &PropValue[T]{get: get}
-}
-
-// Get returns the current prop value.
-func (p *PropValue[T]) Get() T {
-	if p == nil || p.get == nil {
-		var zero T
-		return zero
-	}
-	return p.get()
-}
-
-// Watch observes prop changes. Dependency tracking is added in a later slice.
-func (p *PropValue[T]) Watch(func(T)) func() {
-	return func() {}
-}
-
-// Ref is the read/write interface exposed to component code.
-type Ref[T any] interface {
-	Get() T
-	Set(T)
-	Watch(func(T)) func()
-}
-
-// RefValue is the concrete runtime storage for a ref.
-type RefValue[T any] struct {
-	value T
-}
-
-// RefOf returns a ref with an initial value.
-func RefOf[T any](value T) *RefValue[T] {
-	return &RefValue[T]{value: value}
-}
-
-// Get returns the current ref value.
-func (r *RefValue[T]) Get() T {
-	if r == nil {
-		var zero T
-		return zero
-	}
-	return r.value
-}
-
-// Set updates the ref value.
-func (r *RefValue[T]) Set(value T) {
-	if r == nil {
-		return
-	}
-	r.value = value
-}
-
-// Watch observes ref changes. Dependency tracking is added in a later slice.
-func (r *RefValue[T]) Watch(func(T)) func() {
-	return func() {}
-}
-
-// Computed is the read interface exposed to component code.
-type Computed[T any] interface {
-	Get() T
-	Watch(func(T)) func()
-}
-
-// ComputedValue is the concrete runtime storage for a computed value.
-type ComputedValue[T any] struct {
-	compute func() T
-}
-
-// ComputedOfFunc returns a computed value backed by a function.
-func ComputedOfFunc[T any](compute func() T) *ComputedValue[T] {
-	return &ComputedValue[T]{compute: compute}
-}
-
-// Get returns the current computed value.
-func (c *ComputedValue[T]) Get() T {
-	if c == nil || c.compute == nil {
-		var zero T
-		return zero
-	}
-	return c.compute()
-}
-
-// Watch observes computed changes. Dependency tracking is added in a later slice.
-func (c *ComputedValue[T]) Watch(func(T)) func() {
-	return func() {}
-}
-
 // VNode is the generated render tree consumed by the runtime.
 type VNode struct {
 	Type     VNodeType
@@ -175,7 +69,8 @@ type Comp struct {
 	Component any
 	Render    func() VNode
 
-	cleanups []func()
+	effectCleanups []func()
+	cleanups       []func()
 }
 
 type initComponent interface {
@@ -203,7 +98,9 @@ func CompOf[C any](component *C, render func(*C) VNode) *Comp {
 		}
 	}
 	if initializable, ok := any(component).(initComponent); ok {
-		initializable.Init(&contextValue{component: comp})
+		withComponentScope(comp, func() {
+			initializable.Init(&contextValue{component: comp})
+		})
 	}
 	return comp
 }
@@ -222,10 +119,23 @@ func (c *Comp) addCleanup(cleanup func()) {
 	c.cleanups = append(c.cleanups, cleanup)
 }
 
+func (c *Comp) addEffectCleanup(cleanup func()) {
+	if c == nil || cleanup == nil {
+		return
+	}
+	c.effectCleanups = append(c.effectCleanups, cleanup)
+}
+
 func (c *Comp) runCleanups() {
 	if c == nil {
 		return
 	}
+	effectCleanups := c.effectCleanups
+	c.effectCleanups = nil
+	for _, cleanup := range effectCleanups {
+		cleanup()
+	}
+
 	cleanups := c.cleanups
 	c.cleanups = nil
 	for _, cleanup := range cleanups {


### PR DESCRIPTION
## Summary
- Added the root reactivity core for refs, props, computed values, watchers, dependency tracking, and synchronous batching.
- Scoped watchers and computed subscriptions created during component `Init` to the component lifecycle, stopping them before user cleanup callbacks run on unmount.
- Added runtime tests for watch stop behavior, dynamic dependencies, nested batch deduplication, computed caching and invalidation, reactive prop getters, and component-scoped cleanup.

## Validation
- `go fmt ./...`
- `go test ./...`
- `go test -race ./...`
- `git diff --check`
- `GOOS=js GOARCH=wasm go test -c` for each package from `go list ./...`

No lint command was run because no golangci-lint/revive/staticcheck config was present.