### PR TITLE
Added realistic examples.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.tokensave/
+.tue-cache/
+dist/

--- a/README.md
+++ b/README.md
@@ -13,10 +13,18 @@ The pre-migration Vue runtime and examples remain available on the
 ## Current State
 
 - The GitHub repository and Go module path are `github.com/norunners/tue`.
-- The active root package is intentionally a placeholder until the Tue runtime
-  is rebuilt in reviewable slices.
-- Initial `.tue` source fixtures live under `testdata/fixtures/`; they define
-  the intended component shape before parser/runtime work lands.
+- Tue currently includes the runtime, compiler, CLI, production build, dev
+  server, and formatter slices needed for small internal-app examples.
+- Realistic `.tue` examples live under [`examples/`](examples/). They cover a
+  todo queue, user table, settings form, and dashboard.
+
+Try an example from the repository root:
+
+```bash
+go run ./cmd/tue check examples/todo
+go run ./cmd/tue dev examples/todo
+go run ./cmd/tue build examples/todo
+```
 
 ## Verification
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,22 @@
+# Tue Examples
+
+These examples are intentionally small internal-app screens that exercise Tue's
+current compiler and runtime surface.
+
+Run commands from the repository root:
+
+```bash
+go run ./cmd/tue check examples/todo
+go run ./cmd/tue dev examples/todo
+go run ./cmd/tue build examples/todo
+```
+
+Replace `todo` with any example directory:
+
+- `todo`: refs, events, `v-model`, keyed lists, dynamic classes, and filtered list state
+- `user-table`: text filtering, checkbox state, derived list state, and table rendering
+- `settings-form`: string and boolean `v-model` controls with save/dirty feedback
+- `dashboard`: component props, default slots, scoped styles, and child components
+
+`tue dev` serves the generated `dist/` directory and rebuilds as files change.
+`tue build` writes production output to the example's `dist/` directory.

--- a/examples/dashboard/ActivityItem.tue
+++ b/examples/dashboard/ActivityItem.tue
@@ -1,0 +1,41 @@
+<template>
+	<article class="activity-item" :class="tone">
+		<span>{{ time }}</span>
+		<p>{{ message }}</p>
+	</article>
+</template>
+
+<script lang="go">
+package app
+
+import tue "github.com/norunners/tue"
+
+type ActivityItem struct {
+	message tue.Prop[string] `prop:"message,required"`
+	time    tue.Prop[string] `prop:"time,required"`
+	tone    tue.Prop[string] `prop:"tone"`
+}
+</script>
+
+<style scoped>
+.activity-item {
+	align-items: center;
+	border-bottom: 1px solid #eaecf0;
+	display: flex;
+	gap: 1rem;
+	padding-block: 0.75rem;
+}
+
+.activity-item span {
+	color: #667085;
+	font-variant-numeric: tabular-nums;
+}
+
+.healthy p {
+	color: #067647;
+}
+
+.warning p {
+	color: #b54708;
+}
+</style>

