### PR TITLE
Replaced dev reload transport with WebSockets.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/norunners/tue
 go 1.26.4
 
 require (
+	github.com/coder/websocket v1.8.14
 	github.com/dave/jennifer v1.7.1
 	github.com/google/go-cmp v0.7.0
+	github.com/tdewolff/parse/v2 v2.8.13
 )
-
-require github.com/tdewolff/parse/v2 v2.8.13

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
+github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/dave/jennifer v1.7.1 h1:B4jJJDHelWcDhlRQxWeo0Npa/pYKBLrirAQoTN45txo=
 github.com/dave/jennifer v1.7.1/go.mod h1:nXbxhEmQfOZhWml3D1cDK5M1FLnMSozpbFN/m3RmGZc=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2,15 +2,21 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"embed"
+	"encoding/json"
 	"fmt"
 	"io/fs"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/coder/websocket"
 	"github.com/google/go-cmp/cmp"
 	"github.com/norunners/tue/internal/compiler/sfc"
 	gotemplate "github.com/norunners/tue/internal/compiler/template"
@@ -342,8 +348,31 @@ func TestBuildDevProjectWritesClient(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read dev client: %v", err)
 	}
-	if !strings.Contains(string(client), `new EventSource("/__tue/events")`) {
-		t.Errorf("tue_dev.js actual = %q, expected reload stream", string(client))
+	if !strings.Contains(string(client), `new WebSocket(socketURL())`) {
+		t.Errorf("tue_dev.js actual = %q, expected WebSocket client", string(client))
+	}
+	if !strings.Contains(string(client), `"/__tue/ws"`) {
+		t.Errorf("tue_dev.js actual = %q, expected WebSocket path", string(client))
+	}
+	if strings.Contains(string(client), "EventSource") {
+		t.Errorf("tue_dev.js actual = %q, expected no EventSource client", string(client))
+	}
+}
+
+func TestDevClientSourceClearsReconnectOverlayOnReadyEvent(t *testing.T) {
+	source := string(devClientSource())
+	readyBranch, err := sourceBetween(source, `if (!event || event.type === "ready")`, `if (event.type === "style")`)
+	if err != nil {
+		t.Fatalf("find ready event branch: %v", err)
+	}
+	if !strings.Contains(source, `Lost WebSocket connection to Tue dev server. Reconnecting...`) {
+		t.Errorf("tue_dev.js actual = %q, expected reconnect overlay message", source)
+	}
+	if !strings.Contains(readyBranch, `hideOverlay();`) {
+		t.Errorf("ready event branch actual = %q, expected overlay clear", readyBranch)
+	}
+	if !strings.Contains(readyBranch, `return;`) {
+		t.Errorf("ready event branch actual = %q, expected early return", readyBranch)
 	}
 }
 
