### PR TITLE
Improved template compiler ergonomics.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -13,9 +13,9 @@ go run ./cmd/tue build examples/todo
 
 Replace `todo` with any example directory:
 
-- `todo`: refs, events, `v-model`, keyed lists, dynamic classes, and filtered list state
-- `user-table`: text filtering, checkbox state, derived list state, and table rendering
-- `settings-form`: string and boolean `v-model` controls with save/dirty feedback
+- `todo`: refs, events, `v-model`, keyed lists, dynamic classes, and method-derived filtered lists
+- `user-table`: text filtering, checkbox state, method-derived lists, and table rendering
+- `settings-form`: string and boolean `v-model` controls, including textarea, with save/dirty feedback
 - `dashboard`: component props, default slots, scoped styles, and child components
 - `router`: explicit hash routes, `router.Href` links, route params, and not-found state
 

--- a/examples/dashboard/App.tue
+++ b/examples/dashboard/App.tue
@@ -19,7 +19,7 @@
 				<h2>Recent activity</h2>
 				<button type="button" @click="toggleActivity">{{ activityAction }}</button>
 			</div>
-			<div v-for="item in visibleActivity" :key="item.id">
+			<div v-for="item in visibleActivity()" :key="item.id">
 				<ActivityItem :message="item.message" :time="item.time" :tone="item.tone" />
 			</div>
 		</section>
@@ -51,7 +51,6 @@ type App struct {
 	headline        tue.Ref[string]
 	activityAction  tue.Ref[string]
 	showAllActivity tue.Ref[bool]
-	visibleActivity tue.Ref[[]activityItem]
 	metrics         []metric
 	activity        []activityItem
 }
