### PR TITLE
Implemented resource primitive.

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -1,0 +1,147 @@
+package tue
+
+import "sync"
+
+// Resource is the async-state interface exposed to component code.
+type Resource[T any] interface {
+	Value() (T, bool)
+	Error() error
+	Loading() bool
+	Reload()
+}
+
+// ResourceValue is the concrete runtime storage for async resource state.
+type ResourceValue[T any] struct {
+	load func() (T, error)
+
+	mu       sync.Mutex
+	value    T
+	hasValue bool
+	err      error
+	loading  bool
+	stopped  bool
+	runID    int
+	dep      dependency
+}
+
+// ResourceOfFunc returns a resource backed by a load function and starts the
+// initial load immediately.
+func ResourceOfFunc[T any](ctx Context, load func() (T, error)) *ResourceValue[T] {
+	resource := &ResourceValue[T]{load: load}
+	if ctx != nil {
+		ctx.OnCleanup(resource.stop)
+	}
+	resource.Reload()
+	return resource
+}
+
+// Value returns the loaded value and whether a value is currently available.
+func (r *ResourceValue[T]) Value() (T, bool) {
+	if r == nil {
+		var zero T
+		return zero, false
+	}
+	r.dep.track()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.value, r.hasValue
+}
+
+// Error returns the most recent load error.
+func (r *ResourceValue[T]) Error() error {
+	if r == nil {
+		return nil
+	}
+	r.dep.track()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.err
+}
+
+// Loading reports whether a load is currently in flight.
+func (r *ResourceValue[T]) Loading() bool {
+	if r == nil {
+		return false
+	}
+	r.dep.track()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.loading
+}
+
+// Reload starts a new load and invalidates any older in-flight result.
+func (r *ResourceValue[T]) Reload() {
+	if r == nil {
+		return
+	}
+
+	load, runID, ok := r.beginLoad()
+	if !ok {
+		return
+	}
+
+	go func() {
+		value, err := load()
+		r.finishLoad(runID, value, err)
+	}()
+}
+
+func (r *ResourceValue[T]) beginLoad() (func() (T, error), int, bool) {
+	r.mu.Lock()
+	if r.stopped || r.load == nil {
+		r.mu.Unlock()
+		return nil, 0, false
+	}
+
+	var zero T
+	r.runID++
+	runID := r.runID
+	load := r.load
+	r.value = zero
+	r.hasValue = false
+	r.err = nil
+	r.loading = true
+	r.mu.Unlock()
+
+	r.dep.notify()
+	return load, runID, true
+}
+
+func (r *ResourceValue[T]) finishLoad(runID int, value T, err error) {
+	r.mu.Lock()
+	if r.stopped || r.runID != runID {
+		r.mu.Unlock()
+		return
+	}
+
+	var zero T
+	r.loading = false
+	r.err = err
+	if err != nil {
+		r.value = zero
+		r.hasValue = false
+	} else {
+		r.value = value
+		r.hasValue = true
+	}
+	r.mu.Unlock()
+
+	r.dep.notify()
+}
+
+func (r *ResourceValue[T]) stop() {
+	r.mu.Lock()
+	if r.stopped {
+		r.mu.Unlock()
+		return
+	}
+	r.stopped = true
+	r.runID++
+	r.loading = false
+	r.mu.Unlock()
+
+	r.dep.notify()
+}