@@ -463,6 +492,55 @@ func TestDevBroadcasterPublishWhileUnsubscribing(t *testing.T) {
 	close(start)
 	subscribers.Wait()
 	publishers.Wait()
+}
+
+func TestDevBroadcasterServesEventsOverWebSocket(t *testing.T) {
+	broadcaster := newDevBroadcaster()
+	expectedCurrent := devEvent{Type: devEventTypeReady, Message: "ready"}
+	broadcaster.publish(expectedCurrent)
+
+	serverCtx, stopServer := context.WithCancel(context.Background())
+	defer stopServer()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		broadcaster.serveWebSocket(serverCtx, w, r)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	firstConn, _, err := websocket.Dial(ctx, websocketURL(server.URL), nil)
+	if err != nil {
+		t.Fatalf("dial first dev WebSocket: %v", err)
+	}
+	defer firstConn.Close(websocket.StatusNormalClosure, "")
+	secondConn, _, err := websocket.Dial(ctx, websocketURL(server.URL), nil)
+	if err != nil {
+		t.Fatalf("dial second dev WebSocket: %v", err)
+	}
+	defer secondConn.Close(websocket.StatusNormalClosure, "")
+
+	for name, conn := range map[string]*websocket.Conn{"first": firstConn, "second": secondConn} {
+		actual, err := readDevWebSocketEvent(ctx, conn)
+		if err != nil {
+			t.Fatalf("read %s current dev event: %v", name, err)
+		}
+		if diff := cmp.Diff(expectedCurrent, actual); diff != "" {
+			t.Errorf("mismatch %s current dev event (-expected, +actual):\n%s", name, diff)
+		}
+	}
+
+	expectedUpdate := devEvent{Type: devEventTypeStyle, Message: "style changed"}
+	broadcaster.publish(expectedUpdate)
+
+	for name, conn := range map[string]*websocket.Conn{"first": firstConn, "second": secondConn} {
+		actual, err := readDevWebSocketEvent(ctx, conn)
+		if err != nil {
+			t.Fatalf("read %s updated dev event: %v", name, err)
+		}
+		if diff := cmp.Diff(expectedUpdate, actual); diff != "" {
+			t.Errorf("mismatch %s updated dev event (-expected, +actual):\n%s", name, diff)
+		}
+	}
 }
 
 func TestRunBuildGeneratesDistFiles(t *testing.T) {
@@ -804,6 +882,38 @@ func nodeHasDirective(node *gotemplate.Node, directive gotemplate.DirectiveKind)
 		}
 	}
 	return false
+}
+
+func websocketURL(httpURL string) string {
+	return "ws" + strings.TrimPrefix(httpURL, "http")
+}
+
+func readDevWebSocketEvent(ctx context.Context, conn *websocket.Conn) (devEvent, error) {
+	messageType, source, err := conn.Read(ctx)
+	if err != nil {
+		return devEvent{}, err
+	}
+	if messageType != websocket.MessageText {
+		return devEvent{}, fmt.Errorf("read message type %s, expected %s", messageType, websocket.MessageText)
+	}
+
+	var event devEvent
+	if err := json.Unmarshal(source, &event); err != nil {
+		return devEvent{}, fmt.Errorf("decode dev event: %w", err)
+	}
+	return event, nil
+}
+
+func sourceBetween(source string, start string, end string) (string, error) {
+	startIndex := strings.Index(source, start)
+	if startIndex == -1 {
+		return "", fmt.Errorf("source missing start marker %q", start)
+	}
+	endIndex := strings.Index(source[startIndex:], end)
+	if endIndex == -1 {
+		return "", fmt.Errorf("source missing end marker %q", end)
+	}
+	return source[startIndex : startIndex+endIndex], nil
 }
 
 func writeFile(path string, contents string) error {

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -18,15 +18,17 @@ import (
 	"sync"
 	"time"
 
+	"github.com/coder/websocket"
 	"github.com/norunners/tue/internal/compiler/checker"
 	"github.com/norunners/tue/internal/compiler/gogen"
 	"github.com/norunners/tue/internal/compiler/sfc"
 )
 
 const (
-	defaultDevAddr = "127.0.0.1:5173"
-	devClientPath  = "tue_dev.js"
-	devEventsPath  = "/__tue/events"
+	defaultDevAddr           = "127.0.0.1:5173"
+	devClientPath            = "tue_dev.js"
+	devWebSocketPath         = "/__tue/ws"
+	devWebSocketWriteTimeout = 5 * time.Second
 )
 
 type devOptions struct {
@@ -134,7 +136,9 @@ func serveDev(ctx context.Context, options devOptions, stdout, stderr io.Writer)
 	}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc(devEventsPath, broadcaster.serveEvents)
+	mux.HandleFunc(devWebSocketPath, func(w http.ResponseWriter, r *http.Request) {
+		broadcaster.serveWebSocket(ctx, w, r)
+	})
 	mux.Handle("/", http.FileServer(http.Dir(filepath.Join(root, gogen.DistDir))))
 	server := &http.Server{Handler: mux}
 
@@ -393,13 +397,41 @@ func devClientSource() []byte {
 		}
 	}
 
