### PR TITLE
Wired reactive component rerenders.

### DIFF
--- a/mounting.go
+++ b/mounting.go
@@ -4,11 +4,14 @@ import "fmt"
 
 // Mounted is a live component mounted into a runtime target.
 type Mounted struct {
-	component *Comp
-	target    mountTarget
-	tree      *mountedVNode
+	component    *Comp
+	target       mountTarget
+	tree         *mountedVNode
+	renderEffect *componentRenderEffect
 
+	mounted   bool
 	unmounted bool
+	renderErr error
 }
 
 type mountTarget interface {
@@ -36,16 +39,20 @@ func mountComponent(component *Comp, target mountTarget) (*Mounted, error) {
 		return nil, fmt.Errorf("mount target is required")
 	}
 
-	node := component.renderVNode()
 	if err := target.clear(); err != nil {
 		return nil, fmt.Errorf("clear mount target: %w", err)
 	}
-	tree, err := mountVNode(target, target.root(), nil, node)
-	if err != nil {
-		return nil, fmt.Errorf("render mount target: %w", err)
+
+	mounted := &Mounted{component: component, target: target}
+	mounted.renderEffect = newComponentRenderEffect(mounted)
+	mounted.renderEffect.run()
+	if mounted.renderErr != nil {
+		mounted.renderEffect.stop()
+		return nil, mounted.renderErr
 	}
+	mounted.mounted = true
 	component.mounted()
-	return &Mounted{component: component, target: target, tree: tree}, nil
+	return mounted, nil
 }
 
 // Update renders the component again and then calls optional OnUpdated.
@@ -56,13 +63,11 @@ func (m *Mounted) Update() error {
 	if m.unmounted {
 		return fmt.Errorf("mounted component is unmounted")
 	}
-	tree, err := patchVNode(m.target, m.target.root(), m.tree, m.component.renderVNode())
-	if err != nil {
-		return fmt.Errorf("patch mount target: %w", err)
+	if m.renderEffect == nil {
+		return fmt.Errorf("mounted render effect is required")
 	}
-	m.tree = tree
-	m.component.updated()
-	return nil
+	m.renderEffect.run()
+	return m.renderErr
 }
 
 // Unmount calls cleanup functions, clears the target, and calls optional OnUnmounted.
@@ -75,11 +80,121 @@ func (m *Mounted) Unmount() error {
 	}
 	m.unmounted = true
 
+	if m.renderEffect != nil {
+		m.renderEffect.stop()
+	}
 	m.component.runCleanups()
 	err := m.target.clear()
 	m.component.unmounted()
 	if err != nil {
 		return fmt.Errorf("clear mount target: %w", err)
 	}
+	return nil
+}
+
+type componentRenderEffect struct {
+	mounted *Mounted
+	deps    map[*dependency]struct{}
+	stopped bool
+	queued  bool
+}
+
+func newComponentRenderEffect(mounted *Mounted) *componentRenderEffect {
+	return &componentRenderEffect{
+		mounted: mounted,
+		deps:    make(map[*dependency]struct{}),
+	}
+}
+
+func (e *componentRenderEffect) run() {
+	if e == nil || e.stopped || e.mounted == nil || e.mounted.unmounted {
+		return
+	}
+
+	e.dispose()
+	var vnode VNode
+	pushSubscriber(e)
+	func() {
+		defer popSubscriber()
+		vnode = e.mounted.component.renderVNode()
+	}()
+
+	e.mounted.renderErr = e.mounted.patchRenderedVNode(vnode)
+	if e.mounted.renderErr != nil {
+		return
+	}
+	if e.mounted.mounted {
+		e.mounted.component.updated()
+	}
+}
+
+func (e *componentRenderEffect) addDependency(dep *dependency) {
+	if e == nil || dep == nil {
+		return
+	}
+	if e.deps == nil {
+		e.deps = make(map[*dependency]struct{})
+	}
+	if _, ok := e.deps[dep]; ok {
+		return
+	}
+	e.deps[dep] = struct{}{}
+	dep.addSubscriber(e)
+}
+
+func (e *componentRenderEffect) invalidate() {
+	if e == nil || e.stopped {
+		return
+	}
+	queueSubscriber(e)
+}
+
+func (e *componentRenderEffect) stop() {
+	if e == nil || e.stopped {
+		return
+	}
+	e.stopped = true
+	e.dispose()
+	removeQueuedSubscriber(e)
+}
+
+func (e *componentRenderEffect) dispose() {
+	if e == nil {
+		return
+	}
+	for dep := range e.deps {
+		dep.removeSubscriber(e)
+		delete(e.deps, dep)
+	}
+}
+
+func (e *componentRenderEffect) isQueued() bool {
+	return e != nil && e.queued
+}
+
+func (e *componentRenderEffect) setQueued(queued bool) {
+	if e == nil {
+		return
+	}
+	e.queued = queued
+}
+
+func (e *componentRenderEffect) isStopped() bool {
+	return e == nil || e.stopped
+}
+
+func (m *Mounted) patchRenderedVNode(vnode VNode) error {
+	if m == nil {
+		return fmt.Errorf("mounted component is required")
+	}
+	operation := "patch"
+	if m.tree == nil {
+		operation = "render"
+	}
+	tree, err := patchVNode(m.target, m.target.root(), m.tree, vnode)
+	if err != nil {
+		return fmt.Errorf("%s mount target: %w", operation, err)
+	}
+	m.tree = tree
 	return nil
 }

--- a/reactivity.go
+++ b/reactivity.go
@@ -177,7 +177,7 @@ func (c *ComputedValue[T]) dispose() {
 	}
 }
 