--- a/examples/dashboard/App.tue
+++ b/examples/dashboard/App.tue
@@ -1,0 +1,128 @@
+<template>
+	<main class="dashboard-shell">
+		<header>
+			<p class="eyebrow">Executive overview</p>
+			<h1>Dashboard</h1>
+			<p>{{ headline }}</p>
+		</header>
+
+		<section class="metrics">
+			<div v-for="metric in metrics" :key="metric.id">
+				<MetricCard :label="metric.label" :value="metric.value" :tone="metric.tone">
+					<span>{{ metric.detail }}</span>
+				</MetricCard>
+			</div>
+		</section>
+
+		<section class="activity">
+			<div class="activity-header">
+				<h2>Recent activity</h2>
+				<button type="button" @click="toggleActivity">{{ activityAction }}</button>
+			</div>
+			<div v-for="item in visibleActivity" :key="item.id">
+				<ActivityItem :message="item.message" :time="item.time" :tone="item.tone" />
+			</div>
+		</section>
+	</main>
+</template>
+
+<script lang="go">
+package app
+
+import tue "github.com/norunners/tue"
+
+type metric struct {
+	id     int
+	label  string
+	value  string
+	detail string
+	tone   string
+}
+
+type activityItem struct {
+	id        int
+	message   string
+	time      string
+	tone      string
+	important bool
+}
+
+type App struct {
+	headline        tue.Ref[string]
+	activityAction  tue.Ref[string]
+	showAllActivity tue.Ref[bool]
+	visibleActivity tue.Ref[[]activityItem]
+	metrics         []metric
+	activity        []activityItem
+}
+
+func (a *App) Init(tue.Context) {
+	a.headline = tue.RefOf("All critical workflows are inside target thresholds.")
+	a.activityAction = tue.RefOf("Show all")
+	a.showAllActivity = tue.RefOf(false)
+	a.visibleActivity = tue.RefOf([]activityItem{})
+	a.metrics = []metric{
+		{id: 1, label: "Open incidents", value: "3", detail: "Two fewer than yesterday", tone: "warning"},
+		{id: 2, label: "SLA health", value: "99.2%", detail: "On track", tone: "healthy"},
+		{id: 3, label: "Deploy queue", value: "7", detail: "Next release at 14:00", tone: "neutral"},
+	}
+	a.activity = []activityItem{
+		{id: 1, message: "Payments release passed smoke checks", time: "09:12", tone: "healthy", important: true},
+		{id: 2, message: "New support escalation assigned", time: "10:04", tone: "warning", important: true},
+		{id: 3, message: "Analytics backfill completed", time: "10:37", tone: "neutral"},
+		{id: 4, message: "Security review scheduled", time: "11:15", tone: "neutral"},
+	}
+	a.updateVisibleActivity()
+}
+
+func (a *App) toggleActivity() {
+	a.showAllActivity.Set(!a.showAllActivity.Get())
+	if a.showAllActivity.Get() {
+		a.activityAction.Set("Show important")
+	} else {
+		a.activityAction.Set("Show all")
+	}
+	a.updateVisibleActivity()
+}
+
+func (a *App) updateVisibleActivity() {
+	visible := make([]activityItem, 0, len(a.activity))
+	for _, item := range a.activity {
+		if a.showAllActivity.Get() || item.important {
+			visible = append(visible, item)
+		}
+	}
+	a.visibleActivity.Set(visible)
+}
+</script>
+
+<style scoped>
+.dashboard-shell {
+	font-family: system-ui, sans-serif;
+	margin: 2rem;
+}
+
+.eyebrow {
+	color: #5b6472;
+	font-size: 0.75rem;
+	text-transform: uppercase;
+}
+
+.metrics {
+	display: grid;
+	gap: 1rem;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	margin-block: 1.5rem;
+}
+
+.activity {
+	border-top: 1px solid #d0d5dd;
+	padding-top: 1rem;
+}
+
+.activity-header {
+	align-items: center;
+	display: flex;
+	justify-content: space-between;
+}
+</style>

--- a/examples/dashboard/MetricCard.tue
+++ b/examples/dashboard/MetricCard.tue
@@ -1,0 +1,51 @@
+<template>
+	<section class="metric-card" :class="tone">
+		<p>{{ label }}</p>
+		<strong>{{ value }}</strong>
+		<slot>
+			<span>No detail</span>
+		</slot>
+	</section>
+</template>
+
+<script lang="go">
+package app
+
+import tue "github.com/norunners/tue"
+
+type MetricCard struct {
+	label tue.Prop[string] `prop:"label,required"`
+	value tue.Prop[string] `prop:"value,required"`
+	tone  tue.Prop[string] `prop:"tone"`
+}
+</script>
+
+<style scoped>
+.metric-card {
+	border: 1px solid #d0d5dd;
+	display: grid;
+	gap: 0.5rem;
+	padding: 1rem;
+}
+
+.metric-card p {
+	color: #5b6472;
+	margin: 0;
+}
+
+.metric-card strong {
+	font-size: 1.75rem;
+}
+
+.healthy {
+	border-color: #079455;
+}
+
+.warning {
+	border-color: #dc6803;
+}
+
+.neutral {
+	border-color: #667085;
+}
+</style>

