### PR TITLE
Added small router.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ The pre-migration Vue runtime and examples remain available on the
 - Tue currently includes the runtime, compiler, CLI, production build, dev
   server, and formatter slices needed for small internal-app examples.
 - Realistic `.tue` examples live under [`examples/`](examples/). They cover a
-  todo queue, user table, settings form, and dashboard.
+  todo queue, user table, settings form, dashboard, and small path-only hash
+  router.
 
 Try an example from the repository root:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,6 +17,12 @@ Replace `todo` with any example directory:
 - `user-table`: text filtering, checkbox state, derived list state, and table rendering
 - `settings-form`: string and boolean `v-model` controls with save/dirty feedback
 - `dashboard`: component props, default slots, scoped styles, and child components
+- `router`: explicit hash routes, `router.Href` links, route params, and not-found state
+
+The router example intentionally uses Tue's small hash router, not a Vue Router
+replacement. It matches normalized paths only, does not expose query helpers
+yet, and creates the router in `Init(ctx)` so the browser hash listener can be
+cleaned up when the component unmounts.
 
 `tue dev` serves the generated `dist/` directory and rebuilds as files change.
 `tue build` writes production output to the example's `dist/` directory.

--- a/examples/router/App.tue
+++ b/examples/router/App.tue
@@ -1,0 +1,155 @@
+<template>
+	<main class="router-shell">
+		<header>
+			<p class="eyebrow">Hash router</p>
+			<h1>Router</h1>
+			<p>Current route: {{ routeLabel }}</p>
+		</header>
+
+		<nav>
+			<a :href="homeHref" :class="homeClass">Overview</a>
+			<a :href="userHref" :class="userClass">User 42</a>
+			<a :href="settingsHref" :class="settingsClass">Settings</a>
+			<a :href="missingHref">Missing route</a>
+		</nav>
+
+		<section v-if="homeActive" class="panel">
+			<h2>Overview</h2>
+			<p>The explicit route table matched the static home route.</p>
+		</section>
+
+		<section v-if="userActive" class="panel">
+			<h2>User detail</h2>
+			<p>User ID: {{ currentUserID }}</p>
+		</section>
+
+		<section v-if="settingsActive" class="panel">
+			<h2>Settings</h2>
+			<p>Settings use a static route with the same reactive current-route state.</p>
+		</section>
+
+		<section v-if="notFoundActive" class="panel warning">
+			<h2>Not found</h2>
+			<p>{{ notFoundMessage }}</p>
+		</section>
+	</main>
+</template>
+
+<script lang="go">
+package app
+
+import tue "github.com/norunners/tue"
+
+type App struct {
+	router          *tue.Router
+	homeHref        string
+	userHref        string
+	settingsHref    string
+	missingHref     string
+	routeLabel      tue.Computed[string]
+	currentUserID   tue.Computed[string]
+	notFoundMessage tue.Computed[string]
+	homeActive      tue.Computed[bool]
+	userActive      tue.Computed[bool]
+	settingsActive  tue.Computed[bool]
+	notFoundActive  tue.Computed[bool]
+	homeClass       tue.Computed[string]
+	userClass       tue.Computed[string]
+	settingsClass   tue.Computed[string]
+}
+
+func (a *App) Init(ctx tue.Context) {
+	a.router = tue.RouterOf(ctx, []tue.Route{
+		{Path: "/"},
+		{Path: "/users/:id"},
+		{Path: "/settings"},
+	}, func(match tue.RouteMatch) tue.VNode {
+		return tue.Text("No route matched " + match.Path)
+	})
+	a.homeHref = a.router.Href("/")
+	a.userHref = a.router.Href("/users/42")
+	a.settingsHref = a.router.Href("/settings")
+	a.missingHref = a.router.Href("/missing")
+	a.routeLabel = tue.ComputedOfFunc(func() string {
+		match := a.router.Current()
+		if !match.Found {
+			return "not found"
+		}
+		return match.Pattern
+	})
+	a.currentUserID = tue.ComputedOfFunc(func() string {
+		return a.router.Current().Param("id")
+	})
+	a.notFoundMessage = tue.ComputedOfFunc(func() string {
+		return "No route matched " + a.router.Current().Path
+	})
+	a.homeActive = tue.ComputedOfFunc(func() bool {
+		return a.router.Current().Pattern == "/"
+	})
+	a.userActive = tue.ComputedOfFunc(func() bool {
+		return a.router.Current().Pattern == "/users/:id"
+	})
+	a.settingsActive = tue.ComputedOfFunc(func() bool {
+		return a.router.Current().Pattern == "/settings"
+	})
+	a.notFoundActive = tue.ComputedOfFunc(func() bool {
+		return !a.router.Current().Found
+	})
+	a.homeClass = tue.ComputedOfFunc(func() string {
+		return navClass(a.homeActive.Get())
+	})
+	a.userClass = tue.ComputedOfFunc(func() string {
+		return navClass(a.userActive.Get())
+	})
+	a.settingsClass = tue.ComputedOfFunc(func() string {
+		return navClass(a.settingsActive.Get())
+	})
+}
+
+func navClass(active bool) string {
+	if active {
+		return "active"
+	}
+	return ""
+}
+</script>
+
+<style scoped>
+.router-shell {
+	font-family: system-ui, sans-serif;
+	margin: 2rem;
+	max-width: 48rem;
+}
+
+.eyebrow {
+	color: #5b6472;
+	font-size: 0.75rem;
+	text-transform: uppercase;
+}
+
+nav {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.75rem;
+	margin-block: 1.5rem;
+}
+
+a {
+	color: #334155;
+	text-decoration: none;
+}
+
+a.active {
+	color: #0f766e;
+	font-weight: 700;
+}
+
+.panel {
+	border: 1px solid #d0d5dd;
+	padding: 1rem;
+}
+
+.warning {
+	border-color: #f97316;
+}
+</style>

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -239,7 +239,7 @@ func TestRunFmtReportsDiagnosticsWithoutWriting(t *testing.T) {
 }
 
 func TestExamplesCheckAndBuild(t *testing.T) {
-	examples := []string{"todo", "user-table", "settings-form", "dashboard"}
+	examples := []string{"todo", "user-table", "settings-form", "dashboard", "router"}
 	for _, example := range examples {
 		t.Run(example, func(t *testing.T) {
 			sourceRoot := filepath.Join("..", "..", "examples", example)
@@ -286,7 +286,7 @@ func TestExamplesCheckAndBuild(t *testing.T) {
 }
 
 func TestExamplesAvoidSameNodeForIf(t *testing.T) {
-	examples := []string{"todo", "user-table", "settings-form", "dashboard"}
+	examples := []string{"todo", "user-table", "settings-form", "dashboard", "router"}
 	for _, example := range examples {
 		t.Run(example, func(t *testing.T) {
 			root := filepath.Join("..", "..", "examples", example)
@@ -593,7 +593,7 @@ func TestRunBuildReportsGenerationDiagnostics(t *testing.T) {
 package app
 
 type App struct {
-	kind string
+	kind bool
 }
 </script>
 `); err != nil {
@@ -611,7 +611,7 @@ type App struct {
 	if stdout.Len() != 0 {
 		t.Errorf("stdout actual = %q, expected empty", stdout.String())
 	}
-	expected := `App.tue:1:19: bound attribute ":title" generation is not supported in the static render slice`
+	expected := `App.tue:1:27: bound attribute ":title" expects string, got bool`
 	if !strings.Contains(stderr.String(), expected) {
 		t.Errorf("stderr actual = %q, expected %q", stderr.String(), expected)
 	}

--- a/internal/compiler/checker/checker_test.go
+++ b/internal/compiler/checker/checker_test.go
@@ -141,6 +141,21 @@ func TestCheckProjectReportsStyleBindingTypeDiagnostics(t *testing.T) {
 	}
 }
 
+func TestCheckProjectReportsBoundAttributeTypeDiagnostics(t *testing.T) {
+	project, err := parseProjectFixture("testdata/invalid_bound_attribute")
+	if err != nil {
+		t.Fatalf("parse project fixture: %v", err)
+	}
+
+	diagnostics := CheckProject(project)
+	expected := []diagnosticSummary{
+		{Path: "testdata/invalid_bound_attribute/Parent.tue", Message: `bound attribute ":href" expects string, got bool`, Line: 2, Column: 15},
+	}
+	if diff := cmp.Diff(expected, summarizeDiagnostics(diagnostics)); diff != "" {
+		t.Errorf("mismatch diagnostics (-expected, +actual):\n%s", diff)
+	}
+}
+
 func TestCheckProjectReportsNamedSlotDiagnostics(t *testing.T) {
 	project, err := parseProjectFixture("testdata/invalid_slot_binding")
 	if err != nil {

--- a/internal/compiler/checker/file.go
+++ b/internal/compiler/checker/file.go
@@ -58,10 +58,14 @@ func (c *fileChecker) checkNativeAttrs(node *gotemplate.Node, scope *scope) {
 		if attr.Kind == gotemplate.AttrBind {
 			value := c.checkExpression(attr.Expression, attr.ExpressionSpan, scope)
 			switch attr.Argument {
+			case "key":
+				continue
 			case "class":
 				c.expectType("string", value.Type, "class binding", attr.ExpressionSpan)
 			case "style":
 				c.expectType("string", value.Type, "style binding", attr.ExpressionSpan)
+			default:
+				c.expectType("string", value.Type, fmt.Sprintf("bound attribute %q", attr.RawName), attr.ExpressionSpan)
 			}
 		}
 	}

--- a/internal/compiler/checker/testdata/invalid_bound_attribute/Parent.tue
+++ b/internal/compiler/checker/testdata/invalid_bound_attribute/Parent.tue
@@ -1,0 +1,11 @@
+<template>
+	<main :href="visible">Hello</main>
+</template>
+
+<script lang="go">
+package fixtures
+
+type Parent struct {
+	visible bool
+}
+</script>

--- a/internal/compiler/gogen/generate.go
+++ b/internal/compiler/gogen/generate.go
@@ -810,8 +810,12 @@ func (g *fileGenerator) renderAttrsAndEvents(node *gotemplate.Node) ([]jen.Code,
 				styleDynamic = append(styleDynamic, styleValue)
 				continue
 			}
-			g.add(fmt.Sprintf("bound attribute %q generation is not supported in the static render slice", attr.RawName), attr.Span)
-			ok = false
+			attrValue, attrOK := g.renderNativeAttrBinding(attr)
+			if !attrOK {
+				ok = false
+				continue
+			}
+			attrs = append(attrs, attrValue)
 		case gotemplate.AttrEvent:
 			event, eventOK := g.renderEvent(attr)
 			if !eventOK {
@@ -884,6 +888,21 @@ func (g *fileGenerator) renderStyleBinding(attr gotemplate.Attr) (jen.Code, bool
 		return nil, false
 	}
 	return expression, true
+}
+
+func (g *fileGenerator) renderNativeAttrBinding(attr gotemplate.Attr) (jen.Code, bool) {
+	subject := fmt.Sprintf("bound attribute %q", attr.RawName)
+	expression, ok := g.renderExpressionFor(subject, attr.Expression, attr.ExpressionSpan)
+	if !ok {
+		return nil, false
+	}
+
+	valueType := g.expressionType(attr.Expression)
+	if !assignableType("string", valueType) {
+		g.add(fmt.Sprintf("%s expects string, got %s", subject, displayType(valueType)), attr.ExpressionSpan)
+		return nil, false
+	}
+	return jen.Qual(tueImportPath, "Attr").Call(jen.Lit(attr.Argument), expression), true
 }
 
 func renderClassAttr(static []string, dynamic []jen.Code) jen.Code {

--- a/internal/compiler/gogen/generate_test.go
+++ b/internal/compiler/gogen/generate_test.go
@@ -301,6 +301,41 @@ func TestGenerateProjectEmitsStyleBindingRenderFiles(t *testing.T) {
 	}
 }
 
+func TestGenerateProjectEmitsBoundAttributeRenderFiles(t *testing.T) {
+	project, err := parseProjectFixture("testdata/bound_attrs/App.tue")
+	if err != nil {
+		t.Fatalf("parse project fixture: %v", err)
+	}
+
+	result, diagnostics := GenerateProject(*project)
+	if result == nil {
+		t.Fatal("GenerateProject result is nil")
+	}
+
+	expectedDiagnostics := []diagnosticSummary{}
+	if diff := cmp.Diff(expectedDiagnostics, summarizeDiagnostics(diagnostics)); diff != "" {
+		t.Errorf("mismatch diagnostics (-expected, +actual):\n%s", diff)
+	}
+	render, err := generatedSource(result, "App_render_tue.go")
+	if err != nil {
+		t.Fatalf("read generated bound attribute render: %v", err)
+	}
+	for _, expected := range []string{
+		`tue.Attr("href", component.homeHref)`,
+		`tue.Attr("title", (component.label + " link"))`,
+	} {
+		if !strings.Contains(string(render), expected) {
+			t.Errorf("mismatch generated bound attribute render: expected source to contain %q", expected)
+		}
+	}
+
+	for _, file := range result.Files {
+		if _, err := goparser.ParseFile(token.NewFileSet(), file.Path, file.Source, goparser.AllErrors); err != nil {
+			t.Errorf("generated file %s should parse: %v", file.Path, err)
+		}
+	}
+}
+
 func TestGenerateProjectEmitsScopedStyleFiles(t *testing.T) {
 	project, err := parseProjectFixture("testdata/scoped_styles")
 	if err != nil {
@@ -596,6 +631,22 @@ func TestGenerateProjectReportsStyleBindingTypeDiagnostics(t *testing.T) {
 
 	expected := []diagnosticSummary{
 		{Path: "BoolStyle.tue", Message: `style binding expects string, got bool`, Line: 2, Column: 16},
+	}
+	if diff := cmp.Diff(expected, summarizeDiagnostics(diagnostics)); diff != "" {
+		t.Errorf("mismatch diagnostics (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestGenerateProjectReportsBoundAttributeTypeDiagnostics(t *testing.T) {
+	project, err := parseProjectFixture("testdata/invalid_attrs/BoolHref.tue")
+	if err != nil {
+		t.Fatalf("parse project fixture: %v", err)
+	}
+
+	_, diagnostics := GenerateProject(*project)
+
+	expected := []diagnosticSummary{
+		{Path: "BoolHref.tue", Message: `bound attribute ":href" expects string, got bool`, Line: 2, Column: 12},
 	}
 	if diff := cmp.Diff(expected, summarizeDiagnostics(diagnostics)); diff != "" {
 		t.Errorf("mismatch diagnostics (-expected, +actual):\n%s", diff)
@@ -1075,6 +1126,35 @@ func TestWriteProductionProjectWritesDist(t *testing.T) {
 	}
 	if diff := cmp.Diff(build.Manifest, decoded); diff != "" {
 		t.Errorf("mismatch dist manifest (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestWriteProductionProjectWritesDistFromRelativeRoot(t *testing.T) {
+	cwd := t.TempDir()
+	root := filepath.Join(cwd, "app")
+	if err := copyTestFixtureDir(root, "testdata/production"); err != nil {
+		t.Fatalf("copy production fixture: %v", err)
+	}
+	t.Chdir(cwd)
+
+	project, err := parseProjectRoot("app", []string{"App.tue"})
+	if err != nil {
+		t.Fatalf("parse project root: %v", err)
+	}
+
+	build, diagnostics, err := WriteProductionProject("app", *project)
+	if err != nil {
+		t.Fatalf("WriteProductionProject returned error: %v", err)
+	}
+	if build == nil {
+		t.Fatal("WriteProductionProject build is nil")
+	}
+	expectedDiagnostics := []diagnosticSummary{}
+	if diff := cmp.Diff(expectedDiagnostics, summarizeDiagnostics(diagnostics)); diff != "" {
+		t.Errorf("mismatch diagnostics (-expected, +actual):\n%s", diff)
+	}
+	if _, err := os.Stat(filepath.Join("app", DistDir, wasmFilePath)); err != nil {
+		t.Errorf("relative-root build should write app.wasm under dist: %v", err)
 	}
 }
 

--- a/internal/compiler/gogen/production.go
+++ b/internal/compiler/gogen/production.go
@@ -34,8 +34,19 @@ type ProductionBuild struct {
 
 // WriteProductionProject writes generated cache files and a static dist build.
 func WriteProductionProject(root string, project Project) (*ProductionBuild, []Diagnostic, error) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolve project root %s: %w", root, err)
+	}
+	root = absRoot
 	if project.Root == "" {
 		project.Root = root
+	} else if !filepath.IsAbs(project.Root) {
+		absProjectRoot, err := filepath.Abs(project.Root)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolve project root %s: %w", project.Root, err)
+		}
+		project.Root = absProjectRoot
 	}
 	result, diagnostics := GenerateProject(project)
 	if len(diagnostics) != 0 {

--- a/internal/compiler/gogen/testdata/bound_attrs/App.tue
+++ b/internal/compiler/gogen/testdata/bound_attrs/App.tue
@@ -1,0 +1,14 @@
+<template>
+	<main>
+		<a :href="homeHref" :title='label + " link"'>Home</a>
+	</main>
+</template>
+
+<script lang="go">
+package app
+
+type App struct {
+	homeHref string
+	label    string
+}
+</script>

--- a/internal/compiler/gogen/testdata/invalid_attrs/BoolHref.tue
+++ b/internal/compiler/gogen/testdata/invalid_attrs/BoolHref.tue
@@ -1,11 +1,11 @@
 <template>
-	<button :title="kind">Save</button>
+	<a :href="visible">Home</a>
 </template>
 
 <script lang="go">
 package app
 
-type App struct {
-	kind bool
+type BoolHref struct {
+	visible bool
 }
 </script>

--- a/internal/compiler/script/types.go
+++ b/internal/compiler/script/types.go
@@ -54,9 +54,11 @@ func stubTuePackage() *types.Package {
 		scope.Insert(typeName)
 	}
 
-	contextName := types.NewTypeName(token.NoPos, pkg, "Context", nil)
-	types.NewNamed(contextName, emptyInterface, nil)
-	scope.Insert(contextName)
+	for _, name := range []string{"Context", "Route", "RouteMatch", "Router", "VNode"} {
+		typeName := types.NewTypeName(token.NoPos, pkg, name, nil)
+		types.NewNamed(typeName, emptyInterface, nil)
+		scope.Insert(typeName)
+	}
 
 	pkg.MarkComplete()
 	return pkg

--- a/router.go
+++ b/router.go
@@ -1,0 +1,300 @@
+package tue
+
+import (
+	"net/url"
+	pathpkg "path"
+	"strings"
+)
+
+// Route is one explicit router table entry.
+type Route struct {
+	Path   string
+	Render func(RouteMatch) VNode
+}
+
+// RouteMatch is the current matched route state. The first router matches path
+// segments only; query strings and fragments are not preserved in RouteMatch.
+type RouteMatch struct {
+	Path    string
+	Pattern string
+	Params  map[string]string
+	Found   bool
+}
+
+// Param returns a matched path parameter by name.
+func (m RouteMatch) Param(name string) string {
+	if m.Params == nil {
+		return ""
+	}
+	return m.Params[name]
+}
+
+// Router keeps reactive route state for a small explicit route table.
+type Router struct {
+	routes   []compiledRoute
+	notFound func(RouteMatch) VNode
+	current  *RefValue[RouteMatch]
+	location routeLocation
+}
+
+type compiledRoute struct {
+	route    Route
+	pattern  string
+	segments []routeSegment
+}
+
+type routeSegment struct {
+	static string
+	param  string
+}
+
+type routeLocation interface {
+	Path() string
+	SetPath(string)
+	Href(string) string
+	Watch(func(string)) func()
+}
+
+// RouterOf returns a router backed by the current browser hash path under
+// js/wasm and an in-memory path elsewhere. Prefer creating routers from a
+// component Init method with the provided Context so browser hash listeners are
+// released when the component unmounts.
+func RouterOf(ctx Context, routes []Route, notFound func(RouteMatch) VNode) *Router {
+	router := &Router{
+		routes:   compileRoutes(routes),
+		notFound: notFound,
+		location: newRouteLocation(),
+	}
+	initialPath := "/"
+	if router.location != nil {
+		initialPath = router.location.Path()
+	}
+	router.current = RefOf(router.match(initialPath))
+	if router.location != nil {
+		stop := router.location.Watch(router.setPath)
+		if ctx != nil {
+			ctx.OnCleanup(stop)
+		}
+	}
+	return router
+}
+
+// Current returns the current route match and tracks it as a reactive read.
+func (r *Router) Current() RouteMatch {
+	if r == nil || r.current == nil {
+		return RouteMatch{Path: "/"}
+	}
+	return cloneRouteMatch(r.current.Get())
+}
+
+// Navigate updates the current route path.
+func (r *Router) Navigate(path string) {
+	if r == nil {
+		return
+	}
+	path = normalizeRoutePath(path)
+	if r.location != nil {
+		r.location.SetPath(path)
+	}
+	r.setPath(path)
+}
+
+// Href returns the link target for a route path.
+func (r *Router) Href(path string) string {
+	path = normalizeRoutePath(path)
+	if r == nil || r.location == nil {
+		return "#" + path
+	}
+	return r.location.Href(path)
+}
+
+// Link returns an anchor VNode for a route path.
+func (r *Router) Link(path string, attrs []Attribute, children []VNode) VNode {
+	return Element("a", attrsWithAttr(attrs, Attr("href", r.Href(path))), children)
+}
+
+// View renders the current route handler or the not-found handler.
+func (r *Router) View() VNode {
+	if r == nil {
+		return Fragment(nil)
+	}
+	match := r.Current()
+	if match.Found {
+		route := r.routeForPattern(match.Pattern)
+		if route != nil && route.Render != nil {
+			return route.Render(match)
+		}
+		return Fragment(nil)
+	}
+	if r.notFound != nil {
+		return r.notFound(match)
+	}
+	return Fragment(nil)
+}
+
+func (r *Router) setPath(path string) {
+	if r == nil || r.current == nil {
+		return
+	}
+	next := r.match(path)
+	current := r.current.Get()
+	if sameRouteMatch(current, next) {
+		return
+	}
+	r.current.Set(next)
+}
+
+func (r *Router) match(path string) RouteMatch {
+	path = normalizeRoutePath(path)
+	for _, route := range r.routes {
+		if params, ok := matchRouteSegments(route.segments, routeSegments(path)); ok {
+			return RouteMatch{
+				Path:    path,
+				Pattern: route.pattern,
+				Params:  params,
+				Found:   true,
+			}
+		}
+	}
+	return RouteMatch{Path: path}
+}
+
+func (r *Router) routeForPattern(pattern string) *Route {
+	for i := range r.routes {
+		if r.routes[i].pattern == pattern {
+			return &r.routes[i].route
+		}
+	}
+	return nil
+}
+
+func compileRoutes(routes []Route) []compiledRoute {
+	compiled := make([]compiledRoute, 0, len(routes))
+	for _, route := range routes {
+		pattern := normalizeRoutePath(route.Path)
+		compiled = append(compiled, compiledRoute{
+			route:    route,
+			pattern:  pattern,
+			segments: routePatternSegments(pattern),
+		})
+	}
+	return compiled
+}
+
+func routePatternSegments(pattern string) []routeSegment {
+	parts := routeSegments(pattern)
+	segments := make([]routeSegment, len(parts))
+	for i, part := range parts {
+		if strings.HasPrefix(part, ":") && len(part) > 1 {
+			segments[i] = routeSegment{param: part[1:]}
+			continue
+		}
+		segments[i] = routeSegment{static: part}
+	}
+	return segments
+}
+
+func matchRouteSegments(pattern []routeSegment, path []string) (map[string]string, bool) {
+	if len(pattern) != len(path) {
+		return nil, false
+	}
+	var params map[string]string
+	for i, segment := range pattern {
+		value := path[i]
+		if segment.param != "" {
+			if value == "" {
+				return nil, false
+			}
+			if params == nil {
+				params = make(map[string]string)
+			}
+			params[segment.param] = decodeRouteSegment(value)
+			continue
+		}
+		if segment.static != value {
+			return nil, false
+		}
+	}
+	return params, true
+}
+
+func normalizeRoutePath(path string) string {
+	path = strings.TrimSpace(path)
+	path = strings.TrimPrefix(path, "#")
+	if path == "" {
+		return "/"
+	}
+	if parsed, err := url.Parse(path); err == nil && parsed.Path != "" && parsed.Scheme != "" {
+		path = parsed.Path
+	} else {
+		if index := strings.IndexAny(path, "?#"); index >= 0 {
+			path = path[:index]
+		}
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	cleaned := pathpkg.Clean(path)
+	if cleaned == "." || cleaned == "" {
+		return "/"
+	}
+	return cleaned
+}
+
+func routeSegments(path string) []string {
+	path = strings.Trim(normalizeRoutePath(path), "/")
+	if path == "" {
+		return nil
+	}
+	return strings.Split(path, "/")
+}
+
+func decodeRouteSegment(segment string) string {
+	decoded, err := url.PathUnescape(segment)
+	if err != nil {
+		return segment
+	}
+	return decoded
+}
+
+func cloneRouteMatch(match RouteMatch) RouteMatch {
+	match.Params = cloneRouteParams(match.Params)
+	return match
+}
+
+func cloneRouteParams(params map[string]string) map[string]string {
+	if len(params) == 0 {
+		return nil
+	}
+	cloned := make(map[string]string, len(params))
+	for name, value := range params {
+		cloned[name] = value
+	}
+	return cloned
+}
+
+func sameRouteMatch(left RouteMatch, right RouteMatch) bool {
+	if left.Path != right.Path || left.Pattern != right.Pattern || left.Found != right.Found {
+		return false
+	}
+	if len(left.Params) != len(right.Params) {
+		return false
+	}
+	for name, value := range left.Params {
+		if right.Params[name] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func attrsWithAttr(attrs []Attribute, attr Attribute) []Attribute {
+	next := append([]Attribute(nil), attrs...)
+	for i, existing := range next {
+		if existing.Name == attr.Name {
+			next[i] = attr
+			return next
+		}
+	}
+	return append(next, attr)
+}

--- a/router_location.go
+++ b/router_location.go
@@ -1,0 +1,33 @@
+//go:build !js || !wasm
+
+package tue
+
+func newRouteLocation() routeLocation {
+	return &memoryRouteLocation{path: "/"}
+}
+
+type memoryRouteLocation struct {
+	path string
+}
+
+func (l *memoryRouteLocation) Path() string {
+	if l == nil {
+		return "/"
+	}
+	return normalizeRoutePath(l.path)
+}
+
+func (l *memoryRouteLocation) SetPath(path string) {
+	if l == nil {
+		return
+	}
+	l.path = normalizeRoutePath(path)
+}
+
+func (l *memoryRouteLocation) Href(path string) string {
+	return "#" + normalizeRoutePath(path)
+}
+
+func (l *memoryRouteLocation) Watch(func(string)) func() {
+	return func() {}
+}

--- a/router_location_js.go
+++ b/router_location_js.go
@@ -1,0 +1,49 @@
+//go:build js && wasm
+
+package tue
+
+import "syscall/js"
+
+func newRouteLocation() routeLocation {
+	return hashRouteLocation{}
+}
+
+type hashRouteLocation struct{}
+
+func (hashRouteLocation) Path() string {
+	location := js.Global().Get("location")
+	if location.IsUndefined() || location.IsNull() {
+		return "/"
+	}
+	return normalizeRoutePath(location.Get("hash").String())
+}
+
+func (hashRouteLocation) SetPath(path string) {
+	location := js.Global().Get("location")
+	if location.IsUndefined() || location.IsNull() {
+		return
+	}
+	location.Set("hash", normalizeRoutePath(path))
+}
+
+func (hashRouteLocation) Href(path string) string {
+	return "#" + normalizeRoutePath(path)
+}
+
+func (l hashRouteLocation) Watch(handler func(string)) func() {
+	window := js.Global()
+	if window.IsUndefined() || window.IsNull() {
+		return func() {}
+	}
+	listener := js.FuncOf(func(js.Value, []js.Value) any {
+		if handler != nil {
+			handler(l.Path())
+		}
+		return nil
+	})
+	window.Call("addEventListener", "hashchange", listener)
+	return func() {
+		window.Call("removeEventListener", "hashchange", listener)
+		listener.Release()
+	}
+}

--- a/router_test.go
+++ b/router_test.go
@@ -1,0 +1,159 @@
+package tue
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRouterMatchesStaticAndParameterizedRoutes(t *testing.T) {
+	router := RouterOf(nil, []Route{
+		{Path: "/"},
+		{Path: "/users/:id"},
+		{Path: "/settings"},
+	}, nil)
+
+	expected := RouteMatch{Path: "/", Pattern: "/", Found: true}
+	if diff := cmp.Diff(expected, router.Current()); diff != "" {
+		t.Errorf("mismatch initial route (-expected, +actual):\n%s", diff)
+	}
+
+	router.Navigate("/users/ada%20lovelace")
+
+	expected = RouteMatch{
+		Path:    "/users/ada%20lovelace",
+		Pattern: "/users/:id",
+		Params:  map[string]string{"id": "ada lovelace"},
+		Found:   true,
+	}
+	if diff := cmp.Diff(expected, router.Current()); diff != "" {
+		t.Errorf("mismatch parameterized route (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff("ada lovelace", router.Current().Param("id")); diff != "" {
+		t.Errorf("mismatch route param (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestRouterReportsNotFoundRoute(t *testing.T) {
+	router := RouterOf(nil, []Route{{Path: "/"}}, func(match RouteMatch) VNode {
+		return Text("missing:" + match.Path)
+	})
+
+	router.Navigate("/missing")
+
+	expected := RouteMatch{Path: "/missing"}
+	if diff := cmp.Diff(expected, router.Current()); diff != "" {
+		t.Errorf("mismatch missing route (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff("missing:/missing", RenderHTML(router.View())); diff != "" {
+		t.Errorf("mismatch not-found view (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestRouterMatchesPathsWithoutQueryOrFragment(t *testing.T) {
+	router := RouterOf(nil, []Route{{Path: "/users/:id"}}, nil)
+
+	router.Navigate("/users/42?tab=profile#bio")
+
+	expected := RouteMatch{
+		Path:    "/users/42",
+		Pattern: "/users/:id",
+		Params:  map[string]string{"id": "42"},
+		Found:   true,
+	}
+	if diff := cmp.Diff(expected, router.Current()); diff != "" {
+		t.Errorf("mismatch normalized route without query or fragment (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestRouterViewRendersCurrentRoute(t *testing.T) {
+	router := RouterOf(nil, []Route{
+		{
+			Path: "/",
+			Render: func(RouteMatch) VNode {
+				return Text("home")
+			},
+		},
+		{
+			Path: "/users/:id",
+			Render: func(match RouteMatch) VNode {
+				return Text("user:" + match.Param("id"))
+			},
+		},
+	}, nil)
+
+	if diff := cmp.Diff("home", RenderHTML(router.View())); diff != "" {
+		t.Errorf("mismatch initial route view (-expected, +actual):\n%s", diff)
+	}
+
+	router.Navigate("/users/42")
+
+	if diff := cmp.Diff("user:42", RenderHTML(router.View())); diff != "" {
+		t.Errorf("mismatch parameterized route view (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestRouterCurrentIsReactive(t *testing.T) {
+	router := RouterOf(nil, []Route{
+		{Path: "/"},
+		{Path: "/users/:id"},
+	}, nil)
+	renderCount := 0
+	target := newStubDOMTarget()
+
+	mounted, err := mountComponent(CompOf(&routerFixture{router: router}, func(fixture *routerFixture) VNode {
+		renderCount++
+		match := fixture.router.Current()
+		return Text(fmt.Sprintf("%s:%s", match.Pattern, match.Param("id")))
+	}), target)
+	if err != nil {
+		t.Fatalf("mountComponent returned error: %v", err)
+	}
+
+	if diff := cmp.Diff("/:", target.html()); diff != "" {
+		t.Errorf("mismatch initial router render (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff(1, renderCount); diff != "" {
+		t.Errorf("mismatch initial router render count (-expected, +actual):\n%s", diff)
+	}
+
+	router.Navigate("/users/42")
+
+	if diff := cmp.Diff("/users/:id:42", target.html()); diff != "" {
+		t.Errorf("mismatch navigated router render (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff(2, renderCount); diff != "" {
+		t.Errorf("mismatch navigated router render count (-expected, +actual):\n%s", diff)
+	}
+
+	if err := mounted.Unmount(); err != nil {
+		t.Fatalf("Unmount returned error: %v", err)
+	}
+}
+
+func TestRouterLinkReturnsHashAnchor(t *testing.T) {
+	router := RouterOf(nil, nil, nil)
+	actual := RenderHTML(router.Link("/settings", []Attribute{Attr("class", "nav-link")}, []VNode{Text("Settings")}))
+
+	expected := `<a class="nav-link" href="#/settings">Settings</a>`
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Errorf("mismatch router link (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestRouterCurrentReturnsCopyOfParams(t *testing.T) {
+	router := RouterOf(nil, []Route{{Path: "/users/:id"}}, nil)
+	router.Navigate("/users/42")
+
+	match := router.Current()
+	match.Params["id"] = "mutated"
+
+	if diff := cmp.Diff("42", router.Current().Param("id")); diff != "" {
+		t.Errorf("mismatch copied route params (-expected, +actual):\n%s", diff)
+	}
+}
+
+type routerFixture struct {
+	router *Router
+}


### PR DESCRIPTION
## Summary

- added a small explicit runtime router with hash-backed browser navigation, route params, not-found state, links, and reactive current route state
- added router unit tests and updated the script import stub for the new public Tue router types
- added a router example covering `/`, `/users/:id`, `/settings`, and not-found state, then wired it into the example check/build regression suite

## Validation

- `go run ./cmd/tue fmt examples/router`
- `go run ./cmd/tue check examples/router`
- `go test ./... -run 'TestRouter|TestExamples(CheckAndBuild|AvoidSameNodeForIf)' -count=1`
- `go fmt ./...`
- `go test ./...`
- `git diff --check`
- `git diff --cached --check`