-// Batch deduplicates watcher reruns until the outermost batch returns.
+// Batch deduplicates reactive effect reruns until the outermost batch returns.
 func Batch(fn func()) {
 	if fn == nil {
 		return
@@ -186,7 +186,7 @@ func Batch(fn func()) {
 	defer func() {
 		scheduler.batchDepth--
 		if scheduler.batchDepth == 0 {
-			flushWatchers()
+			flushSubscribers()
 		}
 	}()
 	fn()
@@ -285,20 +285,13 @@ func (w *watcher) addDependency(dep *dependency) {
 	dep.addSubscriber(w)
 }
 
-func (w *watcher) invalidate() {
-	if w == nil || w.stopped {
-		return
-	}
-	queueWatcher(w)
-}
-
 func (w *watcher) stop() {
 	if w == nil || w.stopped {
 		return
 	}
 	w.stopped = true
 	w.dispose()
-	removeQueuedWatcher(w)
+	removeQueuedSubscriber(w)
 }
 
 func (w *watcher) dispose() {
@@ -309,6 +302,28 @@ func (w *watcher) dispose() {
 		dep.removeSubscriber(w)
 		delete(w.deps, dep)
 	}
+}
+
+func (w *watcher) invalidate() {
+	if w == nil || w.stopped {
+		return
+	}
+	queueSubscriber(w)
+}
+
+func (w *watcher) isQueued() bool {
+	return w != nil && w.queued
+}
+
+func (w *watcher) setQueued(queued bool) {
+	if w == nil {
+		return
+	}
+	w.queued = queued
+}
+
+func (w *watcher) isStopped() bool {
+	return w == nil || w.stopped
 }
 
 var subscriberStack []reactiveSubscriber
@@ -334,36 +349,44 @@ func currentSubscriber() reactiveSubscriber {
 type schedulerState struct {
 	batchDepth int
 	flushing   bool
-	pending    []*watcher
+	pending    []scheduledSubscriber
 }
 
 var scheduler schedulerState
 
-func queueWatcher(w *watcher) {
-	if w == nil || w.stopped || w.queued {
+type scheduledSubscriber interface {
+	reactiveSubscriber
+	run()
+	isQueued() bool
+	setQueued(bool)
+	isStopped() bool
+}
+
+func queueSubscriber(subscriber scheduledSubscriber) {
+	if subscriber == nil || subscriber.isStopped() || subscriber.isQueued() {
 		return
 	}
-	w.queued = true
-	scheduler.pending = append(scheduler.pending, w)
+	subscriber.setQueued(true)
+	scheduler.pending = append(scheduler.pending, subscriber)
 	if scheduler.batchDepth == 0 {
-		flushWatchers()
+		flushSubscribers()
 	}
 }
 
-func removeQueuedWatcher(w *watcher) {
-	if w == nil || !w.queued {
+func removeQueuedSubscriber(subscriber scheduledSubscriber) {
+	if subscriber == nil || !subscriber.isQueued() {
 		return
 	}
 	for i, pending := range scheduler.pending {
-		if pending == w {
+		if pending == subscriber {
 			scheduler.pending = append(scheduler.pending[:i], scheduler.pending[i+1:]...)
 			break
 		}
 	}
-	w.queued = false
+	subscriber.setQueued(false)
 }
 
-func flushWatchers() {
+func flushSubscribers() {
 	if scheduler.flushing {
 		return
 	}
@@ -375,9 +398,9 @@ func flushWatchers() {
 	for len(scheduler.pending) > 0 {
 		pending := scheduler.pending
 		scheduler.pending = nil
-		for _, watcher := range pending {
-			watcher.queued = false
-			watcher.run()
+		for _, subscriber := range pending {
+			subscriber.setQueued(false)
+			subscriber.run()
 		}
 	}
 }

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -87,6 +87,158 @@ func TestMountComponentRunsLifecycleInOrder(t *testing.T) {
 	}
 }
 
+func TestMountedReactiveRerendersWhenRenderDependencyChanges(t *testing.T) {
+	count := RefOf(0)
+	renderCount := 0
+	component := &reactiveRenderFixture{}
+	target := newFakeDOMTarget()
+	mounted, err := mountComponent(CompOf(component, func(*reactiveRenderFixture) VNode {
+		renderCount++
+		return Text(fmt.Sprintf("count:%d", count.Get()))
+	}), target)
+	if err != nil {
+		t.Fatalf("mountComponent returned error: %v", err)
+	}
+
+	if diff := cmp.Diff("count:0", target.html()); diff != "" {
+		t.Errorf("mismatch initial reactive render HTML (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff(1, renderCount); diff != "" {
+		t.Errorf("mismatch initial reactive render count (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff(0, component.updateCount); diff != "" {
+		t.Errorf("mismatch initial update count (-expected, +actual):\n%s", diff)
+	}
+
+	count.Set(1)
+
+	if diff := cmp.Diff("count:1", target.html()); diff != "" {
+		t.Errorf("mismatch updated reactive render HTML (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff(2, renderCount); diff != "" {
+		t.Errorf("mismatch updated reactive render count (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff(1, component.updateCount); diff != "" {
+		t.Errorf("mismatch updated lifecycle count (-expected, +actual):\n%s", diff)
+	}
+
+	if err := mounted.Unmount(); err != nil {
+		t.Fatalf("Unmount returned error: %v", err)
+	}
+}
+
+func TestMountedReactiveRerendersCoalesceInsideBatch(t *testing.T) {
+	count := RefOf(0)
+	renderCount := 0
+	component := &reactiveRenderFixture{}
+	target := newFakeDOMTarget()
+	mounted, err := mountComponent(CompOf(component, func(*reactiveRenderFixture) VNode {
+		renderCount++
+		return Text(fmt.Sprint(count.Get()))
+	}), target)
+	if err != nil {
+		t.Fatalf("mountComponent returned error: %v", err)
+	}
+
+	Batch(func() {
+		count.Set(1)
+		count.Set(2)
+		count.Set(3)
+
+		if diff := cmp.Diff("0", target.html()); diff != "" {
+			t.Errorf("mismatch batched reactive render HTML before flush (-expected, +actual):\n%s", diff)
+		}
+		if diff := cmp.Diff(1, renderCount); diff != "" {
+			t.Errorf("mismatch batched reactive render count before flush (-expected, +actual):\n%s", diff)
+		}
+		if diff := cmp.Diff(0, component.updateCount); diff != "" {
+			t.Errorf("mismatch batched update count before flush (-expected, +actual):\n%s", diff)
+		}
+	})
+
+	if diff := cmp.Diff("3", target.html()); diff != "" {
+		t.Errorf("mismatch batched reactive render HTML after flush (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff(2, renderCount); diff != "" {
+		t.Errorf("mismatch batched reactive render count after flush (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff(1, component.updateCount); diff != "" {
+		t.Errorf("mismatch batched update count after flush (-expected, +actual):\n%s", diff)
+	}
+
+	if err := mounted.Unmount(); err != nil {
+		t.Fatalf("Unmount returned error: %v", err)
+	}
+}
+
+func TestMountedReactiveRerenderStopsOnUnmount(t *testing.T) {
+	count := RefOf(0)
+	renderCount := 0
+	component := &reactiveRenderFixture{}
+	target := newFakeDOMTarget()
+	mounted, err := mountComponent(CompOf(component, func(*reactiveRenderFixture) VNode {
+		renderCount++
+		return Text(fmt.Sprint(count.Get()))
+	}), target)
+	if err != nil {
+		t.Fatalf("mountComponent returned error: %v", err)
+	}
+
+	Batch(func() {
+		count.Set(1)
+		if err := mounted.Unmount(); err != nil {
+			t.Fatalf("Unmount returned error: %v", err)
+		}
+	})
+	count.Set(2)
+
+	if diff := cmp.Diff("", target.html()); diff != "" {
+		t.Errorf("mismatch unmounted reactive render HTML (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff(1, renderCount); diff != "" {
+		t.Errorf("mismatch unmounted reactive render count (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff(0, component.updateCount); diff != "" {
+		t.Errorf("mismatch unmounted update count (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestMountedReactiveRerenderDoesNotTrackUpdatedHookReads(t *testing.T) {
+	count := RefOf(0)
+	hookValue := RefOf("initial")
+	events := []string{}
+	component := &reactiveUpdatedHookFixture{
+		events:    &events,
+		hookValue: hookValue,
+	}
+	target := newFakeDOMTarget()
+	mounted, err := mountComponent(CompOf(component, func(*reactiveUpdatedHookFixture) VNode {
+		events = append(events, fmt.Sprintf("render:%d", count.Get()))
+		return Text(fmt.Sprint(count.Get()))
+	}), target)
+	if err != nil {
+		t.Fatalf("mountComponent returned error: %v", err)
+	}
+
+	count.Set(1)
+	hookValue.Set("changed")
+
+	if diff := cmp.Diff("1", target.html()); diff != "" {
+		t.Errorf("mismatch hook-read reactive render HTML (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff([]string{
+		"render:0",
+		"render:1",
+		"updated:initial",
+	}, events); diff != "" {
+		t.Errorf("mismatch hook-read reactive render events (-expected, +actual):\n%s", diff)
+	}
+
+	if err := mounted.Unmount(); err != nil {
+		t.Fatalf("Unmount returned error: %v", err)
+	}
+}
+
 func TestMountedUpdateRejectsUnmountedComponent(t *testing.T) {
 	mounted, err := mountComponent(CompOf(&initFixture{}, func(*initFixture) VNode {
 		return Text("value")
@@ -167,6 +319,23 @@ func (f *lifecycleFixture) OnUpdated() {
 
 func (f *lifecycleFixture) OnUnmounted() {
 	*f.events = append(*f.events, "unmounted")
+}
+
+type reactiveRenderFixture struct {
+	updateCount int
+}
+
+func (f *reactiveRenderFixture) OnUpdated() {
+	f.updateCount++
+}
+
+type reactiveUpdatedHookFixture struct {
+	events    *[]string
+	hookValue *RefValue[string]
+}
+
+func (f *reactiveUpdatedHookFixture) OnUpdated() {
+	*f.events = append(*f.events, "updated:"+f.hookValue.Get())
 }
 
 func errorString(err error) string {


### PR DESCRIPTION
## Summary

- Added a mounted component render effect that tracks reactive values read during render and patches the existing DOM tree when those values change.
- Generalized the synchronous scheduler so user watchers and mounted render effects share batching and deduplication.
- Added runtime tests for reactive rerenders, batched coalescing, `OnUpdated` ordering, hook dependency isolation, and stopping updates after `Unmount`.

## Validation

- `go fmt ./...`
- `go test ./...`
- `git diff --check`
- js/wasm compile smoke: `GOOS=js GOARCH=wasm go test -c` for every package
- `tokensave sync`