--- a/examples/settings-form/App.tue
+++ b/examples/settings-form/App.tue
@@ -1,0 +1,146 @@
+<template>
+	<main class="app-shell">
+		<header>
+			<p class="eyebrow">Admin</p>
+			<h1>Settings Form</h1>
+			<p :class="statusClass">{{ status }}</p>
+		</header>
+
+		<section class="settings-grid">
+			<label>
+				Workspace name
+				<input v-model="workspaceName" @input="markDirty" />
+			</label>
+
+			<label>
+				Owner email
+				<input v-model="ownerEmail" @input="markDirty" />
+			</label>
+
+			<label>
+				Theme
+				<select v-model="theme" @change="markDirty">
+					<option value="system">System</option>
+					<option value="light">Light</option>
+					<option value="dark">Dark</option>
+				</select>
+			</label>
+
+			<label>
+				Density
+				<select v-model="density" @change="markDirty">
+					<option value="comfortable">Comfortable</option>
+					<option value="compact">Compact</option>
+				</select>
+			</label>
+
+			<label class="toggle">
+				<input type="checkbox" v-model="weeklyDigest" @change="markDirty" />
+				Send weekly digest
+			</label>
+
+			<label class="notes">
+				Release notes
+				<input v-model="notes" @input="markDirty" />
+			</label>
+		</section>
+
+		<footer>
+			<button type="button" @click="save">Save settings</button>
+			<p v-if="saved" class="saved">Saved changes are ready to publish.</p>
+		</footer>
+	</main>
+</template>
+
+<script lang="go">
+package app
+
+import tue "github.com/norunners/tue"
+
+type App struct {
+	workspaceName tue.Ref[string]
+	ownerEmail    tue.Ref[string]
+	theme         tue.Ref[string]
+	density       tue.Ref[string]
+	weeklyDigest  tue.Ref[bool]
+	notes         tue.Ref[string]
+	saved         tue.Ref[bool]
+	status        tue.Ref[string]
+	statusClass   tue.Ref[string]
+}
+
+func (a *App) Init(tue.Context) {
+	a.workspaceName = tue.RefOf("Control Room")
+	a.ownerEmail = tue.RefOf("ops@example.com")
+	a.theme = tue.RefOf("system")
+	a.density = tue.RefOf("comfortable")
+	a.weeklyDigest = tue.RefOf(true)
+	a.notes = tue.RefOf("Publish weekly status updates every Friday.")
+	a.saved = tue.RefOf(false)
+	a.status = tue.RefOf("No unsaved changes")
+	a.statusClass = tue.RefOf("status")
+}
+
+func (a *App) markDirty() {
+	a.saved.Set(false)
+	a.status.Set("Unsaved changes")
+	a.statusClass.Set("status dirty")
+}
+
+func (a *App) save() {
+	a.saved.Set(true)
+	a.status.Set("Settings saved")
+	a.statusClass.Set("status saved")
+}
+</script>
+
+<style scoped>
+.app-shell {
+	font-family: system-ui, sans-serif;
+	margin: 2rem;
+	max-width: 860px;
+}
+
+.eyebrow {
+	color: #5b6472;
+	font-size: 0.75rem;
+	text-transform: uppercase;
+}
+
+.status {
+	color: #344054;
+}
+
+.status.dirty {
+	color: #b42318;
+}
+
+.status.saved,
+.saved {
+	color: #067647;
+}
+
+.settings-grid {
+	display: grid;
+	gap: 1rem;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+label {
+	display: grid;
+	gap: 0.375rem;
+}
+
+.toggle,
+.notes {
+	grid-column: 1 / -1;
+}
+
+.notes input {
+	min-height: 7rem;
+}
+
+footer {
+	margin-top: 1.5rem;
+}
+</style>

--- a/examples/todo/App.tue
+++ b/examples/todo/App.tue
@@ -1,0 +1,191 @@
+<template>
+	<main class="app-shell">
+		<header>
+			<p class="eyebrow">Operations</p>
+			<h1>Todo Queue</h1>
+			<p :class="summaryClass">{{ summary }}</p>
+		</header>
+
+		<section class="toolbar">
+			<input v-model="newTodo" @input="markEditing" placeholder="Add an operational follow-up" />
+			<button type="button" @click="addTodo">Add</button>
+			<label>
+				<input type="checkbox" v-model="showDone" @change="showDoneChanged" />
+				Show completed
+			</label>
+			<button type="button" @click="archiveDone">Archive completed</button>
+		</section>
+
+		<ul class="todo-list">
+			<li v-for="todo in visibleTodos" :key="todo.id" class="todo-row" :class="todo.className">
+				<span>{{ todo.text }}</span>
+				<strong v-if="todo.done">Done</strong>
+				<strong v-if="!todo.done">Open</strong>
+			</li>
+		</ul>
+	</main>
+</template>
+
+<script lang="go">
+package app
+
+import (
+	"strconv"
+	"strings"
+
+	tue "github.com/norunners/tue"
+)
+
+type todo struct {
+	id        int
+	text      string
+	done      bool
+	className string
+}
+
+type App struct {
+	newTodo      tue.Ref[string]
+	showDone     tue.Ref[bool]
+	summary      tue.Ref[string]
+	summaryClass tue.Ref[string]
+	visibleTodos tue.Ref[[]todo]
+	nextID       int
+	todos        []todo
+}
+
+func (a *App) Init(tue.Context) {
+	a.newTodo = tue.RefOf("")
+	a.showDone = tue.RefOf(true)
+	a.summary = tue.RefOf("")
+	a.summaryClass = tue.RefOf("summary")
+	a.visibleTodos = tue.RefOf([]todo{})
+	a.nextID = 4
+	a.todos = []todo{
+		{id: 1, text: "Review support escalations", className: "priority-high"},
+		{id: 2, text: "Prepare weekly metrics", done: true, className: "muted"},
+		{id: 3, text: "Confirm launch checklist", className: "priority-medium"},
+	}
+	a.updateSummary()
+	a.updateVisibleTodos()
+}
+
+func (a *App) markEditing() {
+	a.summaryClass.Set("summary editing")
+}
+
+func (a *App) addTodo() {
+	text := strings.TrimSpace(a.newTodo.Get())
+	if text == "" {
+		a.summaryClass.Set("summary warning")
+		return
+	}
+	a.todos = append(a.todos, todo{
+		id:        a.nextID,
+		text:      text,
+		className: "priority-medium",
+	})
+	a.nextID++
+	a.newTodo.Set("")
+	a.summaryClass.Set("summary updated")
+	a.updateSummary()
+	a.updateVisibleTodos()
+}
+
+func (a *App) archiveDone() {
+	open := a.todos[:0]
+	for _, item := range a.todos {
+		if !item.done {
+			open = append(open, item)
+		}
+	}
+	a.todos = open
+	a.summaryClass.Set("summary updated")
+	a.updateSummary()
+	a.updateVisibleTodos()
+}
+
+func (a *App) showDoneChanged() {
+	a.updateVisibleTodos()
+}
+
+func (a *App) updateSummary() {
+	open := 0
+	for _, item := range a.todos {
+		if !item.done {
+			open++
+		}
+	}
+	a.summary.Set("Open items: " + strconv.Itoa(open))
+}
+
+func (a *App) updateVisibleTodos() {
+	visible := make([]todo, 0, len(a.todos))
+	for _, item := range a.todos {
+		if a.showDone.Get() || !item.done {
+			visible = append(visible, item)
+		}
+	}
+	a.visibleTodos.Set(visible)
+}
+</script>
+
+<style scoped>
+.app-shell {
+	font-family: system-ui, sans-serif;
+	margin: 2rem;
+	max-width: 760px;
+}
+
+.eyebrow {
+	color: #5b6472;
+	font-size: 0.75rem;
+	text-transform: uppercase;
+}
+
+.summary {
+	color: #344054;
+}
+
+.summary.warning {
+	color: #b42318;
+}
+
+.summary.updated,
+.summary.editing {
+	color: #067647;
+}
+
+.toolbar {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.75rem;
+	margin-block: 1.5rem;
+}
+
+.todo-list {
+	display: grid;
+	gap: 0.5rem;
+	list-style: none;
+	padding: 0;
+}
+
+.todo-row {
+	align-items: center;
+	border: 1px solid #d0d5dd;
+	display: flex;
+	justify-content: space-between;
+	padding: 0.75rem;
+}
+
+.priority-high {
+	border-color: #d92d20;
+}
+
+.priority-medium {
+	border-color: #f79009;
+}
+
+.muted {
+	color: #667085;
+}
+</style>

--- a/examples/user-table/App.tue
+++ b/examples/user-table/App.tue
@@ -1,0 +1,153 @@
+<template>
+	<main class="app-shell">
+		<header>
+			<p class="eyebrow">Directory</p>
+			<h1>User Table</h1>
+			<p>{{ status }}</p>
+		</header>
+
+		<section class="filters">
+			<input v-model="query" @input="applyFilter" placeholder="Filter by name, email, or role" />
+			<label>
+				<input type="checkbox" v-model="showInactive" @change="inactiveVisibilityChanged" />
+				Show inactive users
+			</label>
+			<button type="button" @click="toggleInactive">{{ toggleLabel }}</button>
+		</section>
+
+		<table>
+			<thead>
+				<tr>
+					<th>Name</th>
+					<th>Email</th>
+					<th>Role</th>
+					<th>Status</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr v-for="user in visibleUsers" :key="user.id" :class="user.rowClass">
+					<td>{{ user.name }}</td>
+					<td>{{ user.email }}</td>
+					<td>{{ user.role }}</td>
+					<td>{{ user.status }}</td>
+				</tr>
+			</tbody>
+		</table>
+	</main>
+</template>
+
+<script lang="go">
+package app
+
+import (
+	"strconv"
+	"strings"
+
+	tue "github.com/norunners/tue"
+)
+
+type user struct {
+	id       int
+	name     string
+	email    string
+	role     string
+	active   bool
+	status   string
+	rowClass string
+	match    bool
+}
+
+type App struct {
+	query        tue.Ref[string]
+	showInactive tue.Ref[bool]
+	toggleLabel  tue.Ref[string]
+	status       tue.Ref[string]
+	visibleUsers tue.Ref[[]user]
+	users        []user
+}
+
+func (a *App) Init(tue.Context) {
+	a.query = tue.RefOf("")
+	a.showInactive = tue.RefOf(false)
+	a.toggleLabel = tue.RefOf("Show inactive")
+	a.status = tue.RefOf("")
+	a.visibleUsers = tue.RefOf([]user{})
+	a.users = []user{
+		{id: 1, name: "Ada Lovelace", email: "ada@example.com", role: "Admin", active: true, status: "Active", rowClass: "active", match: true},
+		{id: 2, name: "Grace Hopper", email: "grace@example.com", role: "Operator", active: true, status: "Active", rowClass: "active", match: true},
+		{id: 3, name: "Katherine Johnson", email: "katherine@example.com", role: "Analyst", active: false, status: "Suspended", rowClass: "inactive", match: true},
+		{id: 4, name: "Mary Jackson", email: "mary@example.com", role: "Reviewer", active: true, status: "Active", rowClass: "active", match: true},
+	}
+	a.refreshVisibleUsers()
+}
+
+func (a *App) applyFilter() {
+	needle := strings.ToLower(strings.TrimSpace(a.query.Get()))
+	for index := range a.users {
+		haystack := strings.ToLower(a.users[index].name + " " + a.users[index].email + " " + a.users[index].role)
+		a.users[index].match = needle == "" || strings.Contains(haystack, needle)
+	}
+	a.refreshVisibleUsers()
+}
+
+func (a *App) toggleInactive() {
+	a.showInactive.Set(!a.showInactive.Get())
+	a.inactiveVisibilityChanged()
+}
+
+func (a *App) inactiveVisibilityChanged() {
+	if a.showInactive.Get() {
+		a.toggleLabel.Set("Hide inactive")
+	} else {
+		a.toggleLabel.Set("Show inactive")
+	}
+	a.refreshVisibleUsers()
+}
+
+func (a *App) refreshVisibleUsers() {
+	visible := make([]user, 0, len(a.users))
+	for _, item := range a.users {
+		if item.match && (a.showInactive.Get() || item.active) {
+			visible = append(visible, item)
+		}
+	}
+	a.visibleUsers.Set(visible)
+	a.status.Set("Visible users: " + strconv.Itoa(len(visible)))
+}
+</script>
+
+<style scoped>
+.app-shell {
+	font-family: system-ui, sans-serif;
+	margin: 2rem;
+}
+
+.eyebrow {
+	color: #5b6472;
+	font-size: 0.75rem;
+	text-transform: uppercase;
+}
+
+.filters {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.75rem;
+	margin-block: 1rem;
+}
+
+table {
+	border-collapse: collapse;
+	width: 100%;
+}
+
+th,
+td {
+	border-bottom: 1px solid #eaecf0;
+	padding: 0.75rem;
+	text-align: left;
+}
+
+.inactive {
+	color: #667085;
+}
+</style>

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"embed"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/norunners/tue/internal/compiler/sfc"
+	gotemplate "github.com/norunners/tue/internal/compiler/template"
 )
 
 //go:embed testdata/*.tue
