### PR TITLE
Implemented tue fmt.

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -41,7 +41,7 @@ func Run(args []string, stdout, stderr io.Writer) int {
 	case "dev":
 		return runDev(args[1:], stdout, stderr)
 	case "fmt":
-		return runStub(args[0], args[1:], stdout, stderr)
+		return runFmt(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "tue: unknown command %q\n\n", args[0])
 		printUsage(stderr)
@@ -140,15 +140,6 @@ func runBuild(args []string, stdout, stderr io.Writer) int {
 	}
 
 	return exitOK
-}
-
-func runStub(command string, args []string, stdout, stderr io.Writer) int {
-	if _, code, ok := parseProjectRoot(command, args, stdout, stderr); !ok {
-		return code
-	}
-
-	fmt.Fprintf(stderr, "tue %s: not implemented yet\n", command)
-	return exitError
 }
 
 func parseProjectRoot(command string, args []string, stdout, stderr io.Writer) (string, int, bool) {
@@ -380,7 +371,7 @@ Commands:
   check [project-root]  Parse and check .tue files under a project root.
   build [project-root]  Generate static production files under dist.
   dev [project-root]    Start the Tue dev server.
-  fmt [project-root]    Format Tue source files. Not implemented yet.
+  fmt [project-root]    Format Tue source files.
 `)
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 //go:embed testdata/*.tue
@@ -82,28 +84,6 @@ func TestRunRejectsUnknownCommand(t *testing.T) {
 	}
 }
 
-func TestRunStubCommandsReturnNotImplemented(t *testing.T) {
-	for _, command := range []string{"fmt"} {
-		t.Run(command, func(t *testing.T) {
-			var stdout bytes.Buffer
-			var stderr bytes.Buffer
-
-			code := Run([]string{command}, &stdout, &stderr)
-
-			if code != exitError {
-				t.Errorf("Run(%s) exit code actual = %d, expected %d", command, code, exitError)
-			}
-			if stdout.Len() != 0 {
-				t.Errorf("stdout actual = %q, expected empty", stdout.String())
-			}
-			expected := "tue " + command + ": not implemented yet"
-			if !strings.Contains(stderr.String(), expected) {
-				t.Errorf("stderr actual = %q, expected %q", stderr.String(), expected)
-			}
-		})
-	}
-}
-
 func TestRunDevPrintsHelp(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -121,6 +101,137 @@ func TestRunDevPrintsHelp(t *testing.T) {
 	}
 	if stderr.Len() != 0 {
 		t.Errorf("stderr actual = %q, expected empty", stderr.String())
+	}
+}
+
+func TestRunFmtPrintsHelp(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := Run([]string{"fmt", "--help"}, &stdout, &stderr)
+
+	if code != exitOK {
+		t.Errorf("Run(fmt --help) exit code actual = %d, expected %d", code, exitOK)
+	}
+	if !strings.Contains(stdout.String(), "tue fmt [project-root]") {
+		t.Errorf("stdout actual = %q, expected fmt usage", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr actual = %q, expected empty", stderr.String())
+	}
+}
+
+func TestRunFmtFormatsTueFiles(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "App.tue")
+	if err := writeFixture(path, "testdata/FmtUnformattedApp.tue"); err != nil {
+		t.Fatalf("setup App.tue: %v", err)
+	}
+	expected, err := cliFixture("testdata/FmtFormattedApp.tue")
+	if err != nil {
+		t.Fatalf("read expected fixture: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := Run([]string{"fmt", root}, &stdout, &stderr)
+
+	if code != exitOK {
+		t.Errorf("Run(fmt) exit code actual = %d, expected %d; stderr = %q", code, exitOK, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr actual = %q, expected empty", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "tue fmt: formatted 1 .tue file(s)") {
+		t.Errorf("stdout actual = %q, expected formatted summary", stdout.String())
+	}
+	actual, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read formatted App.tue: %v", err)
+	}
+	if diff := cmp.Diff(expected, string(actual)); diff != "" {
+		t.Errorf("mismatch formatted App.tue (-expected, +actual):\n%s", diff)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"fmt", root}, &stdout, &stderr)
+
+	if code != exitOK {
+		t.Errorf("Run(fmt idempotent) exit code actual = %d, expected %d; stderr = %q", code, exitOK, stderr.String())
+	}
+	actual, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read reformatted App.tue: %v", err)
+	}
+	if diff := cmp.Diff(expected, string(actual)); diff != "" {
+		t.Errorf("mismatch reformatted App.tue (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestRunFmtPreservesTemplateTextWhitespace(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "App.tue")
+	if err := writeFixture(path, "testdata/FmtWhitespaceUnformattedApp.tue"); err != nil {
+		t.Fatalf("setup App.tue: %v", err)
+	}
+	expected, err := cliFixture("testdata/FmtWhitespaceFormattedApp.tue")
+	if err != nil {
+		t.Fatalf("read expected fixture: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := Run([]string{"fmt", root}, &stdout, &stderr)
+
+	if code != exitOK {
+		t.Errorf("Run(fmt) exit code actual = %d, expected %d; stderr = %q", code, exitOK, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr actual = %q, expected empty", stderr.String())
+	}
+	actual, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read formatted App.tue: %v", err)
+	}
+	if diff := cmp.Diff(expected, string(actual)); diff != "" {
+		t.Errorf("mismatch whitespace-sensitive formatted App.tue (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestRunFmtReportsDiagnosticsWithoutWriting(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "App.tue")
+	source, err := cliFixture("testdata/FmtInvalidTemplate.tue")
+	if err != nil {
+		t.Fatalf("read invalid fixture: %v", err)
+	}
+	if err := writeFile(path, source); err != nil {
+		t.Fatalf("setup App.tue: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := Run([]string{"fmt", root}, &stdout, &stderr)
+
+	if code != exitError {
+		t.Errorf("Run(fmt invalid) exit code actual = %d, expected %d", code, exitError)
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("stdout actual = %q, expected empty", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), `App.tue:2:2: missing closing </main> tag`) {
+		t.Errorf("stderr actual = %q, expected template diagnostic", stderr.String())
+	}
+	actual, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read invalid App.tue: %v", err)
+	}
+	if diff := cmp.Diff(source, string(actual)); diff != "" {
+		t.Errorf("mismatch invalid App.tue after fmt (-expected, +actual):\n%s", diff)
 	}
 }
 

--- a/internal/cli/fmt.go
+++ b/internal/cli/fmt.go
@@ -1,0 +1,396 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	goformat "go/format"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/norunners/tue/internal/compiler/checker"
+	"github.com/norunners/tue/internal/compiler/sfc"
+	compilerTemplate "github.com/norunners/tue/internal/compiler/template"
+)
+
+func runFmt(args []string, stdout, stderr io.Writer) int {
+	root, code, ok := parseProjectRoot("fmt", args, stdout, stderr)
+	if !ok {
+		return code
+	}
+
+	files, err := discoverTueFiles(root)
+	if err != nil {
+		fmt.Fprintf(stderr, "tue fmt: %v\n", err)
+		return exitError
+	}
+
+	formattedFiles, diagnostics, err := formatTueFiles(root, files)
+	if err != nil {
+		fmt.Fprintf(stderr, "tue fmt: %v\n", err)
+		return exitError
+	}
+	if len(diagnostics) != 0 {
+		printDiagnostics(stderr, diagnostics)
+		return exitError
+	}
+
+	for _, file := range formattedFiles {
+		if !file.changed {
+			continue
+		}
+		if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(file.path)), file.source, 0o644); err != nil {
+			fmt.Fprintf(stderr, "tue fmt: write %s: %v\n", file.path, err)
+			return exitError
+		}
+	}
+
+	fmt.Fprintf(stdout, "tue fmt: formatted %d .tue file(s) in %s\n", len(files), filepath.Clean(root))
+	return exitOK
+}
+
+type formattedTueFile struct {
+	path    string
+	source  []byte
+	changed bool
+}
+
+func formatTueFiles(root string, paths []string) ([]formattedTueFile, []checker.Diagnostic, error) {
+	files := make([]formattedTueFile, 0, len(paths))
+	var diagnostics []checker.Diagnostic
+
+	for _, path := range paths {
+		source, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(path)))
+		if err != nil {
+			return nil, nil, fmt.Errorf("read %s: %w", path, err)
+		}
+
+		formatted, fileDiagnostics, err := formatTueSource(path, source)
+		if err != nil {
+			return nil, nil, err
+		}
+		diagnostics = append(diagnostics, fileDiagnostics...)
+		if len(fileDiagnostics) != 0 {
+			continue
+		}
+		files = append(files, formattedTueFile{
+			path:    path,
+			source:  formatted,
+			changed: !bytes.Equal(source, formatted),
+		})
+	}
+
+	return files, diagnostics, nil
+}
+
+func formatTueSource(path string, source []byte) ([]byte, []checker.Diagnostic, error) {
+	file, sfcDiagnostics := sfc.Parse(path, source)
+	if len(sfcDiagnostics) != 0 {
+		return nil, sfcDiagnosticsFor(path, sfcDiagnostics), nil
+	}
+
+	blockContents := make(map[*sfc.Block]string, len(file.Blocks))
+	for _, block := range file.Blocks {
+		content, diagnostics, err := formatTueBlock(path, block)
+		if err != nil || len(diagnostics) != 0 {
+			return nil, diagnostics, err
+		}
+		blockContents[block] = content
+	}
+
+	return rebuildFormattedTueSource(source, file, blockContents), nil, nil
+}
+
+func formatTueBlock(path string, block *sfc.Block) (string, []checker.Diagnostic, error) {
+	switch block.Kind {
+	case sfc.BlockTemplate:
+		if _, diagnostics := compilerTemplate.ParseBlock(block); len(diagnostics) != 0 {
+			return "", templateDiagnosticsFor(path, diagnostics), nil
+		}
+		return formatTemplateContent(block.Content), nil, nil
+	case sfc.BlockScript:
+		formatted, err := goformat.Source([]byte(trimBlockBoundaryNewlines(block.Content)))
+		if err != nil {
+			return "", []checker.Diagnostic{{
+				Path:    path,
+				Message: fmt.Sprintf("format script block: %v", err),
+				Span:    block.ContentSpan,
+			}}, nil
+		}
+		return strings.TrimRight(string(formatted), "\n"), nil, nil
+	case sfc.BlockStyle:
+		return trimBlockBoundaryNewlines(block.Content), nil, nil
+	default:
+		return trimBlockBoundaryNewlines(block.Content), nil, nil
+	}
+}
+
+func rebuildFormattedTueSource(source []byte, file *sfc.File, blockContents map[*sfc.Block]string) []byte {
+	var builder strings.Builder
+	for i, block := range file.Blocks {
+		if i > 0 {
+			builder.WriteString("\n\n")
+		}
+
+		builder.WriteString(sourceSpan(source, block.OpenTagSpan))
+		builder.WriteByte('\n')
+		if content := blockContents[block]; content != "" {
+			builder.WriteString(content)
+			builder.WriteByte('\n')
+		}
+		builder.WriteString(sourceSpan(source, block.CloseTagSpan))
+	}
+	builder.WriteByte('\n')
+	return []byte(builder.String())
+}
+
+func sourceSpan(source []byte, span sfc.Span) string {
+	start := span.Start.Offset
+	end := span.End.Offset
+	if start < 0 {
+		start = 0
+	}
+	if end > len(source) {
+		end = len(source)
+	}
+	if start > end {
+		start = end
+	}
+	return string(source[start:end])
+}
+
+func formatTemplateContent(source string) string {
+	source = trimBlockBoundaryNewlines(source)
+	if strings.TrimSpace(source) == "" {
+		return ""
+	}
+
+	tree, diagnostics := compilerTemplate.ParseBlock(&sfc.Block{Content: source})
+	if len(diagnostics) != 0 {
+		return source
+	}
+	protectedLines := templateTextLines(source, tree)
+
+	lines := strings.Split(source, "\n")
+	formatted := make([]string, 0, len(lines))
+	indent := 1
+	for index, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			if len(formatted) > 0 && formatted[len(formatted)-1] != "" {
+				formatted = append(formatted, "")
+			}
+			continue
+		}
+
+		if protectedLines[index] {
+			formatted = append(formatted, line)
+			indent += templateLineIndentDelta(trimmed)
+			if indent < 0 {
+				indent = 0
+			}
+			continue
+		}
+
+		lineIndent := indent
+		if strings.HasPrefix(trimmed, "</") && lineIndent > 0 {
+			lineIndent--
+		}
+		formatted = append(formatted, strings.Repeat("\t", lineIndent)+trimmed)
+
+		indent += templateLineIndentDelta(trimmed)
+		if indent < 0 {
+			indent = 0
+		}
+	}
+
+	for len(formatted) > 0 && formatted[len(formatted)-1] == "" {
+		formatted = formatted[:len(formatted)-1]
+	}
+	return strings.Join(formatted, "\n")
+}
+
+type templateContentLine struct {
+	start int
+	end   int
+}
+
+func templateTextLines(source string, tree *compilerTemplate.Tree) map[int]bool {
+	lines := templateContentLines(source)
+	protected := make(map[int]bool)
+	var walk func(nodes []*compilerTemplate.Node)
+	walk = func(nodes []*compilerTemplate.Node) {
+		for _, node := range nodes {
+			if node.Kind == compilerTemplate.NodeText {
+				markTemplateTextLines(source, lines, protected, node.ContentSpan.Start.Offset, node.ContentSpan.End.Offset)
+			}
+			walk(node.Children)
+		}
+	}
+	if tree != nil {
+		walk(tree.Nodes)
+	}
+	return protected
+}
+
+func templateContentLines(source string) []templateContentLine {
+	lines := make([]templateContentLine, 0, strings.Count(source, "\n")+1)
+	start := 0
+	for start <= len(source) {
+		end := strings.IndexByte(source[start:], '\n')
+		if end == -1 {
+			lines = append(lines, templateContentLine{start: start, end: len(source)})
+			break
+		}
+		end += start
+		lines = append(lines, templateContentLine{start: start, end: end})
+		start = end + 1
+	}
+	return lines
+}
+
+func markTemplateTextLines(source string, lines []templateContentLine, protected map[int]bool, start int, end int) {
+	start, end = trimTemplateSpaceRange(source, start, end)
+	if start == end {
+		return
+	}
+
+	for index, line := range lines {
+		if start < line.end && end > line.start {
+			protected[index] = true
+		}
+	}
+}
+
+func trimTemplateSpaceRange(source string, start int, end int) (int, int) {
+	if start < 0 {
+		start = 0
+	}
+	if end > len(source) {
+		end = len(source)
+	}
+	if start > end {
+		start = end
+	}
+	for start < end && isTemplateSpace(source[start]) {
+		start++
+	}
+	for end > start && isTemplateSpace(source[end-1]) {
+		end--
+	}
+	return start, end
+}
+
+func templateLineIndentDelta(line string) int {
+	delta := 0
+	for offset := 0; offset < len(line); {
+		if strings.HasPrefix(line[offset:], "<!--") {
+			end := strings.Index(line[offset+len("<!--"):], "-->")
+			if end == -1 {
+				return delta
+			}
+			offset += len("<!--") + end + len("-->")
+			continue
+		}
+		if line[offset] != '<' || offset+1 >= len(line) {
+			offset++
+			continue
+		}
+
+		if line[offset+1] == '/' {
+			if end := templateTagEnd(line, offset); end != -1 {
+				delta--
+				offset = end
+				continue
+			}
+		}
+		if !isTemplateTagNameStart(line[offset+1]) {
+			offset++
+			continue
+		}
+
+		end := templateTagEnd(line, offset)
+		if end == -1 {
+			return delta
+		}
+		name := templateTagName(line, offset+1, end)
+		if name != "" && !isVoidTemplateTag(name) && !isSelfClosingTemplateTag(line[offset:end]) {
+			delta++
+		}
+		offset = end
+	}
+	return delta
+}
+
+func templateTagEnd(source string, start int) int {
+	var quote byte
+	for offset := start + 1; offset < len(source); offset++ {
+		current := source[offset]
+		if quote != 0 {
+			if current == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch current {
+		case '\'', '"':
+			quote = current
+		case '>':
+			return offset + 1
+		}
+	}
+	return -1
+}
+
+func templateTagName(source string, start int, end int) string {
+	offset := start
+	for offset < end && isTemplateTagNameChar(source[offset]) {
+		offset++
+	}
+	return source[start:offset]
+}
+
+func isSelfClosingTemplateTag(tag string) bool {
+	offset := len(tag) - 1
+	if offset >= 0 && tag[offset] == '>' {
+		offset--
+	}
+	for offset >= 0 && isTemplateSpace(tag[offset]) {
+		offset--
+	}
+	return offset >= 0 && tag[offset] == '/'
+}
+
+func isVoidTemplateTag(name string) bool {
+	switch strings.ToLower(name) {
+	case "area", "base", "br", "col", "embed", "hr", "img", "input",
+		"link", "meta", "param", "source", "track", "wbr":
+		return true
+	default:
+		return false
+	}
+}
+
+func isTemplateTagNameStart(value byte) bool {
+	return value >= 'A' && value <= 'Z' || value >= 'a' && value <= 'z'
+}
+
+func isTemplateTagNameChar(value byte) bool {
+	return isTemplateTagNameStart(value) || value >= '0' && value <= '9' || value == '-' || value == '_' || value == ':'
+}
+
+func isTemplateSpace(value byte) bool {
+	switch value {
+	case ' ', '\n', '\r', '\t', '\f':
+		return true
+	default:
+		return false
+	}
+}
+
+func trimBlockBoundaryNewlines(source string) string {
+	source = strings.ReplaceAll(source, "\r\n", "\n")
+	source = strings.ReplaceAll(source, "\r", "\n")
+	return strings.Trim(source, "\n")
+}

--- a/internal/cli/testdata/FmtFormattedApp.tue
+++ b/internal/cli/testdata/FmtFormattedApp.tue
@@ -1,0 +1,18 @@
+<template>
+	<main>
+		<p>{{ name }}</p>
+		<UserBadge name="Ada" />
+	</main>
+</template>
+
+<script lang="go">
+package app
+
+type App struct{ name string }
+
+func (a *App) greet() string { return a.name }
+</script>
+
+<style scoped>
+.page { color: red; }
+</style>

--- a/internal/cli/testdata/FmtInvalidTemplate.tue
+++ b/internal/cli/testdata/FmtInvalidTemplate.tue
@@ -1,0 +1,9 @@
+<template>
+	<main>
+</template>
+
+<script lang="go">
+package app
+
+type App struct{}
+</script>

--- a/internal/cli/testdata/FmtUnformattedApp.tue
+++ b/internal/cli/testdata/FmtUnformattedApp.tue
@@ -1,0 +1,16 @@
+<template>
+<main>
+<p>{{ name }}</p>
+<UserBadge name="Ada" />
+</main>
+</template>
+
+<script lang="go">
+package app
+type App struct{ name string}
+func (a *App) greet( ) string { return a.name}
+</script>
+
+<style scoped>
+.page { color: red; }
+</style>

--- a/internal/cli/testdata/FmtWhitespaceFormattedApp.tue
+++ b/internal/cli/testdata/FmtWhitespaceFormattedApp.tue
@@ -1,0 +1,19 @@
+<template>
+	<main>
+		<pre>
+  first
+    second
+		</pre>
+<p>  padded label  </p>
+ keep leading space
+		<section>
+			<span>{{ label }}</span>
+		</section>
+	</main>
+</template>
+
+<script lang="go">
+package app
+
+type App struct{ label string }
+</script>

--- a/internal/cli/testdata/FmtWhitespaceUnformattedApp.tue
+++ b/internal/cli/testdata/FmtWhitespaceUnformattedApp.tue
@@ -1,0 +1,18 @@
+<template>
+<main>
+<pre>
+  first
+    second
+</pre>
+<p>  padded label  </p>
+ keep leading space
+<section>
+<span>{{ label }}</span>
+</section>
+</main>
+</template>
+
+<script lang="go">
+package app
+type App struct{ label string}
+</script>


### PR DESCRIPTION
## Summary

- Implemented `tue fmt [project-root]` as an in-place `.tue` formatter.
- Formatted Go script blocks with `gofmt`, conservatively indented structural template lines, and preserved block order plus raw block tags.
- Preserved template lines containing meaningful text nodes so formatting does not change rendered text, including whitespace-sensitive `<pre>` content and padded inline text.
- Left style block declarations and comments alone except for line-ending and surrounding block-boundary newline normalization.
- Added fixture-backed tests for formatting, idempotence, help output, diagnostic/no-write behavior, and whitespace-sensitive template text.

## Notes

- Local `docs/` updates were kept out of this PR per project workflow.
- Template formatting intentionally avoids attribute reflow and expression rewriting.

## Validation

- `go fmt ./...`
- `go test ./internal/cli -run 'TestRunFmt' -count=1`
- `go test ./internal/cli -count=1`
- `go test ./...`
- `go test -race ./internal/cli -count=1`
- `git diff --check`
- `git diff --cached --check`