-	const source = new EventSource("/__tue/events");
-	source.onmessage = function (message) {
-		handleEvent(JSON.parse(message.data));
-	};
-	source.onerror = function () {
-		showError({ type: "error", message: "Lost connection to Tue dev server." });
-	};
+	let socket;
+	let reconnectTimer;
+
+	function socketURL() {
+		const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+		return protocol + "//" + window.location.host + "/__tue/ws";
+	}
+
+	function scheduleReconnect() {
+		if (reconnectTimer) {
+			return;
+		}
+		showError({ type: "error", message: "Lost WebSocket connection to Tue dev server. Reconnecting..." });
+		reconnectTimer = window.setTimeout(function () {
+			reconnectTimer = null;
+			connect();
+		}, 1000);
+	}
+
+	function connect() {
+		socket = new WebSocket(socketURL());
+		socket.onmessage = function (message) {
+			try {
+				handleEvent(JSON.parse(message.data));
+			} catch (error) {
+				showError({ type: "error", message: "Invalid Tue dev server message: " + String(error) });
+			}
+		};
+		socket.onclose = scheduleReconnect;
+		socket.onerror = function () {
+			socket.close();
+		};
+	}
+
+	connect();
 
 	window.addEventListener("error", function (event) {
 		showError({ type: "error", message: event.message || "Runtime error" });
@@ -475,39 +507,50 @@ func (b *devBroadcaster) unsubscribe(client chan devEvent) {
 	b.mu.Unlock()
 }
 
-func (b *devBroadcaster) serveEvents(w http.ResponseWriter, r *http.Request) {
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+func (b *devBroadcaster) serveWebSocket(serverCtx context.Context, w http.ResponseWriter, r *http.Request) {
+	conn, err := websocket.Accept(w, r, nil)
+	if err != nil {
 		return
 	}
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	socketCtx := conn.CloseRead(context.Background())
 
 	client, current := b.subscribe()
 	defer b.unsubscribe(client)
 
-	writeDevSSE(w, current)
-	flusher.Flush()
+	if err := writeDevWebSocketEvent(socketCtx, conn, current); err != nil {
+		return
+	}
 
 	for {
 		select {
 		case event := <-client:
-			writeDevSSE(w, event)
-			flusher.Flush()
-		case <-r.Context().Done():
+			if err := writeDevWebSocketEvent(socketCtx, conn, event); err != nil {
+				return
+			}
+		case <-socketCtx.Done():
+			return
+		case <-serverCtx.Done():
+			conn.Close(websocket.StatusGoingAway, "dev server stopped")
 			return
 		}
 	}
 }
 
-func writeDevSSE(w io.Writer, event devEvent) {
+func writeDevWebSocketEvent(ctx context.Context, conn *websocket.Conn, event devEvent) error {
+	source := devEventJSON(event)
+	writeCtx, cancel := context.WithTimeout(ctx, devWebSocketWriteTimeout)
+	defer cancel()
+	return conn.Write(writeCtx, websocket.MessageText, source)
+}
+
+func devEventJSON(event devEvent) []byte {
 	source, err := json.Marshal(event)
 	if err != nil {
 		source, _ = json.Marshal(devErrorEvent(fmt.Sprintf("encode dev event: %v", err), nil))
 	}
-	fmt.Fprintf(w, "data: %s\n\n", source)
+	return source
 }
 
 type devSnapshot map[string]devWatchedFile


### PR DESCRIPTION
## Summary

- replaced the dev reload stream with a `github.com/coder/websocket` endpoint at `/__tue/ws`
- updated the injected dev client to use native WebSocket, reconnect on connection loss, and keep the existing overlay behavior
- added WebSocket fan-out coverage for current and published dev events

## Validation

- `go test ./internal/cli`
- `go test -race ./internal/cli`
- `go fmt ./...`
- `go test ./...`
- `go test -race ./...`
- `git diff --check`
- `git diff --cached --check`
- `tokensave sync`