@@ -232,6 +235,88 @@ func TestRunFmtReportsDiagnosticsWithoutWriting(t *testing.T) {
 	}
 	if diff := cmp.Diff(source, string(actual)); diff != "" {
 		t.Errorf("mismatch invalid App.tue after fmt (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestExamplesCheckAndBuild(t *testing.T) {
+	examples := []string{"todo", "user-table", "settings-form", "dashboard"}
+	for _, example := range examples {
+		t.Run(example, func(t *testing.T) {
+			sourceRoot := filepath.Join("..", "..", "examples", example)
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			code := Run([]string{"check", sourceRoot}, &stdout, &stderr)
+
+			if code != exitOK {
+				t.Fatalf("Run(check %s) exit code actual = %d, expected %d; stderr = %q", example, code, exitOK, stderr.String())
+			}
+			if stderr.Len() != 0 {
+				t.Errorf("stderr actual = %q, expected empty", stderr.String())
+			}
+
+			buildRoot := filepath.Join(t.TempDir(), example)
+			if err := copyExampleProject(sourceRoot, buildRoot); err != nil {
+				t.Fatalf("copy example project: %v", err)
+			}
+
+			stdout.Reset()
+			stderr.Reset()
+			code = Run([]string{"build", buildRoot}, &stdout, &stderr)
+
+			if code != exitOK {
+				t.Fatalf("Run(build %s) exit code actual = %d, expected %d; stderr = %q", example, code, exitOK, stderr.String())
+			}
+			if stderr.Len() != 0 {
+				t.Errorf("stderr actual = %q, expected empty", stderr.String())
+			}
+			for _, path := range []string{
+				filepath.Join("dist", "app.wasm"),
+				filepath.Join("dist", "index.html"),
+				filepath.Join("dist", "manifest.json"),
+				filepath.Join("dist", "style.css"),
+				filepath.Join("dist", "tue_loader.js"),
+			} {
+				if _, err := os.Stat(filepath.Join(buildRoot, path)); err != nil {
+					t.Errorf("generated file %s should exist: %v", path, err)
+				}
+			}
+		})
+	}
+}
+
+func TestExamplesAvoidSameNodeForIf(t *testing.T) {
+	examples := []string{"todo", "user-table", "settings-form", "dashboard"}
+	for _, example := range examples {
+		t.Run(example, func(t *testing.T) {
+			root := filepath.Join("..", "..", "examples", example)
+			err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+				if walkErr != nil {
+					return walkErr
+				}
+				if entry.IsDir() || filepath.Ext(path) != ".tue" {
+					return nil
+				}
+
+				source, err := os.ReadFile(path)
+				if err != nil {
+					return fmt.Errorf("read %s: %w", path, err)
+				}
+				file, diagnostics := sfc.Parse(path, source)
+				if len(diagnostics) != 0 {
+					return fmt.Errorf("sfc.Parse(%s) diagnostics = %#v", path, sfcDiagnosticMessages(diagnostics))
+				}
+				tree, templateDiagnostics := gotemplate.ParseBlock(file.Template)
+				if len(templateDiagnostics) != 0 {
+					return fmt.Errorf("template.ParseBlock(%s) diagnostics = %#v", path, templateDiagnosticMessages(templateDiagnostics))
+				}
+				assertNoSameNodeForIf(t, path, tree.Nodes)
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("walk example templates: %v", err)
+			}
+		})
 	}
 }
 