@@ -60,7 +59,6 @@ func (a *App) Init(tue.Context) {
 	a.headline = tue.RefOf("All critical workflows are inside target thresholds.")
 	a.activityAction = tue.RefOf("Show all")
 	a.showAllActivity = tue.RefOf(false)
-	a.visibleActivity = tue.RefOf([]activityItem{})
 	a.metrics = []metric{
 		{id: 1, label: "Open incidents", value: "3", detail: "Two fewer than yesterday", tone: "warning"},
 		{id: 2, label: "SLA health", value: "99.2%", detail: "On track", tone: "healthy"},
@@ -72,7 +70,6 @@ func (a *App) Init(tue.Context) {
 		{id: 3, message: "Analytics backfill completed", time: "10:37", tone: "neutral"},
 		{id: 4, message: "Security review scheduled", time: "11:15", tone: "neutral"},
 	}
-	a.updateVisibleActivity()
 }
 
 func (a *App) toggleActivity() {
@@ -82,17 +79,16 @@ func (a *App) toggleActivity() {
 	} else {
 		a.activityAction.Set("Show all")
 	}
-	a.updateVisibleActivity()
 }
 
-func (a *App) updateVisibleActivity() {
+func (a *App) visibleActivity() []activityItem {
 	visible := make([]activityItem, 0, len(a.activity))
 	for _, item := range a.activity {
 		if a.showAllActivity.Get() || item.important {
 			visible = append(visible, item)
 		}
 	}
-	a.visibleActivity.Set(visible)
+	return visible
 }
 </script>
 

--- a/examples/settings-form/App.tue
+++ b/examples/settings-form/App.tue
@@ -41,7 +41,7 @@
 
 			<label class="notes">
 				Release notes
-				<input v-model="notes" @input="markDirty" />
+				<textarea v-model="notes" @input="markDirty"></textarea>
 			</label>
 		</section>
 
@@ -136,7 +136,7 @@ label {
 	grid-column: 1 / -1;
 }
 
-.notes input {
+.notes textarea {
 	min-height: 7rem;
 }
 

--- a/examples/todo/App.tue
+++ b/examples/todo/App.tue
@@ -10,14 +10,14 @@
 			<input v-model="newTodo" @input="markEditing" placeholder="Add an operational follow-up" />
 			<button type="button" @click="addTodo">Add</button>
 			<label>
-				<input type="checkbox" v-model="showDone" @change="showDoneChanged" />
+				<input type="checkbox" v-model="showDone" />
 				Show completed
 			</label>
 			<button type="button" @click="archiveDone">Archive completed</button>
 		</section>
 
 		<ul class="todo-list">
-			<li v-for="todo in visibleTodos" :key="todo.id" class="todo-row" :class="todo.className">
+			<li v-for="todo in visibleTodos()" :key="todo.id" class="todo-row" :class="todo.className">
 				<span>{{ todo.text }}</span>
 				<strong v-if="todo.done">Done</strong>
 				<strong v-if="!todo.done">Open</strong>
@@ -48,7 +48,6 @@ type App struct {
 	showDone     tue.Ref[bool]
 	summary      tue.Ref[string]
 	summaryClass tue.Ref[string]
-	visibleTodos tue.Ref[[]todo]
 	nextID       int
 	todos        []todo
 }
@@ -58,7 +57,6 @@ func (a *App) Init(tue.Context) {
 	a.showDone = tue.RefOf(true)
 	a.summary = tue.RefOf("")
 	a.summaryClass = tue.RefOf("summary")
-	a.visibleTodos = tue.RefOf([]todo{})
 	a.nextID = 4
 	a.todos = []todo{
 		{id: 1, text: "Review support escalations", className: "priority-high"},
@@ -66,7 +64,6 @@ func (a *App) Init(tue.Context) {
 		{id: 3, text: "Confirm launch checklist", className: "priority-medium"},
 	}
 	a.updateSummary()
-	a.updateVisibleTodos()
 }
 
 func (a *App) markEditing() {
@@ -88,7 +85,6 @@ func (a *App) addTodo() {
 	a.newTodo.Set("")
 	a.summaryClass.Set("summary updated")
 	a.updateSummary()
-	a.updateVisibleTodos()
 }
 
 func (a *App) archiveDone() {
@@ -101,11 +97,6 @@ func (a *App) archiveDone() {
 	a.todos = open
 	a.summaryClass.Set("summary updated")
 	a.updateSummary()
-	a.updateVisibleTodos()
-}
-
-func (a *App) showDoneChanged() {
-	a.updateVisibleTodos()
 }
 
 func (a *App) updateSummary() {
@@ -118,14 +109,14 @@ func (a *App) updateSummary() {
 	a.summary.Set("Open items: " + strconv.Itoa(open))
 }
 
-func (a *App) updateVisibleTodos() {
+func (a *App) visibleTodos() []todo {
 	visible := make([]todo, 0, len(a.todos))
 	for _, item := range a.todos {
 		if a.showDone.Get() || !item.done {
 			visible = append(visible, item)
 		}
 	}
-	a.visibleTodos.Set(visible)
+	return visible
 }
 </script>
 

--- a/examples/user-table/App.tue
+++ b/examples/user-table/App.tue
@@ -3,16 +3,16 @@
 		<header>
 			<p class="eyebrow">Directory</p>
 			<h1>User Table</h1>
-			<p>{{ status }}</p>
+			<p>{{ status() }}</p>
 		</header>
 
 		<section class="filters">
-			<input v-model="query" @input="applyFilter" placeholder="Filter by name, email, or role" />
+			<input v-model="query" placeholder="Filter by name, email, or role" />
 			<label>
-				<input type="checkbox" v-model="showInactive" @change="inactiveVisibilityChanged" />
+				<input type="checkbox" v-model="showInactive" />
 				Show inactive users
 			</label>
-			<button type="button" @click="toggleInactive">{{ toggleLabel }}</button>
+			<button type="button" @click="toggleInactive">{{ toggleLabel() }}</button>
 		</section>
 
 		<table>
@@ -25,7 +25,7 @@
 				</tr>
 			</thead>
 			<tbody>
-				<tr v-for="user in visibleUsers" :key="user.id" :class="user.rowClass">
+				<tr v-for="user in visibleUsers()" :key="user.id" :class="user.rowClass">
 					<td>{{ user.name }}</td>
 					<td>{{ user.email }}</td>
 					<td>{{ user.role }}</td>
@@ -54,65 +54,51 @@ type user struct {
 	active   bool
 	status   string
 	rowClass string
-	match    bool
 }
 
 type App struct {
 	query        tue.Ref[string]
 	showInactive tue.Ref[bool]
-	toggleLabel  tue.Ref[string]
-	status       tue.Ref[string]
-	visibleUsers tue.Ref[[]user]
 	users        []user
 }
 
 func (a *App) Init(tue.Context) {
 	a.query = tue.RefOf("")
 	a.showInactive = tue.RefOf(false)
-	a.toggleLabel = tue.RefOf("Show inactive")
-	a.status = tue.RefOf("")
-	a.visibleUsers = tue.RefOf([]user{})
 	a.users = []user{
-		{id: 1, name: "Ada Lovelace", email: "ada@example.com", role: "Admin", active: true, status: "Active", rowClass: "active", match: true},
-		{id: 2, name: "Grace Hopper", email: "grace@example.com", role: "Operator", active: true, status: "Active", rowClass: "active", match: true},
-		{id: 3, name: "Katherine Johnson", email: "katherine@example.com", role: "Analyst", active: false, status: "Suspended", rowClass: "inactive", match: true},
-		{id: 4, name: "Mary Jackson", email: "mary@example.com", role: "Reviewer", active: true, status: "Active", rowClass: "active", match: true},
+		{id: 1, name: "Ada Lovelace", email: "ada@example.com", role: "Admin", active: true, status: "Active", rowClass: "active"},
+		{id: 2, name: "Grace Hopper", email: "grace@example.com", role: "Operator", active: true, status: "Active", rowClass: "active"},
+		{id: 3, name: "Katherine Johnson", email: "katherine@example.com", role: "Analyst", active: false, status: "Suspended", rowClass: "inactive"},
+		{id: 4, name: "Mary Jackson", email: "mary@example.com", role: "Reviewer", active: true, status: "Active", rowClass: "active"},
 	}
-	a.refreshVisibleUsers()
-}
-
-func (a *App) applyFilter() {
-	needle := strings.ToLower(strings.TrimSpace(a.query.Get()))
-	for index := range a.users {
-		haystack := strings.ToLower(a.users[index].name + " " + a.users[index].email + " " + a.users[index].role)
-		a.users[index].match = needle == "" || strings.Contains(haystack, needle)
-	}
-	a.refreshVisibleUsers()
 }
 
 func (a *App) toggleInactive() {
 	a.showInactive.Set(!a.showInactive.Get())
-	a.inactiveVisibilityChanged()
 }
 
-func (a *App) inactiveVisibilityChanged() {
+func (a *App) toggleLabel() string {
 	if a.showInactive.Get() {
-		a.toggleLabel.Set("Hide inactive")
-	} else {
-		a.toggleLabel.Set("Show inactive")
+		return "Hide inactive"
 	}
-	a.refreshVisibleUsers()
+	return "Show inactive"
 }
 
-func (a *App) refreshVisibleUsers() {
+func (a *App) status() string {
+	return "Visible users: " + strconv.Itoa(len(a.visibleUsers()))
+}
+
+func (a *App) visibleUsers() []user {
+	needle := strings.ToLower(strings.TrimSpace(a.query.Get()))
 	visible := make([]user, 0, len(a.users))
 	for _, item := range a.users {
-		if item.match && (a.showInactive.Get() || item.active) {
+		haystack := strings.ToLower(item.name + " " + item.email + " " + item.role)
+		match := needle == "" || strings.Contains(haystack, needle)
+		if match && (a.showInactive.Get() || item.active) {
 			visible = append(visible, item)
 		}
 	}
-	a.visibleUsers.Set(visible)
-	a.status.Set("Visible users: " + strconv.Itoa(len(visible)))
+	return visible
 }
 </script>
 

--- a/internal/compiler/checker/checker_test.go
+++ b/internal/compiler/checker/checker_test.go
@@ -156,6 +156,39 @@ func TestCheckProjectReportsBoundAttributeTypeDiagnostics(t *testing.T) {
 	}
 }
 
+func TestCheckProjectReportsExpressionShapeDiagnostics(t *testing.T) {
+	project, err := parseProjectFixture("testdata/invalid_expression")
+	if err != nil {
+		t.Fatalf("parse project fixture: %v", err)
+	}
+
+	diagnostics := CheckProject(project)
+	expected := []diagnosticSummary{
+		{Path: "testdata/invalid_expression/Parent.tue", Message: `type User has no field "missing"`, Line: 3, Column: 14},
+		{Path: "testdata/invalid_expression/Parent.tue", Message: `method call "visible" must have signature func() T`, Line: 4, Column: 12},
+	}
+	if diff := cmp.Diff(expected, summarizeDiagnostics(diagnostics)); diff != "" {
+		t.Errorf("mismatch diagnostics (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestCheckProjectReportsControlFlowDiagnostics(t *testing.T) {
+	project, err := parseProjectFixture("testdata/invalid_control_flow")
+	if err != nil {
+		t.Fatalf("parse project fixture: %v", err)
+	}
+
+	diagnostics := CheckProject(project)
+	expected := []diagnosticSummary{
+		{Path: "testdata/invalid_control_flow/Parent.tue", Message: `v-else must follow v-if`, Line: 3, Column: 6},
+		{Path: "testdata/invalid_control_flow/Parent.tue", Message: `v-else cannot follow v-if on an element that also has v-for; use a <template v-for> wrapper`, Line: 6, Column: 8},
+		{Path: "testdata/invalid_control_flow/Parent.tue", Message: `v-else must follow v-if`, Line: 9, Column: 8},
+	}
+	if diff := cmp.Diff(expected, summarizeDiagnostics(diagnostics)); diff != "" {
+		t.Errorf("mismatch diagnostics (-expected, +actual):\n%s", diff)
+	}
+}
+
 func TestCheckProjectReportsNamedSlotDiagnostics(t *testing.T) {
 	project, err := parseProjectFixture("testdata/invalid_slot_binding")
 	if err != nil {
@@ -182,7 +215,6 @@ func TestCheckProjectReportsModelBindingDiagnostics(t *testing.T) {
 	expected := []diagnosticSummary{
 		{Path: "testdata/invalid_model_binding/Parent.tue", Message: `v-model expects bool, got string`, Line: 3, Column: 35},
 		{Path: "testdata/invalid_model_binding/Parent.tue", Message: `v-model expects string, got bool`, Line: 4, Column: 20},
-		{Path: "testdata/invalid_model_binding/Parent.tue", Message: `v-model is only supported on text inputs, checkboxes, and selects`, Line: 8, Column: 13},
 		{Path: "testdata/invalid_model_binding/Parent.tue", Message: `v-model is not supported for input type "number"`, Line: 9, Column: 24},
 		{Path: "testdata/invalid_model_binding/Parent.tue", Message: `type string has no field "Text"`, Line: 11, Column: 25},
 	}

--- a/internal/compiler/checker/directive.go
+++ b/internal/compiler/checker/directive.go
@@ -161,18 +161,28 @@ func nativeModelBinding(node *gotemplate.Node) (nativeModel, bool) {
 	switch node.Tag {
 	case "input":
 		inputType, _ := staticAttrValue(node, "type")
-		switch inputType {
-		case "", "text":
+		if isTextInputType(inputType) {
 			return nativeModel{ValueType: "string"}, true
-		case "checkbox":
-			return nativeModel{ValueType: "bool"}, true
-		default:
-			return nativeModel{}, false
 		}
+		if inputType == "checkbox" {
+			return nativeModel{ValueType: "bool"}, true
+		}
+		return nativeModel{}, false
 	case "select":
+		return nativeModel{ValueType: "string"}, true
+	case "textarea":
 		return nativeModel{ValueType: "string"}, true
 	default:
 		return nativeModel{}, false
+	}
+}
+
+func isTextInputType(inputType string) bool {
+	switch inputType {
+	case "", "text", "email", "password", "search", "tel", "url":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -185,7 +195,7 @@ func modelUnsupportedMessage(node *gotemplate.Node) string {
 			return fmt.Sprintf("v-model is not supported for input type %q", inputType)
 		}
 	}
-	return "v-model is only supported on text inputs, checkboxes, and selects"
+	return "v-model is only supported on text inputs, textareas, checkboxes, and selects"
 }
 
 func directiveAttr(node *gotemplate.Node, kind gotemplate.DirectiveKind) (gotemplate.Attr, bool) {
@@ -195,6 +205,11 @@ func directiveAttr(node *gotemplate.Node, kind gotemplate.DirectiveKind) (gotemp
 		}
 	}
 	return gotemplate.Attr{}, false
+}
+
+func hasDirective(node *gotemplate.Node, kind gotemplate.DirectiveKind) bool {
+	_, ok := directiveAttr(node, kind)
+	return ok
 }
 
 func hasBoundKey(node *gotemplate.Node) bool {

--- a/internal/compiler/checker/expression.go
+++ b/internal/compiler/checker/expression.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/norunners/tue/internal/compiler/script"
 	"github.com/norunners/tue/internal/compiler/sfc"
 )
 
@@ -179,17 +180,41 @@ func (c *exprChecker) selector(selector *ast.SelectorExpr) value {
 	if base.Type == unknownType {
 		return value{Type: unknownType}
 	}
-	if isScalar(base.Type) || strings.HasPrefix(normalizeType(base.Type), "[]") {
+	if field, ok := c.fileChecker.structField(base.Type, selector.Sel.Name); ok {
+		return value{Type: fieldType(field)}
+	}
+	if _, ok := c.fileChecker.structs[normalizeType(base.Type)]; ok {
+		c.fileChecker.add(fmt.Sprintf("type %s has no field %q", displayType(base.Type), selector.Sel.Name), c.nodeSpan(selector.Sel))
+		return value{Type: unknownType}
+	}
+	if isScalar(base.Type) || strings.HasPrefix(normalizeType(base.Type), "[]") || strings.HasPrefix(normalizeType(base.Type), "map[") {
 		c.fileChecker.add(fmt.Sprintf("type %s has no field %q", displayType(base.Type), selector.Sel.Name), c.nodeSpan(selector.Sel))
 	}
 	return value{Type: unknownType}
 }
 
 func (c *exprChecker) call(call *ast.CallExpr) value {
-	c.eval(call.Fun)
 	for _, arg := range call.Args {
 		c.eval(arg)
 	}
+
+	if ident, ok := call.Fun.(*ast.Ident); ok {
+		symbol, found := c.scope.lookup(ident.Name)
+		if !found {
+			c.fileChecker.add(fmt.Sprintf("unknown identifier %q", ident.Name), c.nodeSpan(ident))
+			return value{Type: unknownType}
+		}
+		if !symbol.Method {
+			return value{Type: unknownType}
+		}
+		if len(call.Args) != 0 || symbol.Parameters != 0 || symbol.Results != 1 {
+			c.fileChecker.add(fmt.Sprintf("method call %q must have signature func() T", ident.Name), c.nodeSpan(call))
+			return value{Type: unknownType}
+		}
+		return value{Type: symbol.ResultType}
+	}
+
+	c.eval(call.Fun)
 	return value{Type: unknownType}
 }
 
@@ -207,6 +232,15 @@ func (c *exprChecker) expectOperand(expected string, actual value, expr ast.Expr
 		return
 	}
 	c.fileChecker.add(fmt.Sprintf("operand expects %s, got %s", displayType(expected), displayType(actual.Type)), c.nodeSpan(expr))
+}
+
+func (c *fileChecker) structField(typeName string, fieldName string) (script.Field, bool) {
+	fields, ok := c.structs[normalizeType(typeName)]
+	if !ok {
+		return script.Field{}, false
+	}
+	field, ok := fields[fieldName]
+	return field, ok
 }
 
 func (c *exprChecker) nodeSpan(node ast.Node) sfc.Span {

--- a/internal/compiler/checker/file.go
+++ b/internal/compiler/checker/file.go
@@ -2,6 +2,7 @@ package checker
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/norunners/tue/internal/compiler/script"
 	"github.com/norunners/tue/internal/compiler/sfc"
@@ -12,12 +13,28 @@ type fileChecker struct {
 	path        string
 	component   *script.Component
 	components  map[string]componentBinding
+	structs     map[string]map[string]script.Field
 	diagnostics []Diagnostic
 }
 
 func (c *fileChecker) checkNodes(nodes []*gotemplate.Node, scope *scope) {
+	previousIf := false
+	previousIfHasFor := false
 	for _, node := range nodes {
+		if ignorableControlSibling(node) {
+			continue
+		}
+		if attr, ok := directiveAttr(node, gotemplate.DirectiveElse); ok {
+			switch {
+			case !previousIf:
+				c.add("v-else must follow v-if", attr.DirectiveSpan)
+			case previousIfHasFor:
+				c.add("v-else cannot follow v-if on an element that also has v-for; use a <template v-for> wrapper", attr.DirectiveSpan)
+			}
+		}
 		c.checkNode(node, scope)
+		previousIf = hasDirective(node, gotemplate.DirectiveIf)
+		previousIfHasFor = previousIf && hasDirective(node, gotemplate.DirectiveFor)
 	}
 }
 
@@ -43,6 +60,8 @@ func (c *fileChecker) checkElement(node *gotemplate.Node, scope *scope) {
 	if node.IsComponent {
 		c.checkCommonAttrs(node, elementScope, false)
 		c.checkComponent(node, elementScope)
+	} else if node.Tag == "template" {
+		c.checkCommonAttrs(node, elementScope, false)
 	} else {
 		c.checkCommonAttrs(node, elementScope, true)
 		if node.Tag == "slot" {
@@ -175,4 +194,18 @@ func (c *fileChecker) add(message string, span sfc.Span) {
 		Message: message,
 		Span:    span,
 	})
+}
+
+func ignorableControlSibling(node *gotemplate.Node) bool {
+	if node == nil {
+		return true
+	}
+	switch node.Kind {
+	case gotemplate.NodeComment:
+		return true
+	case gotemplate.NodeText:
+		return strings.TrimSpace(node.Text) == ""
+	default:
+		return false
+	}
 }

--- a/internal/compiler/checker/project.go
+++ b/internal/compiler/checker/project.go
@@ -80,6 +80,7 @@ func (c *projectChecker) checkFile(file File) {
 		path:       path,
 		component:  file.Script.Component,
 		components: c.components,
+		structs:    structFieldMaps(file.Script.Structs),
 	}
 	fileChecker.checkNodes(file.Template.Nodes, componentScope(file.Script.Component))
 	c.diagnostics = append(c.diagnostics, fileChecker.diagnostics...)

--- a/internal/compiler/checker/scope.go
+++ b/internal/compiler/checker/scope.go
@@ -19,6 +19,7 @@ type scope struct {
 type symbol struct {
 	Name       string
 	Type       string
+	ResultType string
 	Writable   bool
 	Method     bool
 	Parameters int
@@ -49,7 +50,14 @@ func componentScope(component *script.Component) *scope {
 		scope.add(symbol{Name: field.Name, Type: fieldType(field)})
 	}
 	for _, method := range component.Methods {
-		scope.add(symbol{Name: method.Name, Type: funcType, Method: true, Parameters: len(method.Parameters), Results: len(method.Results)})
+		scope.add(symbol{
+			Name:       method.Name,
+			Type:       funcType,
+			ResultType: methodResultType(method),
+			Method:     true,
+			Parameters: len(method.Parameters),
+			Results:    len(method.Results),
+		})
 	}
 	return scope
 }
@@ -86,6 +94,25 @@ func fieldType(field script.Field) string {
 		return field.Type
 	}
 	return unknownType
+}
+
+func methodResultType(method script.Method) string {
+	if len(method.Results) != 1 {
+		return unknownType
+	}
+	return method.Results[0].Type
+}
+
+func structFieldMaps(structs []script.Struct) map[string]map[string]script.Field {
+	byType := make(map[string]map[string]script.Field, len(structs))
+	for _, structure := range structs {
+		fields := make(map[string]script.Field, len(structure.Fields))
+		for _, field := range structure.Fields {
+			fields[field.Name] = field
+		}
+		byType[structure.Name] = fields
+	}
+	return byType
 }
 
 func iterableTypesFor(typ string) (iterableTypes, bool) {

--- a/internal/compiler/checker/testdata/invalid_control_flow/Parent.tue
+++ b/internal/compiler/checker/testdata/invalid_control_flow/Parent.tue
@@ -1,0 +1,27 @@
+<template>
+	<main>
+		<p v-else>Hidden</p>
+		<ul>
+			<li v-for="todo in todos" v-if="todo.Done" :key="todo.ID">{{ todo.Text }}</li>
+			<li v-else>Open</li>
+			<li v-if="ready">Ready</li>
+			<li v-else>Fallback</li>
+			<li v-else>Extra fallback</li>
+		</ul>
+	</main>
+</template>
+
+<script lang="go">
+package fixtures
+
+type Todo struct {
+	ID   int
+	Text string
+	Done bool
+}
+
+type Parent struct {
+	todos []Todo
+	ready bool
+}
+</script>

--- a/internal/compiler/checker/testdata/invalid_expression/Parent.tue
+++ b/internal/compiler/checker/testdata/invalid_expression/Parent.tue
@@ -1,0 +1,22 @@
+<template>
+	<main>
+		<p>{{ user.missing }}</p>
+		<p v-if="visible(true)">Visible</p>
+	</main>
+</template>
+
+<script lang="go">
+package fixtures
+
+type User struct {
+	name string
+}
+
+type Parent struct {
+	user User
+}
+
+func (p *Parent) visible(enabled bool) bool {
+	return enabled
+}
+</script>

--- a/internal/compiler/checker/testdata/valid/Parent.tue
+++ b/internal/compiler/checker/testdata/valid/Parent.tue
@@ -1,9 +1,9 @@
 <template>
 	<main>
 		<UserBadge :name="name" :isAdmin='role == "admin"' @select="selectUser" />
-		<ul>
-			<li v-for="todo in todos" :key="todo.ID">{{ todo.Text }}</li>
-		</ul>
+			<ul>
+				<li v-for="todo in visibleTodos()" :key="todo.ID">{{ todo.Text }}</li>
+			</ul>
 		<input v-model="query" />
 		<button type="button" @click="increment">Increment</button>
 		<p v-if="ready">Count: {{ count }}</p>
@@ -32,4 +32,8 @@ type Parent struct {
 func (p *Parent) increment() {}
 
 func (p *Parent) selectUser() {}
+
+func (p *Parent) visibleTodos() []Todo {
+	return p.todos
+}
 </script>

--- a/internal/compiler/gogen/expression.go
+++ b/internal/compiler/gogen/expression.go
@@ -12,8 +12,11 @@ import (
 )
 
 type expressionGenerator struct {
-	fields map[string]script.Field
-	locals map[string]string
+	fields     map[string]script.Field
+	methods    map[string]script.Method
+	locals     map[string]string
+	localTypes map[string]string
+	typeFields map[string]map[string]script.Field
 }
 
 func (g expressionGenerator) render(expr ast.Expr) (jen.Code, bool) {
@@ -45,11 +48,16 @@ func (g expressionGenerator) render(expr ast.Expr) (jen.Code, bool) {
 		}
 		return jen.Parens(inner), true
 	case *ast.SelectorExpr:
+		if !g.validSelector(typed) {
+			return nil, false
+		}
 		base, ok := g.render(typed.X)
 		if !ok {
 			return nil, false
 		}
 		return base.(*jen.Statement).Dot(typed.Sel.Name), true
+	case *ast.CallExpr:
+		return g.call(typed)
 	case *ast.IndexExpr:
 		base, ok := g.render(typed.X)
 		if !ok {
@@ -63,6 +71,44 @@ func (g expressionGenerator) render(expr ast.Expr) (jen.Code, bool) {
 	default:
 		return nil, false
 	}
+}
+
+func (g expressionGenerator) call(call *ast.CallExpr) (jen.Code, bool) {
+	ident, ok := call.Fun.(*ast.Ident)
+	if !ok {
+		return nil, false
+	}
+	if len(call.Args) != 0 {
+		return nil, false
+	}
+	if _, local := g.locals[ident.Name]; local {
+		return nil, false
+	}
+	method, ok := g.methods[ident.Name]
+	if !ok || len(method.Parameters) != 0 || len(method.Results) != 1 {
+		return nil, false
+	}
+	return jen.Id("component").Dot(method.Name).Call(), true
+}
+
+func (g expressionGenerator) validSelector(selector *ast.SelectorExpr) bool {
+	baseType := expressionTyper{
+		fields:     g.fields,
+		methods:    g.methods,
+		localTypes: g.localTypes,
+		typeFields: g.typeFields,
+	}.eval(selector.X)
+	if baseType == "unknown" {
+		return true
+	}
+	if _, ok := structField(g.typeFields, baseType, selector.Sel.Name); ok {
+		return true
+	}
+	baseType = normalizeType(baseType)
+	if _, known := g.typeFields[baseType]; known {
+		return false
+	}
+	return !isScalarType(baseType) && !strings.HasPrefix(baseType, "[]") && !strings.HasPrefix(baseType, "map[")
 }
 
 func (g expressionGenerator) ident(ident *ast.Ident) jen.Code {
@@ -131,14 +177,18 @@ func (g *fileGenerator) expressionType(expression string) string {
 	}
 	typer := expressionTyper{
 		fields:     g.fields,
+		methods:    g.methods,
 		localTypes: g.localTypes,
+		typeFields: g.typeFields,
 	}
 	return typer.eval(expr)
 }
 
 type expressionTyper struct {
 	fields     map[string]script.Field
+	methods    map[string]script.Method
 	localTypes map[string]string
+	typeFields map[string]map[string]script.Field
 }
 
 func (t expressionTyper) eval(expr ast.Expr) string {
@@ -154,9 +204,9 @@ func (t expressionTyper) eval(expr ast.Expr) string {
 	case *ast.ParenExpr:
 		return t.eval(typed.X)
 	case *ast.SelectorExpr:
-		return "unknown"
+		return t.selector(typed)
 	case *ast.CallExpr:
-		return "unknown"
+		return t.call(typed)
 	case *ast.IndexExpr:
 		base := t.eval(typed.X)
 		types, ok := iterableTypesFor(base)
@@ -185,6 +235,30 @@ func (t expressionTyper) ident(ident *ast.Ident) string {
 		return fieldValueType(field)
 	}
 	return "unknown"
+}
+
+func (t expressionTyper) selector(selector *ast.SelectorExpr) string {
+	baseType := t.eval(selector.X)
+	field, ok := structField(t.typeFields, baseType, selector.Sel.Name)
+	if !ok {
+		return "unknown"
+	}
+	return fieldValueType(field)
+}
+
+func (t expressionTyper) call(call *ast.CallExpr) string {
+	ident, ok := call.Fun.(*ast.Ident)
+	if !ok || len(call.Args) != 0 {
+		return "unknown"
+	}
+	if _, local := t.localTypes[ident.Name]; local {
+		return "unknown"
+	}
+	method, ok := t.methods[ident.Name]
+	if !ok || len(method.Parameters) != 0 || len(method.Results) != 1 {
+		return "unknown"
+	}
+	return method.Results[0].Type
 }
 
 func literalType(lit *ast.BasicLit) string {
@@ -312,4 +386,22 @@ func isNumericType(typ string) bool {
 	default:
 		return false
 	}
+}
+
+func isScalarType(typ string) bool {
+	switch normalizeType(typ) {
+	case "string", "bool":
+		return true
+	default:
+		return isNumericType(typ)
+	}
+}
+
+func structField(typeFields map[string]map[string]script.Field, typeName string, fieldName string) (script.Field, bool) {
+	fields, ok := typeFields[normalizeType(typeName)]
+	if !ok {
+		return script.Field{}, false
+	}
+	field, ok := fields[fieldName]
+	return field, ok
 }

--- a/internal/compiler/gogen/generate.go
+++ b/internal/compiler/gogen/generate.go
@@ -246,6 +246,7 @@ func (g *projectGenerator) generatedRenderSource(file File, scopeAttr string) ([
 		components: g.components,
 		fields:     componentFields(file.Script.Component),
 		methods:    componentMethods(file.Script.Component),
+		typeFields: structFieldMaps(file.Script.Structs),
 		scopeAttr:  scopeAttr,
 		assets:     g.assets,
 	}
@@ -273,6 +274,7 @@ type fileGenerator struct {
 	components  map[string]componentBinding
 	fields      map[string]script.Field
 	methods     map[string]script.Method
+	typeFields  map[string]map[string]script.Field
 	scopeAttr   string
 	assets      *assetPipeline
 	locals      map[string]string
@@ -294,16 +296,74 @@ func (g *fileGenerator) generate(tree *gotemplate.Tree) {
 }
 
 func (g *fileGenerator) renderNodes(nodes []*gotemplate.Node) jen.Code {
-	rendered := make([]jen.Code, 0, len(nodes))
-	for _, node := range nodes {
-		if code, ok := g.renderNode(node); ok {
-			rendered = append(rendered, code)
-		}
-	}
+	rendered := g.renderNodeList(nodes)
 	if len(rendered) == 1 {
 		return rendered[0]
 	}
 	return jen.Qual(tueImportPath, "Fragment").Call(g.vnodeSlice(rendered))
+}
+
+func (g *fileGenerator) renderNodeList(nodes []*gotemplate.Node) []jen.Code {
+	rendered := make([]jen.Code, 0, len(nodes))
+	for index := 0; index < len(nodes); index++ {
+		node := nodes[index]
+		if g.ignorableControlSibling(node) {
+			continue
+		}
+		if attr := nodeDirectiveAttr(node, gotemplate.DirectiveElse); attr != nil {
+			g.add("v-else must follow v-if", attr.DirectiveSpan)
+			continue
+		}
+		if attr := nodeDirectiveAttr(node, gotemplate.DirectiveIf); attr != nil {
+			elseIndex := g.nextElseNode(nodes, index+1)
+			if elseIndex != -1 {
+				if nodeDirectiveAttr(node, gotemplate.DirectiveFor) != nil {
+					if elseAttr := nodeDirectiveAttr(nodes[elseIndex], gotemplate.DirectiveElse); elseAttr != nil {
+						g.add("v-else cannot follow v-if on an element that also has v-for; use a <template v-for> wrapper", elseAttr.DirectiveSpan)
+					}
+					index = elseIndex
+					continue
+				}
+				if code, ok := g.renderIfElse(node, *attr, nodes[elseIndex]); ok {
+					rendered = append(rendered, code)
+				}
+				index = elseIndex
+				continue
+			}
+		}
+		if code, ok := g.renderNode(node); ok {
+			rendered = append(rendered, code)
+		}
+	}
+	return rendered
+}
+
+func (g *fileGenerator) nextElseNode(nodes []*gotemplate.Node, start int) int {
+	for index := start; index < len(nodes); index++ {
+		node := nodes[index]
+		if g.ignorableControlSibling(node) {
+			continue
+		}
+		if nodeDirectiveAttr(node, gotemplate.DirectiveElse) != nil {
+			return index
+		}
+		return -1
+	}
+	return -1
+}
+
+func (g *fileGenerator) ignorableControlSibling(node *gotemplate.Node) bool {
+	if node == nil {
+		return true
+	}
+	switch node.Kind {
+	case gotemplate.NodeComment:
+		return true
+	case gotemplate.NodeText:
+		return strings.TrimSpace(node.Text) == ""
+	default:
+		return false
+	}
 }
 
 func (g *fileGenerator) renderNode(node *gotemplate.Node) (jen.Code, bool) {
@@ -423,7 +483,26 @@ func (g *fileGenerator) renderIf(node *gotemplate.Node, attr gotemplate.Attr) (j
 	).Call(), true
 }
 
+func (g *fileGenerator) renderIfElse(ifNode *gotemplate.Node, ifAttr gotemplate.Attr, elseNode *gotemplate.Node) (jen.Code, bool) {
+	condition, conditionOK := g.renderExpressionFor("v-if", ifAttr.Expression, ifAttr.ExpressionSpan)
+	ifTrue, trueOK := g.renderNodeBody(ifNode)
+	ifFalse, falseOK := g.renderNodeBody(elseNode)
+	if !conditionOK || !trueOK || !falseOK {
+		return nil, false
+	}
+
+	return jen.Func().Params().Qual(tueImportPath, "VNode").Block(
+		jen.If(condition).Block(
+			jen.Return(ifTrue),
+		),
+		jen.Return(ifFalse),
+	).Call(), true
+}
+
 func (g *fileGenerator) renderElement(node *gotemplate.Node) (jen.Code, bool) {
+	if node.Tag == "template" {
+		return g.renderTemplate(node)
+	}
 	if node.Tag == "slot" {
 		return g.renderSlot(node)
 	}
@@ -437,13 +516,7 @@ func (g *fileGenerator) renderElement(node *gotemplate.Node) (jen.Code, bool) {
 	}
 	attrs = g.withScopeAttr(attrs)
 
-	children := make([]jen.Code, 0, len(node.Children))
-	for _, child := range node.Children {
-		childCode, ok := g.renderNode(child)
-		if ok {
-			children = append(children, childCode)
-		}
-	}
+	children := g.renderNodeList(node.Children)
 
 	g.recordNode(node)
 	if len(events) != 0 {
@@ -459,6 +532,24 @@ func (g *fileGenerator) renderElement(node *gotemplate.Node) (jen.Code, bool) {
 		g.attributeSlice(attrs),
 		g.vnodeSlice(children),
 	), true
+}
+
+func (g *fileGenerator) renderTemplate(node *gotemplate.Node) (jen.Code, bool) {
+	ok := true
+	for _, attr := range node.Attrs {
+		if attr.Kind == gotemplate.AttrDirective && isControlDirective(attr.Directive) {
+			continue
+		}
+		if attr.Kind == gotemplate.AttrBind && attr.Argument == "key" {
+			continue
+		}
+		g.add(fmt.Sprintf("template attribute %q generation is not supported", attr.RawName), attr.Span)
+		ok = false
+	}
+	if !ok {
+		return nil, false
+	}
+	return g.renderNodes(node.Children), true
 }
 
 func (g *fileGenerator) withScopeAttr(attrs []jen.Code) []jen.Code {
@@ -533,7 +624,7 @@ func (g *fileGenerator) renderComponentUpdater(child componentBinding, fields []
 func (g *fileGenerator) renderSlot(node *gotemplate.Node) (jen.Code, bool) {
 	ok := true
 	for _, attr := range node.Attrs {
-		if attr.Kind == gotemplate.AttrDirective && (attr.Directive == gotemplate.DirectiveIf || attr.Directive == gotemplate.DirectiveFor) {
+		if attr.Kind == gotemplate.AttrDirective && isControlDirective(attr.Directive) {
 			continue
 		}
 		if isNamedSlotAttr(attr) {
@@ -594,7 +685,7 @@ func (g *fileGenerator) renderComponentFields(node *gotemplate.Node, child compo
 			}
 			events[field.Name] = field.Value
 		case gotemplate.AttrDirective:
-			if attr.Directive == gotemplate.DirectiveIf || attr.Directive == gotemplate.DirectiveFor {
+			if isControlDirective(attr.Directive) {
 				continue
 			}
 			if attr.Directive == gotemplate.DirectiveModel {
@@ -824,7 +915,7 @@ func (g *fileGenerator) renderAttrsAndEvents(node *gotemplate.Node) ([]jen.Code,
 			}
 			events = append(events, event)
 		case gotemplate.AttrDirective:
-			if attr.Directive == gotemplate.DirectiveIf || attr.Directive == gotemplate.DirectiveFor || attr.Directive == gotemplate.DirectiveModel {
+			if isControlDirective(attr.Directive) || attr.Directive == gotemplate.DirectiveModel {
 				continue
 			}
 			g.add(fmt.Sprintf("directive %q generation is not supported in the static render slice", attr.RawName), attr.Span)
@@ -934,10 +1025,6 @@ func (g *fileGenerator) renderModelBinding(node *gotemplate.Node, attr gotemplat
 		return nil, nil, false
 	}
 
-	expression, expressionOK := g.renderExpressionFor("v-model", attr.Expression, attr.ExpressionSpan)
-	if !expressionOK {
-		return nil, nil, false
-	}
 	actualType := g.expressionType(attr.Expression)
 	if !assignableType(binding.ValueType, actualType) {
 		g.add(fmt.Sprintf("v-model expects %s, got %s", displayType(binding.ValueType), displayType(actualType)), attr.ExpressionSpan)
@@ -946,6 +1033,10 @@ func (g *fileGenerator) renderModelBinding(node *gotemplate.Node, attr gotemplat
 
 	setter, setterOK := g.renderModelSetter(attr.Expression, attr.ExpressionSpan, binding.ValueName)
 	if !setterOK {
+		return nil, nil, false
+	}
+	expression, expressionOK := g.renderExpressionFor("v-model", attr.Expression, attr.ExpressionSpan)
+	if !expressionOK {
 		return nil, nil, false
 	}
 
@@ -1099,8 +1190,11 @@ func (g *fileGenerator) renderExpressionFor(subject string, expression string, s
 	}
 
 	generated := expressionGenerator{
-		fields: g.fields,
-		locals: g.locals,
+		fields:     g.fields,
+		methods:    g.methods,
+		locals:     g.locals,
+		localTypes: g.localTypes,
+		typeFields: g.typeFields,
 	}
 	code, ok := generated.render(expr)
 	if !ok {
@@ -1186,6 +1280,15 @@ func nodeBindAttr(node *gotemplate.Node, argument string) *gotemplate.Attr {
 	return nil
 }
 
+func isControlDirective(kind gotemplate.DirectiveKind) bool {
+	switch kind {
+	case gotemplate.DirectiveIf, gotemplate.DirectiveElse, gotemplate.DirectiveFor:
+		return true
+	default:
+		return false
+	}
+}
+
 func isNamedSlotAttr(attr gotemplate.Attr) bool {
 	return (attr.Kind == gotemplate.AttrStatic && attr.Name == "name") ||
 		(attr.Kind == gotemplate.AttrBind && attr.Argument == "name")
@@ -1206,18 +1309,28 @@ func nativeModelBinding(node *gotemplate.Node) (nativeModel, bool) {
 	switch node.Tag {
 	case "input":
 		inputType, _ := nodeStaticAttrValue(node, "type")
-		switch inputType {
-		case "", "text":
+		if isTextInputType(inputType) {
 			return nativeModel{ValueType: "string", ValueName: "value", EventName: "input"}, true
-		case "checkbox":
-			return nativeModel{ValueType: "bool", ValueName: "checked", EventName: "change", Checked: true}, true
-		default:
-			return nativeModel{}, false
 		}
+		if inputType == "checkbox" {
+			return nativeModel{ValueType: "bool", ValueName: "checked", EventName: "change", Checked: true}, true
+		}
+		return nativeModel{}, false
 	case "select":
 		return nativeModel{ValueType: "string", ValueName: "value", EventName: "change"}, true
+	case "textarea":
+		return nativeModel{ValueType: "string", ValueName: "value", EventName: "input"}, true
 	default:
 		return nativeModel{}, false
+	}
+}
+
+func isTextInputType(inputType string) bool {
+	switch inputType {
+	case "", "text", "email", "password", "search", "tel", "url":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -1230,7 +1343,7 @@ func modelUnsupportedMessage(node *gotemplate.Node) string {
 			return fmt.Sprintf("v-model is not supported for input type %q", inputType)
 		}
 	}
-	return "v-model is only supported on text inputs, checkboxes, and selects"
+	return "v-model is only supported on text inputs, textareas, checkboxes, and selects"
 }
 
 func nodeStaticAttrValue(node *gotemplate.Node, name string) (string, bool) {
@@ -1421,6 +1534,18 @@ func componentMethods(component *script.Component) map[string]script.Method {
 		methods[method.Name] = method
 	}
 	return methods
+}
+
+func structFieldMaps(structs []script.Struct) map[string]map[string]script.Field {
+	byType := make(map[string]map[string]script.Field, len(structs))
+	for _, structure := range structs {
+		fields := make(map[string]script.Field, len(structure.Fields))
+		for _, field := range structure.Fields {
+			fields[field.Name] = field
+		}
+		byType[structure.Name] = fields
+	}
+	return byType
 }
 
 func propValueType(prop script.Prop) string {

--- a/internal/compiler/gogen/generate_test.go
+++ b/internal/compiler/gogen/generate_test.go
@@ -219,6 +219,45 @@ func TestGenerateProjectEmitsKeyedEmptyFragmentForFalseLoopCondition(t *testing.
 	}
 }
 
+func TestGenerateProjectEmitsMethodControlRenderFiles(t *testing.T) {
+	project, err := parseProjectFixture("testdata/method_control/App.tue")
+	if err != nil {
+		t.Fatalf("parse project fixture: %v", err)
+	}
+
+	result, diagnostics := GenerateProject(*project)
+	if result == nil {
+		t.Fatal("GenerateProject result is nil")
+	}
+	if diff := cmp.Diff([]diagnosticSummary{}, summarizeDiagnostics(diagnostics)); diff != "" {
+		t.Errorf("mismatch diagnostics (-expected, +actual):\n%s", diff)
+	}
+
+	actualRender, err := generatedSource(result, "App_render_tue.go")
+	if err != nil {
+		t.Fatalf("read actual generated render: %v", err)
+	}
+	actual := string(actualRender)
+	for _, expected := range []string{
+		"component.visibleTodos()",
+		`if __tueItem.Done`,
+		`tue.Element("li", []tue.Attribute{tue.Attr("class", "done")}`,
+		`tue.Element("li", []tue.Attribute{tue.Attr("class", "open")}`,
+		`tue.ElementWithEvents("textarea"`,
+		`tue.ElementWithEvents("input", []tue.Attribute{tue.Attr("type", "email")`,
+	} {
+		if !strings.Contains(actual, expected) {
+			t.Errorf("generated render actual = %q, expected to contain %q", actual, expected)
+		}
+	}
+
+	for _, file := range result.Files {
+		if _, err := goparser.ParseFile(token.NewFileSet(), file.Path, file.Source, goparser.AllErrors); err != nil {
+			t.Errorf("generated file %s should parse: %v", file.Path, err)
+		}
+	}
+}
+
 func TestGenerateProjectReportsUnsupportedLoopConstructs(t *testing.T) {
 	project, err := parseProjectFixture("testdata/invalid_loops/App.tue")
 	if err != nil {
@@ -232,6 +271,7 @@ func TestGenerateProjectReportsUnsupportedLoopConstructs(t *testing.T) {
 		{Path: "App.tue", Message: `v-for requires a :key attribute`, Line: 4, Column: 6},
 		{Path: "App.tue", Message: `v-for source expression is not supported in the static render slice`, Line: 5, Column: 21},
 		{Path: "App.tue", Message: `v-for key expression is not supported in the static render slice`, Line: 6, Column: 34},
+		{Path: "App.tue", Message: `v-else cannot follow v-if on an element that also has v-for; use a <template v-for> wrapper`, Line: 8, Column: 6},
 	}, summarizeDiagnostics(diagnostics)); diff != "" {
 		t.Errorf("mismatch diagnostics (-expected, +actual):\n%s", diff)
 	}
@@ -664,7 +704,6 @@ func TestGenerateProjectReportsModelBindingDiagnostics(t *testing.T) {
 	expected := []diagnosticSummary{
 		{Path: "App.tue", Message: `v-model expects bool, got string`, Line: 3, Column: 35},
 		{Path: "App.tue", Message: `v-model expects string, got bool`, Line: 4, Column: 20},
-		{Path: "App.tue", Message: `v-model is only supported on text inputs, checkboxes, and selects`, Line: 8, Column: 13},
 		{Path: "App.tue", Message: `v-model is not supported for input type "number"`, Line: 9, Column: 24},
 		{Path: "App.tue", Message: `v-model target "query.Text" is not writable`, Line: 11, Column: 19},
 	}

--- a/internal/compiler/gogen/testdata/invalid_classes/App.tue
+++ b/internal/compiler/gogen/testdata/invalid_classes/App.tue
@@ -1,5 +1,5 @@
 <template>
-<main :class="className()">Hello</main>
+<main :class="className(true)">Hello</main>
 </template>
 
 <script lang="go">
@@ -7,5 +7,5 @@ package app
 
 type App struct{}
 
-func (a *App) className() string { return "" }
+func (a *App) className(active bool) string { return "" }
 </script>

--- a/internal/compiler/gogen/testdata/invalid_conditionals/App.tue
+++ b/internal/compiler/gogen/testdata/invalid_conditionals/App.tue
@@ -1,5 +1,5 @@
 <template>
-<p v-if="visible()">Visible</p>
+<p v-if="visible(true)">Visible</p>
 </template>
 
 <script lang="go">
@@ -7,7 +7,7 @@ package app
 
 type App struct{}
 
-func (a *App) visible() bool {
+func (a *App) visible(enabled bool) bool {
 	return true
 }
 </script>

--- a/internal/compiler/gogen/testdata/invalid_loops/App.tue
+++ b/internal/compiler/gogen/testdata/invalid_loops/App.tue
@@ -4,6 +4,8 @@
 	<li v-for="todo in todos">Missing key</li>
 	<li v-for="todo in makeTodos()" :key="todo.ID">Bad source</li>
 	<li v-for="todo in todos" :key="key(todo)">Bad key</li>
+	<li v-for="todo in todos" v-if="todo.Done" :key="todo.ID">Done</li>
+	<li v-else>Open</li>
 </ul>
 </template>
 
@@ -13,6 +15,7 @@ package app
 type Todo struct {
 	ID   int
 	Text string
+	Done bool
 }
 
 type App struct {

--- a/internal/compiler/gogen/testdata/invalid_styles/App.tue
+++ b/internal/compiler/gogen/testdata/invalid_styles/App.tue
@@ -1,5 +1,5 @@
 <template>
-	<main :style="styleName()">Hello</main>
+	<main :style="styleName(true)">Hello</main>
 </template>
 
 <script lang="go">
@@ -7,5 +7,5 @@ package app
 
 type App struct{}
 
-func (a *App) styleName() string { return "" }
+func (a *App) styleName(active bool) string { return "" }
 </script>

--- a/internal/compiler/gogen/testdata/method_control/App.tue
+++ b/internal/compiler/gogen/testdata/method_control/App.tue
@@ -1,0 +1,33 @@
+<template>
+	<main>
+		<ul>
+			<template v-for="todo in visibleTodos()" :key="todo.ID">
+				<li v-if="todo.Done" class="done">{{ todo.Text }}</li>
+				<li v-else class="open">{{ todo.Text }}</li>
+			</template>
+		</ul>
+
+		<textarea v-model="notes"></textarea>
+		<input type="email" v-model="email" />
+	</main>
+</template>
+
+<script lang="go">
+package app
+
+type Todo struct {
+	ID   int
+	Text string
+	Done bool
+}
+
+type App struct {
+	todos []Todo
+	notes string
+	email string
+}
+
+func (a *App) visibleTodos() []Todo {
+	return a.todos
+}
+</script>

--- a/internal/compiler/script/contract.go
+++ b/internal/compiler/script/contract.go
@@ -8,6 +8,7 @@ type File struct {
 	PackageName string
 	PackageSpan sfc.Span
 	Imports     []Import
+	Structs     []Struct
 	Component   *Component
 }
 
@@ -48,6 +49,12 @@ type Prop struct {
 	Field    Field
 	Name     string
 	Required bool
+}
+
+// Struct is a top-level Go struct declaration available to template expressions.
+type Struct struct {
+	Name   string
+	Fields []Field
 }
 
 // Field is a named field on the component struct.

--- a/internal/compiler/script/parse.go
+++ b/internal/compiler/script/parse.go
@@ -132,6 +132,7 @@ func (e *extractor) parse(componentName string) (*File, []Diagnostic) {
 	file.PackageSpan = e.posSpan(astFile.Pos(), astFile.Name.End())
 	file.Imports = e.extractImports(astFile)
 	e.typeCheck(astFile)
+	file.Structs = e.extractStructs(astFile)
 
 	if componentName != "" {
 		e.extractComponent(file, astFile, componentName)
@@ -262,6 +263,55 @@ func findTypeSpec(file *ast.File, name string) (*ast.TypeSpec, bool) {
 		}
 	}
 	return nil, false
+}
+
+func (e *extractor) extractStructs(file *ast.File) []Struct {
+	var structs []Struct
+	for _, declaration := range file.Decls {
+		general, ok := declaration.(*ast.GenDecl)
+		if !ok || general.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range general.Specs {
+			typeSpec, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			structType, ok := typeSpec.Type.(*ast.StructType)
+			if !ok {
+				continue
+			}
+			structs = append(structs, Struct{
+				Name:   typeSpec.Name.Name,
+				Fields: e.structFields(structType),
+			})
+		}
+	}
+	return structs
+}
+
+func (e *extractor) structFields(structType *ast.StructType) []Field {
+	var fields []Field
+	for _, astField := range structType.Fields.List {
+		if len(astField.Names) == 0 {
+			continue
+		}
+		for _, name := range astField.Names {
+			tag, tagSpan := e.fieldTag(astField)
+			fields = append(fields, Field{
+				Kind:     FieldKindState,
+				Name:     name.Name,
+				Exported: name.IsExported(),
+				Type:     e.nodeString(astField.Type),
+				Tag:      tag,
+				Span:     e.posSpan(name.Pos(), astField.End()),
+				NameSpan: e.nodeSpan(name),
+				TypeSpan: e.nodeSpan(astField.Type),
+				TagSpan:  tagSpan,
+			})
+		}
+	}
+	return fields
 }
 
 func (e *extractor) extractFields(component *Component, structType *ast.StructType) {

--- a/internal/compiler/script/parse_test.go
+++ b/internal/compiler/script/parse_test.go
@@ -29,6 +29,19 @@ func TestParseExtractsComponentContract(t *testing.T) {
 	}}, summarizeImports(file.Imports)); diff != "" {
 		t.Errorf("mismatch imports (-expected, +actual):\n%s", diff)
 	}
+	if diff := cmp.Diff([]structSummary{
+		{Name: "User", Fields: []fieldSummary{}},
+		{Name: "Dashboard", Fields: []fieldSummary{
+			{Kind: FieldKindState, Name: "name", Type: "tue.Prop[string]"},
+			{Kind: FieldKindState, Name: "count", Type: "tue.Ref[int]"},
+			{Kind: FieldKindState, Name: "total", Type: "tue.Computed[int]"},
+			{Kind: FieldKindState, Name: "user", Type: "tue.Resource[User]"},
+			{Kind: FieldKindState, Name: "onSave", Type: "func()"},
+			{Kind: FieldKindState, Name: "label", Type: "string"},
+		}},
+	}, summarizeStructs(file.Structs)); diff != "" {
+		t.Errorf("mismatch structs (-expected, +actual):\n%s", diff)
+	}
 
 	component := requireComponent(t, file)
 	if diff := cmp.Diff("Dashboard", component.Name); diff != "" {
@@ -387,6 +400,11 @@ type fieldSummary struct {
 	ValueType string
 }
 
+type structSummary struct {
+	Name   string
+	Fields []fieldSummary
+}
+
 type methodSummary struct {
 	Name            string
 	ReceiverName    string
@@ -443,6 +461,17 @@ func summarizeFields(fields []Field) []fieldSummary {
 	summaries := make([]fieldSummary, len(fields))
 	for i, field := range fields {
 		summaries[i] = summarizeField(field)
+	}
+	return summaries
+}
+
+func summarizeStructs(structs []Struct) []structSummary {
+	summaries := make([]structSummary, len(structs))
+	for i, structure := range structs {
+		summaries[i] = structSummary{
+			Name:   structure.Name,
+			Fields: summarizeFields(structure.Fields),
+		}
 	}
 	return summaries
 }

--- a/internal/compiler/sfc/parse.go
+++ b/internal/compiler/sfc/parse.go
@@ -102,7 +102,7 @@ func (p *parser) parse() (*File, []Diagnostic) {
 			continue
 		}
 
-		closeStart, closeEnd, found := p.findCloseTag(tag.name, tag.contentFrom)
+		closeStart, closeEnd, found := p.findBlockCloseTag(tag.name, tag.contentFrom)
 		if !found {
 			diagnostics = append(diagnostics, Diagnostic{
 				Message: fmt.Sprintf("missing closing </%s> tag", tag.name),
@@ -373,6 +373,82 @@ func (p *parser) findCloseTag(name string, start int) (int, int, bool) {
 	}
 
 	return 0, 0, false
+}
+
+func (p *parser) findBlockCloseTag(name string, start int) (int, int, bool) {
+	if name != string(BlockTemplate) {
+		return p.findCloseTag(name, start)
+	}
+
+	depth := 1
+	for searchFrom := start; searchFrom < len(p.source); {
+		index := strings.IndexByte(p.source[searchFrom:], '<')
+		if index == -1 {
+			return 0, 0, false
+		}
+
+		tagStart := searchFrom + index
+		if tagStart+1 < len(p.source) && p.source[tagStart+1] == '/' {
+			closeEnd, ok := p.closeTagEndAt(name, tagStart)
+			if !ok {
+				searchFrom = tagStart + 1
+				continue
+			}
+			depth--
+			if depth == 0 {
+				return tagStart, closeEnd, true
+			}
+			searchFrom = closeEnd
+			continue
+		}
+
+		openEnd, selfClosing, ok := p.openTagEndAt(name, tagStart)
+		if !ok {
+			searchFrom = p.advancePastTag(tagStart)
+			continue
+		}
+		if !selfClosing {
+			depth++
+		}
+		searchFrom = openEnd
+	}
+
+	return 0, 0, false
+}
+
+func (p *parser) openTagEndAt(name string, start int) (int, bool, bool) {
+	if start+1+len(name) > len(p.source) || p.source[start:start+1+len(name)] != "<"+name {
+		return 0, false, false
+	}
+	offset := start + 1 + len(name)
+	if offset < len(p.source) && isNameChar(rune(p.source[offset])) {
+		return 0, false, false
+	}
+	end, _, ok := p.findOpenTagEnd(start)
+	if !ok {
+		return 0, false, false
+	}
+	bodyEnd := end - 1
+	for bodyEnd > start && isSpace(p.source[bodyEnd-1]) {
+		bodyEnd--
+	}
+	selfClosing := bodyEnd > start && p.source[bodyEnd-1] == '/'
+	return end, selfClosing, true
+}
+
+func (p *parser) closeTagEndAt(name string, start int) (int, bool) {
+	if start+2+len(name) > len(p.source) || p.source[start:start+2+len(name)] != "</"+name {
+		return 0, false
+	}
+	offset := start + 2 + len(name)
+	if offset < len(p.source) && isNameChar(rune(p.source[offset])) {
+		return 0, false
+	}
+	offset = skipSpaces(p.source, offset, len(p.source))
+	if offset < len(p.source) && p.source[offset] == '>' {
+		return offset + 1, true
+	}
+	return 0, false
 }
 
 func (p *parser) skipUnsupportedBlock(tag openTag) int {

--- a/internal/compiler/sfc/parse_test.go
+++ b/internal/compiler/sfc/parse_test.go
@@ -98,6 +98,34 @@ func TestParseScriptLangMayBeUnquoted(t *testing.T) {
 	}
 }
 
+func TestParseTemplateAllowsNestedTemplateTags(t *testing.T) {
+	source := `<template>
+	<ul>
+		<template v-for="todo in todos">
+			<li>{{ todo.Text }}</li>
+		</template>
+	</ul>
+</template>
+<script lang="go">
+package fixtures
+</script>
+`
+
+	file, diagnostics := Parse("nested.tue", []byte(source))
+	if len(diagnostics) != 0 {
+		t.Fatalf("Parse diagnostics = %#v, want none", diagnosticMessages(diagnostics))
+	}
+	if file.Template == nil {
+		t.Fatal("file.Template is nil")
+	}
+	if !strings.Contains(file.Template.Content, `<template v-for="todo in todos">`) {
+		t.Fatalf("template content = %q, want nested template tag", file.Template.Content)
+	}
+	if strings.Contains(file.Template.Content, `<script`) {
+		t.Fatalf("template content = %q, should not include script block", file.Template.Content)
+	}
+}
+
 func TestParseFixtures(t *testing.T) {
 	root := filepath.Join("..", "..", "..", "testdata", "fixtures")
 	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {


### PR DESCRIPTION
## Summary

- Added local struct field metadata to script contracts so template selectors can be checked before Go generation.
- Added no-arg single-result component method calls in template expressions, plus fragment-only `<template>` control wrappers and immediate sibling `v-else` generation.
- Broadened native `v-model` support for text-like inputs and textareas, then updated examples to use method-derived lists and textarea controls.

## Validation

- `go fmt ./...`
- `go test ./internal/compiler/sfc ./internal/compiler/script ./internal/compiler/checker ./internal/compiler/gogen ./internal/cli`
- `for dir in examples/todo examples/user-table examples/settings-form examples/dashboard examples/router; do go run ./cmd/tue check "$dir"; done`
- `go test ./...`
- `git diff --check`
- `git diff --cached --check`

## Notes

Docs under `docs/` were updated locally and intentionally left out of this PR per repository workflow.