--- a/resource_test.go
+++ b/resource_test.go
@@ -1,0 +1,263 @@
+package tue
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var _ Resource[string] = (*ResourceValue[string])(nil)
+
+func TestResourceLoadsValueAndTracksLoading(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	resource := ResourceOfFunc(nil, func() (string, error) {
+		close(started)
+		<-release
+		return "ready", nil
+	})
+	if err := waitClosed(started, "resource load start"); err != nil {
+		t.Fatalf("wait resource load start: %v", err)
+	}
+
+	expected := resourceSnapshot[string]{Loading: true}
+	if diff := cmp.Diff(expected, snapshotResource(resource)); diff != "" {
+		t.Errorf("mismatch initial resource snapshot (-expected, +actual):\n%s", diff)
+	}
+
+	close(release)
+
+	actual, err := waitForResourceSnapshot(resource, func(snapshot resourceSnapshot[string]) bool {
+		return snapshot.HasValue && snapshot.Value == "ready"
+	})
+	if err != nil {
+		t.Fatalf("wait loaded resource snapshot: %v", err)
+	}
+	expected = resourceSnapshot[string]{Value: "ready", HasValue: true}
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Errorf("mismatch loaded resource snapshot (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestResourceStoresErrorWithoutValue(t *testing.T) {
+	expectedErr := errors.New("load failed")
+	resource := ResourceOfFunc(nil, func() (string, error) {
+		return "", expectedErr
+	})
+
+	actual, err := waitForResourceSnapshot(resource, func(snapshot resourceSnapshot[string]) bool {
+		return !snapshot.Loading && snapshot.Error != ""
+	})
+	if err != nil {
+		t.Fatalf("wait failed resource snapshot: %v", err)
+	}
+	expected := resourceSnapshot[string]{Error: expectedErr.Error()}
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Errorf("mismatch failed resource snapshot (-expected, +actual):\n%s", diff)
+	}
+	if !errors.Is(resource.Error(), expectedErr) {
+		t.Errorf("resource error actual = %v, expected %v", resource.Error(), expectedErr)
+	}
+}
+
+func TestResourceReloadClearsValueAndLoadsLatestResult(t *testing.T) {
+	results := make(chan string, 2)
+	results <- "first"
+	resource := ResourceOfFunc(nil, func() (string, error) {
+		return <-results, nil
+	})
+
+	actual, err := waitForResourceSnapshot(resource, func(snapshot resourceSnapshot[string]) bool {
+		return snapshot.HasValue && snapshot.Value == "first"
+	})
+	if err != nil {
+		t.Fatalf("wait first resource snapshot: %v", err)
+	}
+	expected := resourceSnapshot[string]{Value: "first", HasValue: true}
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Errorf("mismatch first resource snapshot (-expected, +actual):\n%s", diff)
+	}
+
+	resource.Reload()
+
+	expected = resourceSnapshot[string]{Loading: true}
+	if diff := cmp.Diff(expected, snapshotResource(resource)); diff != "" {
+		t.Errorf("mismatch reloading resource snapshot (-expected, +actual):\n%s", diff)
+	}
+
+	results <- "second"
+	actual, err = waitForResourceSnapshot(resource, func(snapshot resourceSnapshot[string]) bool {
+		return snapshot.HasValue && snapshot.Value == "second"
+	})
+	if err != nil {
+		t.Fatalf("wait reloaded resource snapshot: %v", err)
+	}
+	expected = resourceSnapshot[string]{Value: "second", HasValue: true}
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Errorf("mismatch reloaded resource snapshot (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestResourceReloadNotifiesWatchersWhenLoadingStarts(t *testing.T) {
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	finished := make(chan struct{}, 2)
+	resource := ResourceOfFunc(nil, func() (string, error) {
+		started <- struct{}{}
+		<-release
+		finished <- struct{}{}
+		return "unused", nil
+	})
+	if err := waitClosed(started, "initial resource load start"); err != nil {
+		t.Fatalf("wait initial resource load start: %v", err)
+	}
+
+	events := make(chan resourceSnapshot[string], 4)
+	stop := Watch(func() {
+		events <- snapshotResource(resource)
+	})
+
+	expected := resourceSnapshot[string]{Loading: true}
+	actual, err := receiveResourceSnapshot(events)
+	if err != nil {
+		t.Fatalf("receive initial watched resource snapshot: %v", err)
+	}
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Errorf("mismatch initial watched resource snapshot (-expected, +actual):\n%s", diff)
+	}
+
+	resource.Reload()
+
+	expected = resourceSnapshot[string]{Loading: true}
+	actual, err = receiveResourceSnapshot(events)
+	if err != nil {
+		t.Fatalf("receive reloading watched resource snapshot: %v", err)
+	}
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Errorf("mismatch reloading watched resource snapshot (-expected, +actual):\n%s", diff)
+	}
+	stop()
+
+	close(release)
+	if err := waitClosed(finished, "initial resource load finish"); err != nil {
+		t.Fatalf("wait initial resource load finish: %v", err)
+	}
+	if err := waitClosed(finished, "reloaded resource load finish"); err != nil {
+		t.Fatalf("wait reloaded resource load finish: %v", err)
+	}
+}
+
+func TestResourceUnmountIgnoresLateInFlightLoad(t *testing.T) {
+	fixture := &resourceUnmountFixture{
+		started:  make(chan struct{}),
+		release:  make(chan struct{}),
+		finished: make(chan struct{}),
+	}
+	mounted, err := mountComponent(CompOf(fixture, func(*resourceUnmountFixture) VNode {
+		return Text("resource")
+	}), newStubDOMTarget())
+	if err != nil {
+		t.Fatalf("mountComponent returned error: %v", err)
+	}
+	if err := waitClosed(fixture.started, "resource load start"); err != nil {
+		t.Fatalf("wait resource load start: %v", err)
+	}
+
+	expected := resourceSnapshot[string]{Loading: true}
+	if diff := cmp.Diff(expected, snapshotResource(fixture.resource)); diff != "" {
+		t.Errorf("mismatch mounted resource snapshot (-expected, +actual):\n%s", diff)
+	}
+
+	if err := mounted.Unmount(); err != nil {
+		t.Fatalf("Unmount returned error: %v", err)
+	}
+	expected = resourceSnapshot[string]{}
+	if diff := cmp.Diff(expected, snapshotResource(fixture.resource)); diff != "" {
+		t.Errorf("mismatch stopped resource snapshot (-expected, +actual):\n%s", diff)
+	}
+
+	close(fixture.release)
+	if err := waitClosed(fixture.finished, "resource load finish"); err != nil {
+		t.Fatalf("wait resource load finish: %v", err)
+	}
+
+	if diff := cmp.Diff(expected, snapshotResource(fixture.resource)); diff != "" {
+		t.Errorf("mismatch late resource snapshot (-expected, +actual):\n%s", diff)
+	}
+}
+
+type resourceSnapshot[T any] struct {
+	Value    T
+	HasValue bool
+	Loading  bool
+	Error    string
+}
+
+func snapshotResource[T any](resource Resource[T]) resourceSnapshot[T] {
+	value, ok := resource.Value()
+	err := resource.Error()
+	snapshot := resourceSnapshot[T]{
+		Value:    value,
+		HasValue: ok,
+		Loading:  resource.Loading(),
+	}
+	if err != nil {
+		snapshot.Error = err.Error()
+	}
+	return snapshot
+}
+
+func receiveResourceSnapshot[T any](snapshots <-chan resourceSnapshot[T]) (resourceSnapshot[T], error) {
+	select {
+	case snapshot := <-snapshots:
+		return snapshot, nil
+	case <-time.After(time.Second):
+		return resourceSnapshot[T]{}, errors.New("timed out waiting for resource snapshot")
+	}
+}
+
+func waitForResourceSnapshot[T any](resource Resource[T], match func(resourceSnapshot[T]) bool) (resourceSnapshot[T], error) {
+	deadline := time.After(time.Second)
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		snapshot := snapshotResource(resource)
+		if match(snapshot) {
+			return snapshot, nil
+		}
+
+		select {
+		case <-ticker.C:
+		case <-deadline:
+			return resourceSnapshot[T]{}, fmt.Errorf("timed out waiting for matching resource snapshot; last snapshot = %#v", snapshot)
+		}
+	}
+}
+
+func waitClosed(done <-chan struct{}, subject string) error {
+	select {
+	case <-done:
+		return nil
+	case <-time.After(time.Second):
+		return fmt.Errorf("timed out waiting for %s", subject)
+	}
+}
+
+type resourceUnmountFixture struct {
+	resource Resource[string]
+	started  chan struct{}
+	release  chan struct{}
+	finished chan struct{}
+}
+
+func (f *resourceUnmountFixture) Init(ctx Context) {
+	f.resource = ResourceOfFunc(ctx, func() (string, error) {
+		close(f.started)
+		<-f.release
+		close(f.finished)
+		return "late", nil
+	})
+}


### PR DESCRIPTION
## Summary

- Added the public `Resource[T]` access interface and concrete `ResourceValue[T]` runtime storage.
- Added `ResourceOfFunc(ctx, load)` with immediate async loading, `Reload`, loading/error/value state, stale-result suppression, and cleanup through `Context.OnCleanup`.
- Added pure Go coverage for loading, success, error, reload, watcher invalidation when reload enters loading state, and unmount cleanup ignoring late in-flight results.

## Validation

- `go fmt ./...`
- `go test . -run 'TestResource' -count=1`
- `go test ./...`
- `go test -race ./...`
- `git diff --cached --check`