@@ -665,6 +750,62 @@ func writeFixture(path string, fixture string) error {
 	return writeFile(path, contents)
 }
 
+func copyExampleProject(sourceRoot string, targetRoot string) error {
+	return filepath.WalkDir(sourceRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if path != sourceRoot && entry.IsDir() {
+			switch entry.Name() {
+			case ".tue-cache", "dist":
+				return filepath.SkipDir
+			}
+		}
+
+		relativePath, err := filepath.Rel(sourceRoot, path)
+		if err != nil {
+			return err
+		}
+		targetPath := filepath.Join(targetRoot, relativePath)
+		if entry.IsDir() {
+			return os.MkdirAll(targetPath, 0o755)
+		}
+		if !entry.Type().IsRegular() {
+			return nil
+		}
+
+		source, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+		return writeFile(targetPath, string(source))
+	})
+}
+
+func assertNoSameNodeForIf(t *testing.T, path string, nodes []*gotemplate.Node) {
+	t.Helper()
+
+	for _, node := range nodes {
+		if node == nil {
+			continue
+		}
+		if nodeHasDirective(node, gotemplate.DirectiveFor) && nodeHasDirective(node, gotemplate.DirectiveIf) {
+			t.Errorf("%s:%d:%d should avoid v-for and v-if on the same element", path, node.Span.Start.Line, node.Span.Start.Column)
+		}
+		assertNoSameNodeForIf(t, path, node.Children)
+	}
+}
+
+func nodeHasDirective(node *gotemplate.Node, directive gotemplate.DirectiveKind) bool {
+	for _, attr := range node.Attrs {
+		if attr.Kind == gotemplate.AttrDirective && attr.Directive == directive {
+			return true
+		}
+	}
+	return false
+}
+
 func writeFile(path string, contents string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
@@ -681,4 +822,20 @@ func cliFixture(path string) (string, error) {
 		return "", fmt.Errorf("read embedded fixture %s: %w", path, err)
 	}
 	return string(source), nil
+}
+
+func sfcDiagnosticMessages(diagnostics []sfc.Diagnostic) []string {
+	messages := make([]string, len(diagnostics))
+	for i, diagnostic := range diagnostics {
+		messages[i] = diagnostic.Message
+	}
+	return messages
+}
+
+func templateDiagnosticMessages(diagnostics []gotemplate.Diagnostic) []string {
+	messages := make([]string, len(diagnostics))
+	for i, diagnostic := range diagnostics {
+		messages[i] = diagnostic.Message
+	}
+	return messages
 }


