### PR TITLE
Added component callback events.

### DIFF
--- a/internal/compiler/checker/checker_test.go
+++ b/internal/compiler/checker/checker_test.go
@@ -14,7 +14,7 @@ import (
 	gotemplate "github.com/norunners/tue/internal/compiler/template"
 )
 
-//go:embed testdata/valid/*.tue testdata/invalid/*.tue testdata/invalid_event_handler/*.tue testdata/missing_required_prop/*.tue
+//go:embed testdata/valid/*.tue testdata/invalid/*.tue testdata/invalid_event_handler/*.tue testdata/invalid_component_event/*.tue testdata/missing_required_prop/*.tue
 var testFixtures embed.FS
 
 func TestCheckProjectAcceptsValidProject(t *testing.T) {
@@ -75,6 +75,23 @@ func TestCheckProjectReportsUnsupportedEventHandlerShapes(t *testing.T) {
 	if diff := cmp.Diff([]diagnosticSummary{
 		{Path: "testdata/invalid_event_handler/Parent.tue", Message: `event handler "increment" does not accept arguments`, Line: 2, Column: 32},
 		{Path: "testdata/invalid_event_handler/Parent.tue", Message: `event handler "save" must have signature func()`, Line: 3, Column: 32},
+	}, summarizeDiagnostics(diagnostics)); diff != "" {
+		t.Errorf("mismatch diagnostics (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestCheckProjectReportsUnsupportedComponentEventShapes(t *testing.T) {
+	project, err := parseProjectFixture("testdata/invalid_component_event")
+	if err != nil {
+		t.Fatalf("parse project fixture: %v", err)
+	}
+
+	diagnostics := CheckProject(project)
+	if diff := cmp.Diff([]diagnosticSummary{
+		{Path: "testdata/invalid_component_event/Parent.tue", Message: `component "UserBadge" has no event "missing"`, Line: 5, Column: 5},
+		{Path: "testdata/invalid_component_event/Parent.tue", Message: `component "UserBadge" event "payload" must have signature func()`, Line: 6, Column: 5},
+		{Path: "testdata/invalid_component_event/Parent.tue", Message: `event handler "selectUser" does not accept arguments`, Line: 7, Column: 20},
+		{Path: "testdata/invalid_component_event/Parent.tue", Message: `event handler "needsValue" must have signature func()`, Line: 8, Column: 16},
 	}, summarizeDiagnostics(diagnostics)); diff != "" {
 		t.Errorf("mismatch diagnostics (-expected, +actual):\n%s", diff)
 	}

--- a/internal/compiler/checker/directive.go
+++ b/internal/compiler/checker/directive.go
@@ -10,11 +10,13 @@ import (
 	gotemplate "github.com/norunners/tue/internal/compiler/template"
 )
 
-func (c *fileChecker) checkCommonAttrs(node *gotemplate.Node, scope *scope) {
+func (c *fileChecker) checkCommonAttrs(node *gotemplate.Node, scope *scope, checkEvents bool) {
 	for _, attr := range node.Attrs {
 		switch attr.Kind {
 		case gotemplate.AttrEvent:
-			c.checkEvent(attr, scope)
+			if checkEvents {
+				c.checkEvent(attr, scope)
+			}
 		case gotemplate.AttrDirective:
 			switch attr.Directive {
 			case gotemplate.DirectiveIf:

--- a/internal/compiler/checker/file.go
+++ b/internal/compiler/checker/file.go
@@ -40,10 +40,11 @@ func (c *fileChecker) checkElement(node *gotemplate.Node, scope *scope) {
 		elementScope = c.checkFor(node, attr, scope)
 	}
 
-	c.checkCommonAttrs(node, elementScope)
 	if node.IsComponent {
+		c.checkCommonAttrs(node, elementScope, false)
 		c.checkComponent(node, elementScope)
 	} else {
+		c.checkCommonAttrs(node, elementScope, true)
 		c.checkNativeAttrs(node, elementScope)
 	}
 	c.checkNodes(node.Children, elementScope)
@@ -71,6 +72,8 @@ func (c *fileChecker) checkComponent(node *gotemplate.Node, scope *scope) {
 			c.checkStaticComponentProp(node, child, attr, seen)
 		case gotemplate.AttrBind:
 			c.checkBoundComponentProp(node, child, attr, scope, seen)
+		case gotemplate.AttrEvent:
+			c.checkComponentEvent(node, child, attr, scope)
 		}
 	}
 
@@ -106,6 +109,20 @@ func (c *fileChecker) checkBoundComponentProp(node *gotemplate.Node, child compo
 	seen[prop.Name] = true
 	value := c.checkExpression(attr.Expression, attr.ExpressionSpan, scope)
 	c.expectComponentPropType(node.Tag, prop, value.Type, attr.ExpressionSpan)
+}
+
+func (c *fileChecker) checkComponentEvent(node *gotemplate.Node, child componentBinding, attr gotemplate.Attr, scope *scope) {
+	event, ok := child.events[attr.Argument]
+	if !ok {
+		c.add(fmt.Sprintf("component %q has no event %q", node.Tag, attr.Argument), attr.ArgumentSpan)
+		return
+	}
+
+	if !isNoArgFunc(event.Type) {
+		c.add(fmt.Sprintf("component %q event %q must have signature func()", node.Tag, attr.Argument), attr.ArgumentSpan)
+		return
+	}
+	c.checkEvent(attr, scope)
 }
 
 func (c *fileChecker) expectType(expected string, actual string, subject string, span sfc.Span) {

--- a/internal/compiler/checker/project.go
+++ b/internal/compiler/checker/project.go
@@ -29,6 +29,7 @@ type componentBinding struct {
 	path      string
 	component *script.Component
 	props     map[string]script.Prop
+	events    map[string]script.Field
 }
 
 func (c *projectChecker) indexComponents(files []File) {
@@ -48,10 +49,18 @@ func (c *projectChecker) indexComponents(files []File) {
 		for _, prop := range component.Props {
 			props[prop.Name] = prop
 		}
+		events := make(map[string]script.Field, len(component.Events))
+		for _, event := range component.Events {
+			name, ok := script.EventName(event)
+			if ok {
+				events[name] = event
+			}
+		}
 		c.components[component.Name] = componentBinding{
 			path:      path,
 			component: component,
 			props:     props,
+			events:    events,
 		}
 	}
 }

--- a/internal/compiler/checker/scope.go
+++ b/internal/compiler/checker/scope.go
@@ -133,6 +133,10 @@ func displayType(typ string) string {
 	return typ
 }
 
+func isNoArgFunc(typ string) bool {
+	return strings.TrimSpace(typ) == "func()"
+}
+
 func isNumeric(typ string) bool {
 	switch normalizeType(typ) {
 	case "int", "int8", "int16", "int32", "int64", "uint", "uint8", "uint16", "uint32", "uint64", "uintptr", "float32", "float64", "rune", "byte":

--- a/internal/compiler/checker/testdata/invalid_component_event/Parent.tue
+++ b/internal/compiler/checker/testdata/invalid_component_event/Parent.tue
@@ -1,0 +1,21 @@
+<template>
+	<main>
+		<UserBadge
+			name="Ada"
+			@missing="selectUser"
+			@payload="selectUser"
+			@selectWithArg="selectUser(1)"
+			@selectBad="needsValue"
+		/>
+	</main>
+</template>
+
+<script lang="go">
+package fixtures
+
+func (p *Parent) selectUser() {}
+
+func (p *Parent) needsValue(value string) {}
+
+type Parent struct{}
+</script>

--- a/internal/compiler/checker/testdata/invalid_component_event/UserBadge.tue
+++ b/internal/compiler/checker/testdata/invalid_component_event/UserBadge.tue
@@ -1,0 +1,16 @@
+<template>
+	<span>{{ name }}</span>
+</template>
+
+<script lang="go">
+package fixtures
+
+import tue "github.com/norunners/tue"
+
+type UserBadge struct {
+	name            tue.Prop[string] `prop:"name,required"`
+	onPayload       func(string)
+	onSelectWithArg func()
+	onSelectBad     func()
+}
+</script>

--- a/internal/compiler/checker/testdata/valid/UserBadge.tue
+++ b/internal/compiler/checker/testdata/valid/UserBadge.tue
@@ -13,5 +13,6 @@ import tue "github.com/norunners/tue"
 type UserBadge struct {
 	name    tue.Prop[string] `prop:"name,required"`
 	isAdmin tue.Prop[bool]   `prop:"isAdmin"`
+	onSelect func()
 }
 </script>

--- a/internal/compiler/gogen/generate.go
+++ b/internal/compiler/gogen/generate.go
@@ -56,6 +56,7 @@ type componentBinding struct {
 	path      string
 	component *script.Component
 	props     map[string]script.Prop
+	events    map[string]script.Field
 }
 
 func (g *projectGenerator) indexComponents(files []File) {
@@ -76,10 +77,18 @@ func (g *projectGenerator) indexComponents(files []File) {
 		for _, prop := range component.Props {
 			props[prop.Name] = prop
 		}
+		events := make(map[string]script.Field, len(component.Events))
+		for _, event := range component.Events {
+			name, ok := script.EventName(event)
+			if ok {
+				events[name] = event
+			}
+		}
 		g.components[component.Name] = componentBinding{
 			path:      path,
 			component: component,
 			props:     props,
+			events:    events,
 		}
 	}
 }
@@ -278,7 +287,7 @@ func (g *fileGenerator) renderComponent(node *gotemplate.Node) (jen.Code, bool) 
 		return nil, false
 	}
 
-	fields, ok := g.renderComponentPropFields(node, child)
+	fields, ok := g.renderComponentFields(node, child)
 	if !ok {
 		return nil, false
 	}
@@ -293,8 +302,9 @@ func (g *fileGenerator) renderComponent(node *gotemplate.Node) (jen.Code, bool) 
 	), true
 }
 
-func (g *fileGenerator) renderComponentPropFields(node *gotemplate.Node, child componentBinding) ([]jen.Code, bool) {
-	values := make(map[string]jen.Code, len(node.Attrs))
+func (g *fileGenerator) renderComponentFields(node *gotemplate.Node, child componentBinding) ([]jen.Code, bool) {
+	props := make(map[string]jen.Code, len(node.Attrs))
+	events := make(map[string]jen.Code, len(node.Attrs))
 	ok := true
 	for _, attr := range node.Attrs {
 		switch attr.Kind {
@@ -310,7 +320,7 @@ func (g *fileGenerator) renderComponentPropFields(node *gotemplate.Node, child c
 				ok = false
 				continue
 			}
-			values[prop.Name] = value
+			props[prop.Name] = value
 		case gotemplate.AttrBind:
 			prop, found := child.props[attr.Argument]
 			if !found {
@@ -323,10 +333,14 @@ func (g *fileGenerator) renderComponentPropFields(node *gotemplate.Node, child c
 				ok = false
 				continue
 			}
-			values[prop.Name] = value
+			props[prop.Name] = value
 		case gotemplate.AttrEvent:
-			g.add(fmt.Sprintf("component event attribute %q generation is not supported in the component render slice", attr.RawName), attr.Span)
-			ok = false
+			field, eventOK := g.renderComponentEventField(node, child, attr)
+			if !eventOK {
+				ok = false
+				continue
+			}
+			events[field.Name] = field.Value
 		case gotemplate.AttrDirective:
 			g.add(fmt.Sprintf("directive %q generation is not supported on components in the component render slice", attr.RawName), attr.Span)
 			ok = false
@@ -338,7 +352,7 @@ func (g *fileGenerator) renderComponentPropFields(node *gotemplate.Node, child c
 
 	fields := make([]jen.Code, 0, len(child.component.Props))
 	for _, prop := range child.component.Props {
-		value, found := values[prop.Name]
+		value, found := props[prop.Name]
 		if !found {
 			if prop.Required {
 				g.add(fmt.Sprintf("component %q requires prop %q", node.Tag, prop.Name), node.TagSpan)
@@ -355,7 +369,54 @@ func (g *fileGenerator) renderComponentPropFields(node *gotemplate.Node, child c
 		}
 		fields = append(fields, jen.Id(prop.Field.Name).Op(":").Add(value))
 	}
+	for _, event := range child.component.Events {
+		value, found := events[event.Name]
+		if found {
+			fields = append(fields, jen.Id(event.Name).Op(":").Add(value))
+		}
+	}
 	return fields, ok
+}
+
+type componentEventField struct {
+	Name  string
+	Value jen.Code
+}
+
+func (g *fileGenerator) renderComponentEventField(node *gotemplate.Node, child componentBinding, attr gotemplate.Attr) (componentEventField, bool) {
+	event, found := child.events[attr.Argument]
+	if !found {
+		g.add(fmt.Sprintf("component %q has no event %q", node.Tag, attr.Argument), attr.ArgumentSpan)
+		return componentEventField{}, false
+	}
+	if !isNoArgFunc(event.Type) {
+		g.add(fmt.Sprintf("component %q event %q must have signature func()", node.Tag, attr.Argument), attr.ArgumentSpan)
+		return componentEventField{}, false
+	}
+
+	methodName, callWithArgs, ok := g.eventHandlerMethod(attr)
+	if !ok {
+		return componentEventField{}, false
+	}
+	if callWithArgs {
+		g.add(fmt.Sprintf("event handler %q does not accept arguments", methodName), attr.ExpressionSpan)
+		return componentEventField{}, false
+	}
+
+	method, ok := g.methods[methodName]
+	if !ok {
+		g.add(fmt.Sprintf("event handler %q is not a method on %s", methodName, g.component.Name), attr.ExpressionSpan)
+		return componentEventField{}, false
+	}
+	if len(method.Parameters) != 0 || len(method.Results) != 0 {
+		g.add(fmt.Sprintf("event handler %q must have signature func()", methodName), attr.ExpressionSpan)
+		return componentEventField{}, false
+	}
+
+	return componentEventField{
+		Name:  event.Name,
+		Value: jen.Id("component").Dot(methodName),
+	}, true
 }
 
 func (g *fileGenerator) renderStaticComponentProp(componentName string, prop script.Prop, attr gotemplate.Attr) (jen.Code, bool) {
@@ -684,6 +745,10 @@ func displayType(typ string) string {
 		return "unknown"
 	}
 	return typ
+}
+
+func isNoArgFunc(typ string) bool {
+	return strings.TrimSpace(typ) == "func()"
 }
 
 func hasRenderableComponentChildren(children []*gotemplate.Node) bool {

--- a/internal/compiler/gogen/generate_test.go
+++ b/internal/compiler/gogen/generate_test.go
@@ -18,7 +18,7 @@ import (
 	gotemplate "github.com/norunners/tue/internal/compiler/template"
 )
 
-//go:embed testdata/static/*.tue testdata/dynamic/*.tue testdata/events/*.tue testdata/components/*.tue testdata/invalid_events/*.tue testdata/golden/*.go
+//go:embed testdata/static/*.tue testdata/dynamic/*.tue testdata/events/*.tue testdata/components/*.tue testdata/invalid_events/*.tue testdata/invalid_component_events/*.tue testdata/golden/*.go
 var testFixtures embed.FS
 
 func TestGenerateProjectEmitsStaticRenderFiles(t *testing.T) {
@@ -183,6 +183,24 @@ func TestGenerateProjectReportsUnsupportedEventHandlers(t *testing.T) {
 		{Path: "App.tue", Message: `event handler "save" does not accept arguments`, Line: 2, Column: 32},
 		{Path: "App.tue", Message: `event handler "needsValue" must have signature func()`, Line: 3, Column: 32},
 		{Path: "App.tue", Message: `event handler "missing" is not a method on App`, Line: 4, Column: 32},
+	}, summarizeDiagnostics(diagnostics)); diff != "" {
+		t.Errorf("mismatch diagnostics (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestGenerateProjectReportsUnsupportedComponentEvents(t *testing.T) {
+	project, err := parseProjectFixture("testdata/invalid_component_events")
+	if err != nil {
+		t.Fatalf("parse project fixture: %v", err)
+	}
+
+	_, diagnostics := GenerateProject(*project)
+
+	if diff := cmp.Diff([]diagnosticSummary{
+		{Path: "Parent.tue", Message: `component "UserBadge" has no event "missing"`, Line: 5, Column: 4},
+		{Path: "Parent.tue", Message: `component "UserBadge" event "payload" must have signature func()`, Line: 6, Column: 4},
+		{Path: "Parent.tue", Message: `event handler "selectUser" does not accept arguments`, Line: 7, Column: 19},
+		{Path: "Parent.tue", Message: `event handler "needsValue" must have signature func()`, Line: 8, Column: 15},
 	}, summarizeDiagnostics(diagnostics)); diff != "" {
 		t.Errorf("mismatch diagnostics (-expected, +actual):\n%s", diff)
 	}

--- a/internal/compiler/gogen/testdata/components/Parent.tue
+++ b/internal/compiler/gogen/testdata/components/Parent.tue
@@ -1,6 +1,6 @@
 <template>
 <main>
-	<UserBadge :name="name" active />
+	<UserBadge :name="name" active @select="selectUser" />
 </main>
 </template>
 <script lang="go">
@@ -15,4 +15,6 @@ type Parent struct {
 func (p *Parent) Init(tue.Context) {
 	p.name = tue.RefOf("Ada")
 }
+
+func (p *Parent) selectUser() {}
 </script>

--- a/internal/compiler/gogen/testdata/components/UserBadge.tue
+++ b/internal/compiler/gogen/testdata/components/UserBadge.tue
@@ -1,5 +1,5 @@
 <template>
-<span class="badge">{{ name }} {{ active }} {{ label }}</span>
+<button type="button" @click="choose">{{ name }} {{ active }} {{ label }}</button>
 </template>
 <script lang="go">
 package fixtures
@@ -10,5 +10,12 @@ type UserBadge struct {
 	name   tue.Prop[string] `prop:"name,required"`
 	active tue.Prop[bool]   `prop:"active"`
 	label  tue.Prop[string] `prop:"label"`
+	onSelect func()
+}
+
+func (u *UserBadge) choose() {
+	if u.onSelect != nil {
+		u.onSelect()
+	}
 }
 </script>

--- a/internal/compiler/gogen/testdata/golden/Parent_render_tue.go
+++ b/internal/compiler/gogen/testdata/golden/Parent_render_tue.go
@@ -13,7 +13,7 @@ func renderParent(component *Parent) tue.VNode {
 	return tue.Element("main", nil, []tue.VNode{tue.Component("UserBadge", func() *tue.Comp {
 		child := &UserBadge{name: tue.PropOfFunc(func() string {
 			return component.name.Get()
-		}), active: tue.PropOf(true), label: tue.PropOf("")}
+		}), active: tue.PropOf(true), label: tue.PropOf(""), onSelect: component.selectUser}
 		return tue.CompOf(child, renderUserBadge)
 	})})
 }

--- a/internal/compiler/gogen/testdata/invalid_component_events/Parent.tue
+++ b/internal/compiler/gogen/testdata/invalid_component_events/Parent.tue
@@ -1,0 +1,20 @@
+<template>
+<main>
+	<UserBadge
+		name="Ada"
+		@missing="selectUser"
+		@payload="selectUser"
+		@selectWithArg="selectUser(1)"
+		@selectBad="needsValue"
+	/>
+</main>
+</template>
+<script lang="go">
+package fixtures
+
+func (p *Parent) selectUser() {}
+
+func (p *Parent) needsValue(value string) {}
+
+type Parent struct{}
+</script>

--- a/internal/compiler/gogen/testdata/invalid_component_events/UserBadge.tue
+++ b/internal/compiler/gogen/testdata/invalid_component_events/UserBadge.tue
@@ -1,0 +1,15 @@
+<template>
+<span>{{ name }}</span>
+</template>
+<script lang="go">
+package fixtures
+
+import tue "github.com/norunners/tue"
+
+type UserBadge struct {
+	name            tue.Prop[string] `prop:"name,required"`
+	onPayload       func(string)
+	onSelectWithArg func()
+	onSelectBad     func()
+}
+</script>

--- a/internal/compiler/script/contract.go
+++ b/internal/compiler/script/contract.go
@@ -26,6 +26,7 @@ type Component struct {
 	Span       sfc.Span
 	NameSpan   sfc.Span
 	Props      []Prop
+	Events     []Field
 	State      []Field
 	Refs       []Field
 	Computed   []Field
@@ -88,4 +89,12 @@ type Parameter struct {
 type Diagnostic struct {
 	Message string
 	Span    sfc.Span
+}
+
+// EventName returns the template event name represented by an event callback field.
+func EventName(field Field) (string, bool) {
+	if field.Kind != FieldKindEvent {
+		return "", false
+	}
+	return eventNameFromFieldName(field.Name)
 }

--- a/internal/compiler/script/enum.go
+++ b/internal/compiler/script/enum.go
@@ -5,6 +5,7 @@ type FieldKind string
 
 const (
 	FieldKindState    FieldKind = "state"
+	FieldKindEvent    FieldKind = "event"
 	FieldKindProp     FieldKind = "prop"
 	FieldKindRef      FieldKind = "ref"
 	FieldKindComputed FieldKind = "computed"

--- a/internal/compiler/script/parse.go
+++ b/internal/compiler/script/parse.go
@@ -273,6 +273,8 @@ func (e *extractor) extractFields(component *Component, structType *ast.StructTy
 		for _, name := range astField.Names {
 			field := e.fieldFromAST(name, astField)
 			switch field.Kind {
+			case FieldKindEvent:
+				component.Events = append(component.Events, field)
 			case FieldKindProp:
 				component.Props = append(component.Props, e.propFromField(field))
 			case FieldKindRef:
@@ -306,6 +308,13 @@ func (e *extractor) fieldFromAST(name *ast.Ident, astField *ast.Field) Field {
 }
 
 func (e *extractor) classifyField(fieldName string, expr ast.Expr) (FieldKind, string) {
+	if _, ok := expr.(*ast.FuncType); ok {
+		if _, ok := eventNameFromFieldName(fieldName); ok {
+			return FieldKindEvent, ""
+		}
+		return FieldKindState, ""
+	}
+
 	typeName, args, ok := e.tueGenericType(expr)
 	if !ok {
 		return FieldKindState, ""
@@ -376,6 +385,25 @@ func fieldKindForTueType(name string) (FieldKind, bool) {
 	default:
 		return FieldKindState, false
 	}
+}
+
+func eventNameFromFieldName(fieldName string) (string, bool) {
+	const prefix = "on"
+	if !strings.HasPrefix(fieldName, prefix) {
+		return "", false
+	}
+
+	suffix := strings.TrimPrefix(fieldName, prefix)
+	if suffix == "" {
+		return "", false
+	}
+
+	runes := []rune(suffix)
+	if !unicode.IsUpper(runes[0]) {
+		return "", false
+	}
+	runes[0] = unicode.ToLower(runes[0])
+	return string(runes), true
 }
 
 func (e *extractor) fieldTag(field *ast.Field) (string, sfc.Span) {

--- a/internal/compiler/script/parse_test.go
+++ b/internal/compiler/script/parse_test.go
@@ -56,6 +56,7 @@ func TestParseExtractsComponentContract(t *testing.T) {
 	assertField(t, component.Refs, "count", FieldKindRef, "tue.Ref[int]", "int")
 	assertField(t, component.Computed, "total", FieldKindComputed, "tue.Computed[int]", "int")
 	assertField(t, component.Resources, "user", FieldKindResource, "tue.Resource[User]", "User")
+	assertField(t, component.Events, "onSave", FieldKindEvent, "func()", "")
 	assertField(t, component.State, "label", FieldKindState, "string", "")
 
 	init := requireInit(t, component)

--- a/internal/compiler/script/testdata/contracts/dashboard.go
+++ b/internal/compiler/script/testdata/contracts/dashboard.go
@@ -9,6 +9,7 @@ type Dashboard struct {
 	count tue.Ref[int]
 	total tue.Computed[int]
 	user  tue.Resource[User]
+	onSave func()
 	label string
 }
 


### PR DESCRIPTION
## Summary

- Added internal script contract extraction for `on<Event> func()` component callback fields.
- Validated component event attributes against child callback fields and parent no-argument methods.
- Generated child callback field assignments for same-package component tags.
- Added positive and negative checker/generator fixtures, including generated wasm compile coverage.

## Validation

- `go fmt ./...`
- `go test ./...`
- js/wasm package compile pass
- `git diff --check`
- `tokensave sync`

Docs were updated locally only and intentionally left out of this PR.