### PR TITLE
Added the DOM patch boundary.

### DIFF
--- a/mount_js.go
+++ b/mount_js.go
@@ -24,12 +24,97 @@ type jsMountTarget struct {
 	element js.Value
 }
 
-func (t jsMountTarget) render(node VNode) error {
-	t.element.Set("innerHTML", RenderHTML(node))
+func (t jsMountTarget) root() domNode {
+	return t.element
+}
+
+func (t jsMountTarget) createElement(tag string) (domNode, error) {
+	return js.Global().Get("document").Call("createElement", tag), nil
+}
+
+func (t jsMountTarget) createText(text string) (domNode, error) {
+	return js.Global().Get("document").Call("createTextNode", text), nil
+}
+
+func (t jsMountTarget) createMarker(text string) (domNode, error) {
+	return js.Global().Get("document").Call("createComment", text), nil
+}
+
+func (t jsMountTarget) appendChild(parent domNode, child domNode) error {
+	parentValue, childValue, err := jsParentChild(parent, child)
+	if err != nil {
+		return err
+	}
+	parentValue.Call("appendChild", childValue)
+	return nil
+}
+
+func (t jsMountTarget) insertBefore(parent domNode, child domNode, before domNode) error {
+	parentValue, childValue, err := jsParentChild(parent, child)
+	if err != nil {
+		return err
+	}
+	beforeValue, ok := before.(js.Value)
+	if !ok {
+		return fmt.Errorf("expected js.Value before node, got %T", before)
+	}
+	parentValue.Call("insertBefore", childValue, beforeValue)
+	return nil
+}
+
+func (t jsMountTarget) removeChild(parent domNode, child domNode) error {
+	parentValue, childValue, err := jsParentChild(parent, child)
+	if err != nil {
+		return err
+	}
+	parentValue.Call("removeChild", childValue)
+	return nil
+}
+
+func (t jsMountTarget) setText(node domNode, text string) error {
+	nodeValue, ok := node.(js.Value)
+	if !ok {
+		return fmt.Errorf("expected js.Value text node, got %T", node)
+	}
+	nodeValue.Set("nodeValue", text)
+	return nil
+}
+
+func (t jsMountTarget) setAttr(node domNode, attr Attribute) error {
+	nodeValue, ok := node.(js.Value)
+	if !ok {
+		return fmt.Errorf("expected js.Value element node, got %T", node)
+	}
+	value := ""
+	if attr.HasValue {
+		value = attr.Value
+	}
+	nodeValue.Call("setAttribute", attr.Name, value)
+	return nil
+}
+
+func (t jsMountTarget) removeAttr(node domNode, name string) error {
+	nodeValue, ok := node.(js.Value)
+	if !ok {
+		return fmt.Errorf("expected js.Value element node, got %T", node)
+	}
+	nodeValue.Call("removeAttribute", name)
 	return nil
 }
 
 func (t jsMountTarget) clear() error {
-	t.element.Set("innerHTML", "")
+	t.element.Set("textContent", "")
 	return nil
+}
+
+func jsParentChild(parent domNode, child domNode) (js.Value, js.Value, error) {
+	parentValue, ok := parent.(js.Value)
+	if !ok {
+		return js.Value{}, js.Value{}, fmt.Errorf("expected js.Value parent node, got %T", parent)
+	}
+	childValue, ok := child.(js.Value)
+	if !ok {
+		return js.Value{}, js.Value{}, fmt.Errorf("expected js.Value child node, got %T", child)
+	}
+	return parentValue, childValue, nil
 }

--- a/mounting.go
+++ b/mounting.go
@@ -6,12 +6,15 @@ import "fmt"
 type Mounted struct {
 	component *Comp
 	target    mountTarget
+	tree      *mountedVNode
 
 	unmounted bool
 }
 
 type mountTarget interface {
-	render(VNode) error
+	domBoundary
+
+	root() domNode
 	clear() error
 }
 
@@ -32,11 +35,17 @@ func mountComponent(component *Comp, target mountTarget) (*Mounted, error) {
 	if target == nil {
 		return nil, fmt.Errorf("mount target is required")
 	}
-	if err := target.render(component.renderVNode()); err != nil {
+
+	node := component.renderVNode()
+	if err := target.clear(); err != nil {
+		return nil, fmt.Errorf("clear mount target: %w", err)
+	}
+	tree, err := mountVNode(target, target.root(), nil, node)
+	if err != nil {
 		return nil, fmt.Errorf("render mount target: %w", err)
 	}
 	component.mounted()
-	return &Mounted{component: component, target: target}, nil
+	return &Mounted{component: component, target: target, tree: tree}, nil
 }
 
 // Update renders the component again and then calls optional OnUpdated.
@@ -47,9 +56,11 @@ func (m *Mounted) Update() error {
 	if m.unmounted {
 		return fmt.Errorf("mounted component is unmounted")
 	}
-	if err := m.target.render(m.component.renderVNode()); err != nil {
-		return fmt.Errorf("render mount target: %w", err)
+	tree, err := patchVNode(m.target, m.target.root(), m.tree, m.component.renderVNode())
+	if err != nil {
+		return fmt.Errorf("patch mount target: %w", err)
 	}
+	m.tree = tree
 	m.component.updated()
 	return nil
 }

--- a/patch.go
+++ b/patch.go
@@ -1,0 +1,278 @@
+package tue
+
+import "fmt"
+
+type domNode any
+
+type domBoundary interface {
+	createElement(tag string) (domNode, error)
+	createText(text string) (domNode, error)
+	createMarker(text string) (domNode, error)
+	appendChild(parent domNode, child domNode) error
+	insertBefore(parent domNode, child domNode, before domNode) error
+	removeChild(parent domNode, child domNode) error
+	setText(node domNode, text string) error
+	setAttr(node domNode, attr Attribute) error
+	removeAttr(node domNode, name string) error
+}
+
+type mountedVNode struct {
+	vnode    VNode
+	nodes    []domNode
+	children []*mountedVNode
+}
+
+func mountVNode(dom domBoundary, parent domNode, before domNode, vnode VNode) (*mountedVNode, error) {
+	switch vnode.Type {
+	case VNodeTypeElement:
+		return mountElement(dom, parent, before, vnode)
+	case VNodeTypeText:
+		return mountText(dom, parent, before, vnode)
+	case VNodeTypeFragment:
+		return mountFragment(dom, parent, before, vnode)
+	default:
+		return mountText(dom, parent, before, VNode{Type: VNodeTypeText, Text: fmt.Sprint(vnode.Text)})
+	}
+}
+
+func mountElement(dom domBoundary, parent domNode, before domNode, vnode VNode) (*mountedVNode, error) {
+	node, err := dom.createElement(vnode.Tag)
+	if err != nil {
+		return nil, fmt.Errorf("create element %q: %w", vnode.Tag, err)
+	}
+	for _, attr := range vnode.Attrs {
+		if err := dom.setAttr(node, attr); err != nil {
+			return nil, fmt.Errorf("set attribute %q: %w", attr.Name, err)
+		}
+	}
+
+	children := make([]*mountedVNode, 0, len(vnode.Children))
+	for _, child := range vnode.Children {
+		mountedChild, err := mountVNode(dom, node, nil, child)
+		if err != nil {
+			return nil, err
+		}
+		children = append(children, mountedChild)
+	}
+
+	if err := insertNode(dom, parent, node, before); err != nil {
+		return nil, fmt.Errorf("insert element %q: %w", vnode.Tag, err)
+	}
+	return &mountedVNode{vnode: vnode, nodes: []domNode{node}, children: children}, nil
+}
+
+func mountText(dom domBoundary, parent domNode, before domNode, vnode VNode) (*mountedVNode, error) {
+	node, err := dom.createText(vnode.Text)
+	if err != nil {
+		return nil, fmt.Errorf("create text: %w", err)
+	}
+	if err := insertNode(dom, parent, node, before); err != nil {
+		return nil, fmt.Errorf("insert text: %w", err)
+	}
+	return &mountedVNode{vnode: vnode, nodes: []domNode{node}}, nil
+}
+
+func mountFragment(dom domBoundary, parent domNode, before domNode, vnode VNode) (*mountedVNode, error) {
+	start, err := dom.createMarker("tue-fragment-start")
+	if err != nil {
+		return nil, fmt.Errorf("create fragment start: %w", err)
+	}
+	end, err := dom.createMarker("tue-fragment-end")
+	if err != nil {
+		return nil, fmt.Errorf("create fragment end: %w", err)
+	}
+	if err := insertNode(dom, parent, start, before); err != nil {
+		return nil, fmt.Errorf("insert fragment start: %w", err)
+	}
+	if err := insertNode(dom, parent, end, before); err != nil {
+		return nil, fmt.Errorf("insert fragment end: %w", err)
+	}
+
+	children := make([]*mountedVNode, 0, len(vnode.Children))
+	for _, child := range vnode.Children {
+		mountedChild, err := mountVNode(dom, parent, end, child)
+		if err != nil {
+			return nil, err
+		}
+		children = append(children, mountedChild)
+	}
+
+	return &mountedVNode{
+		vnode:    vnode,
+		nodes:    fragmentNodes(start, children, end),
+		children: children,
+	}, nil
+}
+
+func patchVNode(dom domBoundary, parent domNode, old *mountedVNode, next VNode) (*mountedVNode, error) {
+	if old == nil {
+		return mountVNode(dom, parent, nil, next)
+	}
+	if !sameVNode(old.vnode, next) {
+		before := firstDOMNode(old)
+		mounted, err := mountVNode(dom, parent, before, next)
+		if err != nil {
+			return nil, err
+		}
+		if err := removeMountedVNode(dom, parent, old); err != nil {
+			return nil, err
+		}
+		return mounted, nil
+	}
+
+	switch next.Type {
+	case VNodeTypeElement:
+		return patchElement(dom, old, next)
+	case VNodeTypeText:
+		return patchText(dom, old, next)
+	case VNodeTypeFragment:
+		return patchFragment(dom, parent, old, next)
+	default:
+		return patchText(dom, old, VNode{Type: VNodeTypeText, Text: fmt.Sprint(next.Text)})
+	}
+}
+
+func patchElement(dom domBoundary, old *mountedVNode, next VNode) (*mountedVNode, error) {
+	node := firstDOMNode(old)
+	if err := patchAttrs(dom, node, old.vnode.Attrs, next.Attrs); err != nil {
+		return nil, err
+	}
+	children, err := patchChildren(dom, node, nil, old.children, next.Children)
+	if err != nil {
+		return nil, err
+	}
+	old.vnode = next
+	old.children = children
+	return old, nil
+}
+
+func patchText(dom domBoundary, old *mountedVNode, next VNode) (*mountedVNode, error) {
+	if old.vnode.Text != next.Text {
+		if err := dom.setText(firstDOMNode(old), next.Text); err != nil {
+			return nil, fmt.Errorf("set text: %w", err)
+		}
+	}
+	old.vnode = next
+	return old, nil
+}
+
+func patchFragment(dom domBoundary, parent domNode, old *mountedVNode, next VNode) (*mountedVNode, error) {
+	end := lastDOMNode(old)
+	children, err := patchChildren(dom, parent, end, old.children, next.Children)
+	if err != nil {
+		return nil, err
+	}
+	old.vnode = next
+	old.children = children
+	old.nodes = fragmentNodes(firstDOMNode(old), children, end)
+	return old, nil
+}
+
+func patchChildren(dom domBoundary, parent domNode, before domNode, old []*mountedVNode, next []VNode) ([]*mountedVNode, error) {
+	shared := len(old)
+	if len(next) < shared {
+		shared = len(next)
+	}
+
+	children := make([]*mountedVNode, 0, len(next))
+	for i := 0; i < shared; i++ {
+		child, err := patchVNode(dom, parent, old[i], next[i])
+		if err != nil {
+			return nil, err
+		}
+		children = append(children, child)
+	}
+	for i := shared; i < len(next); i++ {
+		child, err := mountVNode(dom, parent, before, next[i])
+		if err != nil {
+			return nil, err
+		}
+		children = append(children, child)
+	}
+	for i := shared; i < len(old); i++ {
+		if err := removeMountedVNode(dom, parent, old[i]); err != nil {
+			return nil, err
+		}
+	}
+	return children, nil
+}
+
+func patchAttrs(dom domBoundary, node domNode, old []Attribute, next []Attribute) error {
+	oldAttrs := attrsByName(old)
+	nextAttrs := attrsByName(next)
+
+	for name, nextAttr := range nextAttrs {
+		if oldAttr, ok := oldAttrs[name]; !ok || oldAttr != nextAttr {
+			if err := dom.setAttr(node, nextAttr); err != nil {
+				return fmt.Errorf("set attribute %q: %w", name, err)
+			}
+		}
+	}
+	for name := range oldAttrs {
+		if _, ok := nextAttrs[name]; !ok {
+			if err := dom.removeAttr(node, name); err != nil {
+				return fmt.Errorf("remove attribute %q: %w", name, err)
+			}
+		}
+	}
+	return nil
+}
+
+func attrsByName(attrs []Attribute) map[string]Attribute {
+	byName := make(map[string]Attribute, len(attrs))
+	for _, attr := range attrs {
+		byName[attr.Name] = attr
+	}
+	return byName
+}
+
+func sameVNode(old VNode, next VNode) bool {
+	if old.Type != next.Type || old.Key != next.Key {
+		return false
+	}
+	if old.Type == VNodeTypeElement {
+		return old.Tag == next.Tag
+	}
+	return true
+}
+
+func insertNode(dom domBoundary, parent domNode, child domNode, before domNode) error {
+	if before == nil {
+		return dom.appendChild(parent, child)
+	}
+	return dom.insertBefore(parent, child, before)
+}
+
+func removeMountedVNode(dom domBoundary, parent domNode, mounted *mountedVNode) error {
+	if mounted == nil {
+		return nil
+	}
+	for _, node := range mounted.nodes {
+		if err := dom.removeChild(parent, node); err != nil {
+			return fmt.Errorf("remove node: %w", err)
+		}
+	}
+	return nil
+}
+
+func firstDOMNode(mounted *mountedVNode) domNode {
+	if mounted == nil || len(mounted.nodes) == 0 {
+		return nil
+	}
+	return mounted.nodes[0]
+}
+
+func lastDOMNode(mounted *mountedVNode) domNode {
+	if mounted == nil || len(mounted.nodes) == 0 {
+		return nil
+	}
+	return mounted.nodes[len(mounted.nodes)-1]
+}
+
+func fragmentNodes(start domNode, children []*mountedVNode, end domNode) []domNode {
+	nodes := []domNode{start}
+	for _, child := range children {
+		nodes = append(nodes, child.nodes...)
+	}
+	return append(nodes, end)
+}

--- a/patch_test.go
+++ b/patch_test.go
@@ -1,0 +1,497 @@
+package tue
+
+import (
+	"fmt"
+	"html"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestMountedUpdatePatchesTextInPlace(t *testing.T) {
+	value := "first"
+	target := newFakeDOMTarget()
+	mounted, err := mountComponent(CompOf(&patchFixture{}, func(*patchFixture) VNode {
+		return Text(value)
+	}), target)
+	if err != nil {
+		t.Fatalf("mountComponent returned error: %v", err)
+	}
+
+	text := onlyVisibleChild(t, target.rootNode)
+	textID := text.id
+
+	value = "second"
+	if err := mounted.Update(); err != nil {
+		t.Fatalf("Update returned error: %v", err)
+	}
+
+	actual := onlyVisibleChild(t, target.rootNode)
+	if diff := cmp.Diff(fakeNodeSummary{ID: textID, Kind: "text", Text: "second"}, summarizeFakeNode(actual)); diff != "" {
+		t.Errorf("mismatch patched text node (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestMountedUpdatePatchesElementAttributesInPlace(t *testing.T) {
+	primary := true
+	target := newFakeDOMTarget()
+	mounted, err := mountComponent(CompOf(&patchFixture{}, func(*patchFixture) VNode {
+		if primary {
+			return Element("button", []Attribute{
+				Attr("class", "primary"),
+				BoolAttr("disabled"),
+			}, []VNode{Text("Save")})
+		}
+		return Element("button", []Attribute{
+			Attr("class", "secondary"),
+			Attr("title", "Ready"),
+		}, []VNode{Text("Save")})
+	}), target)
+	if err != nil {
+		t.Fatalf("mountComponent returned error: %v", err)
+	}
+
+	button := onlyVisibleChild(t, target.rootNode)
+	buttonID := button.id
+
+	primary = false
+	if err := mounted.Update(); err != nil {
+		t.Fatalf("Update returned error: %v", err)
+	}
+
+	actual := onlyVisibleChild(t, target.rootNode)
+	expected := fakeNodeSummary{
+		ID:   buttonID,
+		Kind: "element",
+		Tag:  "button",
+		Attrs: []Attribute{
+			Attr("class", "secondary"),
+			Attr("title", "Ready"),
+		},
+		Children: []fakeNodeSummary{{Kind: "text", Text: "Save"}},
+	}
+	if diff := cmp.Diff(expected, summarizeFakeNodeWithoutChildIDs(actual)); diff != "" {
+		t.Errorf("mismatch patched element attributes (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestMountedUpdateReplacesDifferentKey(t *testing.T) {
+	key := "first"
+	target := newFakeDOMTarget()
+	mounted, err := mountComponent(CompOf(&patchFixture{}, func(*patchFixture) VNode {
+		return VNode{Type: VNodeTypeElement, Key: key, Tag: "section"}
+	}), target)
+	if err != nil {
+		t.Fatalf("mountComponent returned error: %v", err)
+	}
+
+	first := onlyVisibleChild(t, target.rootNode)
+
+	key = "second"
+	if err := mounted.Update(); err != nil {
+		t.Fatalf("Update returned error: %v", err)
+	}
+
+	second := onlyVisibleChild(t, target.rootNode)
+	if second.id == first.id {
+		t.Errorf("mismatch replacement node id: expected a different node from %d", first.id)
+	}
+	if first.parent != nil {
+		t.Errorf("mismatch replaced node parent: expected nil, got %#v", first.parent)
+	}
+	if diff := cmp.Diff("<section></section>", target.html()); diff != "" {
+		t.Errorf("mismatch replaced keyed element HTML (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestMountedUpdatePatchesUnkeyedChildrenPositionally(t *testing.T) {
+	items := []string{"A", "B"}
+	target := newFakeDOMTarget()
+	mounted, err := mountComponent(CompOf(&patchFixture{}, func(*patchFixture) VNode {
+		children := make([]VNode, 0, len(items))
+		for _, item := range items {
+			children = append(children, Text(item))
+		}
+		return Element("p", nil, children)
+	}), target)
+	if err != nil {
+		t.Fatalf("mountComponent returned error: %v", err)
+	}
+
+	paragraph := onlyVisibleChild(t, target.rootNode)
+	first := paragraph.children[0]
+	second := paragraph.children[1]
+
+	items = []string{"A!", "C", "D"}
+	if err := mounted.Update(); err != nil {
+		t.Fatalf("Update returned error: %v", err)
+	}
+
+	if diff := cmp.Diff("<p>A!CD</p>", target.html()); diff != "" {
+		t.Errorf("mismatch patched children HTML (-expected, +actual):\n%s", diff)
+	}
+	children := paragraph.children
+	if diff := cmp.Diff([]fakeNodeSummary{
+		{ID: first.id, Kind: "text", Text: "A!"},
+		{ID: second.id, Kind: "text", Text: "C"},
+		{Kind: "text", Text: "D"},
+	}, summarizeFakeNodesWithoutNewIDs(children, map[int]bool{first.id: true, second.id: true})); diff != "" {
+		t.Errorf("mismatch patched positional children (-expected, +actual):\n%s", diff)
+	}
+
+	appended := children[2]
+	items = []string{"Z"}
+	if err := mounted.Update(); err != nil {
+		t.Fatalf("second Update returned error: %v", err)
+	}
+
+	if diff := cmp.Diff("<p>Z</p>", target.html()); diff != "" {
+		t.Errorf("mismatch trimmed children HTML (-expected, +actual):\n%s", diff)
+	}
+	if second.parent != nil {
+		t.Errorf("mismatch removed second child parent: expected nil, got %#v", second.parent)
+	}
+	if appended.parent != nil {
+		t.Errorf("mismatch removed appended child parent: expected nil, got %#v", appended.parent)
+	}
+	if diff := cmp.Diff(fakeNodeSummary{ID: first.id, Kind: "text", Text: "Z"}, summarizeFakeNode(paragraph.children[0])); diff != "" {
+		t.Errorf("mismatch retained first child after trim (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestMountedUpdatePatchesFragmentChildrenBeforeEndMarker(t *testing.T) {
+	values := []string{"one"}
+	target := newFakeDOMTarget()
+	mounted, err := mountComponent(CompOf(&patchFixture{}, func(*patchFixture) VNode {
+		children := make([]VNode, 0, len(values))
+		for _, value := range values {
+			children = append(children, Text(value))
+		}
+		return Fragment(children)
+	}), target)
+	if err != nil {
+		t.Fatalf("mountComponent returned error: %v", err)
+	}
+	if diff := cmp.Diff([]string{"comment", "text", "comment"}, childKinds(target.rootNode)); diff != "" {
+		t.Errorf("mismatch mounted fragment child kinds (-expected, +actual):\n%s", diff)
+	}
+
+	values = []string{"ONE", "two"}
+	if err := mounted.Update(); err != nil {
+		t.Fatalf("Update returned error: %v", err)
+	}
+
+	if diff := cmp.Diff("ONEtwo", target.html()); diff != "" {
+		t.Errorf("mismatch patched fragment HTML (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff([]string{"comment", "text", "text", "comment"}, childKinds(target.rootNode)); diff != "" {
+		t.Errorf("mismatch patched fragment child kinds (-expected, +actual):\n%s", diff)
+	}
+}
+
+type patchFixture struct{}
+
+type fakeDOMTarget struct {
+	rootNode *fakeDOMNode
+	nextID   int
+	clears   int
+}
+
+func newFakeDOMTarget() *fakeDOMTarget {
+	target := &fakeDOMTarget{}
+	target.rootNode = target.newNode("root")
+	return target
+}
+
+func (t *fakeDOMTarget) root() domNode {
+	return t.rootNode
+}
+
+func (t *fakeDOMTarget) createElement(tag string) (domNode, error) {
+	node := t.newNode("element")
+	node.tag = tag
+	node.attrs = map[string]Attribute{}
+	return node, nil
+}
+
+func (t *fakeDOMTarget) createText(text string) (domNode, error) {
+	node := t.newNode("text")
+	node.text = text
+	return node, nil
+}
+
+func (t *fakeDOMTarget) createMarker(text string) (domNode, error) {
+	node := t.newNode("comment")
+	node.text = text
+	return node, nil
+}
+
+func (t *fakeDOMTarget) appendChild(parent domNode, child domNode) error {
+	parentNode, childNode, err := fakeParentChild(parent, child)
+	if err != nil {
+		return err
+	}
+	childNode.detach()
+	childNode.parent = parentNode
+	parentNode.children = append(parentNode.children, childNode)
+	return nil
+}
+
+func (t *fakeDOMTarget) insertBefore(parent domNode, child domNode, before domNode) error {
+	parentNode, childNode, err := fakeParentChild(parent, child)
+	if err != nil {
+		return err
+	}
+	beforeNode, ok := before.(*fakeDOMNode)
+	if !ok {
+		return fmt.Errorf("expected fake before node, got %T", before)
+	}
+	index := parentNode.childIndex(beforeNode)
+	if index == -1 {
+		return fmt.Errorf("before node %d is not a child of parent %d", beforeNode.id, parentNode.id)
+	}
+	childNode.detach()
+	childNode.parent = parentNode
+	parentNode.children = append(parentNode.children, nil)
+	copy(parentNode.children[index+1:], parentNode.children[index:])
+	parentNode.children[index] = childNode
+	return nil
+}
+
+func (t *fakeDOMTarget) removeChild(parent domNode, child domNode) error {
+	parentNode, childNode, err := fakeParentChild(parent, child)
+	if err != nil {
+		return err
+	}
+	index := parentNode.childIndex(childNode)
+	if index == -1 {
+		return fmt.Errorf("child node %d is not a child of parent %d", childNode.id, parentNode.id)
+	}
+	parentNode.children = append(parentNode.children[:index], parentNode.children[index+1:]...)
+	childNode.parent = nil
+	return nil
+}
+
+func (t *fakeDOMTarget) setText(node domNode, text string) error {
+	fakeNode, ok := node.(*fakeDOMNode)
+	if !ok {
+		return fmt.Errorf("expected fake text node, got %T", node)
+	}
+	fakeNode.text = text
+	return nil
+}
+
+func (t *fakeDOMTarget) setAttr(node domNode, attr Attribute) error {
+	fakeNode, ok := node.(*fakeDOMNode)
+	if !ok {
+		return fmt.Errorf("expected fake element node, got %T", node)
+	}
+	if fakeNode.attrs == nil {
+		fakeNode.attrs = map[string]Attribute{}
+	}
+	fakeNode.attrs[attr.Name] = attr
+	return nil
+}
+
+func (t *fakeDOMTarget) removeAttr(node domNode, name string) error {
+	fakeNode, ok := node.(*fakeDOMNode)
+	if !ok {
+		return fmt.Errorf("expected fake element node, got %T", node)
+	}
+	delete(fakeNode.attrs, name)
+	return nil
+}
+
+func (t *fakeDOMTarget) clear() error {
+	for _, child := range t.rootNode.children {
+		child.parent = nil
+	}
+	t.rootNode.children = nil
+	t.clears++
+	return nil
+}
+
+func (t *fakeDOMTarget) html() string {
+	var builder strings.Builder
+	for _, child := range t.rootNode.children {
+		writeFakeHTML(&builder, child)
+	}
+	return builder.String()
+}
+
+func (t *fakeDOMTarget) newNode(kind string) *fakeDOMNode {
+	t.nextID++
+	return &fakeDOMNode{id: t.nextID, kind: kind}
+}
+
+type fakeDOMNode struct {
+	id       int
+	kind     string
+	tag      string
+	text     string
+	attrs    map[string]Attribute
+	parent   *fakeDOMNode
+	children []*fakeDOMNode
+}
+
+func (n *fakeDOMNode) childIndex(child *fakeDOMNode) int {
+	for i, candidate := range n.children {
+		if candidate == child {
+			return i
+		}
+	}
+	return -1
+}
+
+func (n *fakeDOMNode) detach() {
+	if n.parent == nil {
+		return
+	}
+	index := n.parent.childIndex(n)
+	if index != -1 {
+		n.parent.children = append(n.parent.children[:index], n.parent.children[index+1:]...)
+	}
+	n.parent = nil
+}
+
+func fakeParentChild(parent domNode, child domNode) (*fakeDOMNode, *fakeDOMNode, error) {
+	parentNode, ok := parent.(*fakeDOMNode)
+	if !ok {
+		return nil, nil, fmt.Errorf("expected fake parent node, got %T", parent)
+	}
+	childNode, ok := child.(*fakeDOMNode)
+	if !ok {
+		return nil, nil, fmt.Errorf("expected fake child node, got %T", child)
+	}
+	return parentNode, childNode, nil
+}
+
+func writeFakeHTML(builder *strings.Builder, node *fakeDOMNode) {
+	switch node.kind {
+	case "element":
+		builder.WriteByte('<')
+		builder.WriteString(node.tag)
+		for _, attr := range sortedFakeAttrs(node.attrs) {
+			builder.WriteByte(' ')
+			builder.WriteString(attr.Name)
+			if attr.HasValue {
+				builder.WriteString(`="`)
+				builder.WriteString(html.EscapeString(attr.Value))
+				builder.WriteByte('"')
+			}
+		}
+		builder.WriteByte('>')
+		for _, child := range node.children {
+			writeFakeHTML(builder, child)
+		}
+		builder.WriteString("</")
+		builder.WriteString(node.tag)
+		builder.WriteByte('>')
+	case "text":
+		builder.WriteString(html.EscapeString(node.text))
+	case "comment":
+		return
+	}
+}
+
+func sortedFakeAttrs(attrs map[string]Attribute) []Attribute {
+	if len(attrs) == 0 {
+		return nil
+	}
+	sorted := make([]Attribute, 0, len(attrs))
+	for _, attr := range attrs {
+		sorted = append(sorted, attr)
+	}
+	sort.Slice(sorted, func(i int, j int) bool {
+		return sorted[i].Name < sorted[j].Name
+	})
+	return sorted
+}
+
+func onlyVisibleChild(t *testing.T, node *fakeDOMNode) *fakeDOMNode {
+	t.Helper()
+
+	children := visibleChildren(node)
+	if len(children) != 1 {
+		t.Fatalf("visible children = %#v, want exactly one", summarizeFakeNodes(children))
+	}
+	return children[0]
+}
+
+func visibleChildren(node *fakeDOMNode) []*fakeDOMNode {
+	children := make([]*fakeDOMNode, 0, len(node.children))
+	for _, child := range node.children {
+		if child.kind != "comment" {
+			children = append(children, child)
+		}
+	}
+	return children
+}
+
+func childKinds(node *fakeDOMNode) []string {
+	kinds := make([]string, len(node.children))
+	for i, child := range node.children {
+		kinds[i] = child.kind
+	}
+	return kinds
+}
+
+type fakeNodeSummary struct {
+	ID       int
+	Kind     string
+	Tag      string
+	Text     string
+	Attrs    []Attribute
+	Children []fakeNodeSummary
+}
+
+func summarizeFakeNode(node *fakeDOMNode) fakeNodeSummary {
+	children := make([]fakeNodeSummary, 0, len(node.children))
+	for _, child := range node.children {
+		if child.kind == "comment" {
+			continue
+		}
+		children = append(children, summarizeFakeNode(child))
+	}
+	if len(children) == 0 {
+		children = nil
+	}
+	return fakeNodeSummary{
+		ID:       node.id,
+		Kind:     node.kind,
+		Tag:      node.tag,
+		Text:     node.text,
+		Attrs:    sortedFakeAttrs(node.attrs),
+		Children: children,
+	}
+}
+
+func summarizeFakeNodeWithoutChildIDs(node *fakeDOMNode) fakeNodeSummary {
+	summary := summarizeFakeNode(node)
+	for i := range summary.Children {
+		summary.Children[i].ID = 0
+	}
+	return summary
+}
+
+func summarizeFakeNodes(nodes []*fakeDOMNode) []fakeNodeSummary {
+	summaries := make([]fakeNodeSummary, len(nodes))
+	for i, node := range nodes {
+		summaries[i] = summarizeFakeNode(node)
+	}
+	return summaries
+}
+
+func summarizeFakeNodesWithoutNewIDs(nodes []*fakeDOMNode, keep map[int]bool) []fakeNodeSummary {
+	summaries := make([]fakeNodeSummary, len(nodes))
+	for i, node := range nodes {
+		summary := summarizeFakeNode(node)
+		if !keep[node.id] {
+			summary.ID = 0
+		}
+		summaries[i] = summary
+	}
+	return summaries
+}

--- a/reactivity_test.go
+++ b/reactivity_test.go
@@ -167,7 +167,7 @@ func TestComponentScopedEffectsStopBeforeUserCleanup(t *testing.T) {
 		return Text("cleanup")
 	})
 
-	mounted, err := mountComponent(comp, &recordingMountTarget{})
+	mounted, err := mountComponent(comp, newFakeDOMTarget())
 	if err != nil {
 		t.Fatalf("mountComponent returned error: %v", err)
 	}

--- a/runtime.go
+++ b/runtime.go
@@ -26,6 +26,7 @@ func (c *contextValue) OnCleanup(cleanup func()) {
 // VNode is the generated render tree consumed by the runtime.
 type VNode struct {
 	Type     VNodeType
+	Key      string
 	Tag      string
 	Attrs    []Attribute
 	Children []VNode

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -42,14 +42,14 @@ func TestMountComponentRunsLifecycleInOrder(t *testing.T) {
 		*fixture.events = append(*fixture.events, "render:"+fixture.value)
 		return Text(fixture.value)
 	})
-	target := &recordingMountTarget{}
+	target := newFakeDOMTarget()
 
 	mounted, err := mountComponent(comp, target)
 	if err != nil {
 		t.Fatalf("mountComponent returned error: %v", err)
 	}
-	if diff := cmp.Diff([]string{"first"}, target.rendered); diff != "" {
-		t.Errorf("mismatch mounted target renders (-expected, +actual):\n%s", diff)
+	if diff := cmp.Diff("first", target.html()); diff != "" {
+		t.Errorf("mismatch mounted target HTML (-expected, +actual):\n%s", diff)
 	}
 	if diff := cmp.Diff([]string{"init", "render:first", "mounted"}, events); diff != "" {
 		t.Errorf("mismatch lifecycle after mount (-expected, +actual):\n%s", diff)
@@ -59,8 +59,8 @@ func TestMountComponentRunsLifecycleInOrder(t *testing.T) {
 	if err := mounted.Update(); err != nil {
 		t.Fatalf("Update returned error: %v", err)
 	}
-	if diff := cmp.Diff([]string{"first", "second"}, target.rendered); diff != "" {
-		t.Errorf("mismatch mounted target renders after update (-expected, +actual):\n%s", diff)
+	if diff := cmp.Diff("second", target.html()); diff != "" {
+		t.Errorf("mismatch mounted target HTML after update (-expected, +actual):\n%s", diff)
 	}
 	if diff := cmp.Diff([]string{"init", "render:first", "mounted", "render:second", "updated"}, events); diff != "" {
 		t.Errorf("mismatch lifecycle after update (-expected, +actual):\n%s", diff)
@@ -69,8 +69,8 @@ func TestMountComponentRunsLifecycleInOrder(t *testing.T) {
 	if err := mounted.Unmount(); err != nil {
 		t.Fatalf("Unmount returned error: %v", err)
 	}
-	if diff := cmp.Diff(1, target.cleared); diff != "" {
-		t.Errorf("mismatch target clear count (-expected, +actual):\n%s", diff)
+	if diff := cmp.Diff("", target.html()); diff != "" {
+		t.Errorf("mismatch mounted target HTML after unmount (-expected, +actual):\n%s", diff)
 	}
 	if diff := cmp.Diff([]string{"init", "render:first", "mounted", "render:second", "updated", "cleanup", "unmounted"}, events); diff != "" {
 		t.Errorf("mismatch lifecycle after unmount (-expected, +actual):\n%s", diff)
@@ -79,8 +79,8 @@ func TestMountComponentRunsLifecycleInOrder(t *testing.T) {
 	if err := mounted.Unmount(); err != nil {
 		t.Errorf("second Unmount returned error: %v", err)
 	}
-	if diff := cmp.Diff(1, target.cleared); diff != "" {
-		t.Errorf("mismatch target clear count after second unmount (-expected, +actual):\n%s", diff)
+	if diff := cmp.Diff("", target.html()); diff != "" {
+		t.Errorf("mismatch mounted target HTML after second unmount (-expected, +actual):\n%s", diff)
 	}
 	if diff := cmp.Diff([]string{"init", "render:first", "mounted", "render:second", "updated", "cleanup", "unmounted"}, events); diff != "" {
 		t.Errorf("mismatch lifecycle after second unmount (-expected, +actual):\n%s", diff)
@@ -90,7 +90,7 @@ func TestMountComponentRunsLifecycleInOrder(t *testing.T) {
 func TestMountedUpdateRejectsUnmountedComponent(t *testing.T) {
 	mounted, err := mountComponent(CompOf(&initFixture{}, func(*initFixture) VNode {
 		return Text("value")
-	}), &recordingMountTarget{})
+	}), newFakeDOMTarget())
 	if err != nil {
 		t.Fatalf("mountComponent returned error: %v", err)
 	}
@@ -167,21 +167,6 @@ func (f *lifecycleFixture) OnUpdated() {
 
 func (f *lifecycleFixture) OnUnmounted() {
 	*f.events = append(*f.events, "unmounted")
-}
-
-type recordingMountTarget struct {
-	rendered []string
-	cleared  int
-}
-
-func (t *recordingMountTarget) render(node VNode) error {
-	t.rendered = append(t.rendered, RenderHTML(node))
-	return nil
-}
-
-func (t *recordingMountTarget) clear() error {
-	t.cleared++
-	return nil
 }
 
 func errorString(err error) string {


### PR DESCRIPTION
## Summary

- Replaced the render-only mount target with a common DOM patch boundary and stored mounted VNode state on `Mounted`.
- Added static VNode patching for text updates, element attribute add/update/remove, type/tag/key replacement, fragment markers, and positional unkeyed children.
- Updated the js/wasm mount target to use DOM node operations instead of rewriting `innerHTML`, while keeping `RenderHTML` as the static renderer.
- Added pure Go fake DOM coverage for the patch behavior and updated lifecycle tests to use the patch path.

## Validation

- `go fmt ./...`
- `go test ./...`
- `GOOS=js GOARCH=wasm go test -c` for every package from `go list ./...`
- `git diff --check`
- `tokensave sync`

No Go lint config was present, so no lint command was run.