### PR DESCRIPTION
## Summary

- Added four realistic Tue example project roots: todo queue, user table, settings form, and dashboard.
- Documented example commands and learning goals in `examples/README.md`, and refreshed the root README current-state section.
- Added `.gitignore` entries for generated Tue output so running example builds does not dirty the checkout.
- Added CLI regression coverage that checks and production-builds temp copies of every example root.

## Review Fixes

- Reworked list examples to avoid same-element `v-for` plus `v-if`, matching Vue 3 example guidance instead of teaching a discouraged pattern.
- Added explicit derived visible-list state for todo, user-table, and dashboard examples so filtered rows remain clear and reactive with Tue's current expression surface.
- Added v-model change handlers for controls that affect derived UI: inactive-user visibility updates row count and button text, and the settings weekly digest checkbox marks saved settings dirty again.
- Added parser-backed regression coverage that rejects same-node `v-for`/`v-if` in examples.

## Notes

- Interactive example state uses `tue.Ref` for event-driven and `v-model` fields so browser events trigger rerenders through the current runtime reactivity model.
- Local `docs/` updates were kept out of this PR per project workflow.

## Validation

- `go run ./cmd/tue fmt examples`
- `go run ./cmd/tue check examples/todo`
- `go run ./cmd/tue check examples/user-table`
- `go run ./cmd/tue check examples/settings-form`
- `go run ./cmd/tue check examples/dashboard`
- `go test ./internal/cli -run 'TestExamples(CheckAndBuild|AvoidSameNodeForIf)' -count=1`
- `go test ./internal/cli -count=1`
- `go fmt ./...`
- `go test ./...`
- `git diff --check`
- `git diff --cached --check`
- Browser smoke: served temporary production builds of `examples/user-table` and `examples/settings-form` and verified the reviewed checkbox interactions in headless system Chrome through the Chrome DevTools Protocol.
