### PR TITLE
Added context-aware resource cancellation.

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -1,6 +1,9 @@
 package tue
 
-import "sync"
+import (
+	stdcontext "context"
+	"sync"
+)
 
 // Resource is the async-state interface exposed to component code.
 type Resource[T any] interface {
@@ -12,7 +15,7 @@ type Resource[T any] interface {
 
 // ResourceValue is the concrete runtime storage for async resource state.
 type ResourceValue[T any] struct {
-	load func() (T, error)
+	load func(stdcontext.Context) (T, error)
 
 	mu       sync.Mutex
 	value    T
@@ -21,12 +24,26 @@ type ResourceValue[T any] struct {
 	loading  bool
 	stopped  bool
 	runID    int
+	cancel   stdcontext.CancelFunc
 	dep      dependency
 }
 
 // ResourceOfFunc returns a resource backed by a load function and starts the
 // initial load immediately.
 func ResourceOfFunc[T any](ctx Context, load func() (T, error)) *ResourceValue[T] {
+	if load == nil {
+		return ResourceOfContextFunc[T](ctx, nil)
+	}
+	return ResourceOfContextFunc(ctx, func(stdcontext.Context) (T, error) {
+		return load()
+	})
+}
+
+// ResourceOfContextFunc returns a resource backed by a context-aware load
+// function and starts the initial load immediately. Cancellation is cooperative:
+// Reload and component cleanup cancel the load context, and stale results are
+// ignored if a loader keeps running after cancellation.
+func ResourceOfContextFunc[T any](ctx Context, load func(stdcontext.Context) (T, error)) *ResourceValue[T] {
 	resource := &ResourceValue[T]{load: load}
 	if ctx != nil {
 		ctx.OnCleanup(resource.stop)
@@ -78,36 +95,42 @@ func (r *ResourceValue[T]) Reload() {
 		return
 	}
 
-	load, runID, ok := r.beginLoad()
+	load, loadCtx, runID, ok := r.beginLoad()
 	if !ok {
 		return
 	}
 
 	go func() {
-		value, err := load()
+		value, err := load(loadCtx)
 		r.finishLoad(runID, value, err)
 	}()
 }
 
-func (r *ResourceValue[T]) beginLoad() (func() (T, error), int, bool) {
+func (r *ResourceValue[T]) beginLoad() (func(stdcontext.Context) (T, error), stdcontext.Context, int, bool) {
 	r.mu.Lock()
 	if r.stopped || r.load == nil {
 		r.mu.Unlock()
-		return nil, 0, false
+		return nil, nil, 0, false
 	}
 
 	var zero T
+	oldCancel := r.cancel
+	loadCtx, cancel := stdcontext.WithCancel(stdcontext.Background())
 	r.runID++
 	runID := r.runID
 	load := r.load
+	r.cancel = cancel
 	r.value = zero
 	r.hasValue = false
 	r.err = nil
 	r.loading = true
 	r.mu.Unlock()
 
+	if oldCancel != nil {
+		oldCancel()
+	}
 	r.dep.notify()
-	return load, runID, true
+	return load, loadCtx, runID, true
 }
 
 func (r *ResourceValue[T]) finishLoad(runID int, value T, err error) {
@@ -118,6 +141,8 @@ func (r *ResourceValue[T]) finishLoad(runID int, value T, err error) {
 	}
 
 	var zero T
+	cancel := r.cancel
+	r.cancel = nil
 	r.loading = false
 	r.err = err
 	if err != nil {
@@ -129,6 +154,9 @@ func (r *ResourceValue[T]) finishLoad(runID int, value T, err error) {
 	}
 	r.mu.Unlock()
 
+	if cancel != nil {
+		cancel()
+	}
 	r.dep.notify()
 }
 
@@ -140,8 +168,13 @@ func (r *ResourceValue[T]) stop() {
 	}
 	r.stopped = true
 	r.runID++
+	cancel := r.cancel
+	r.cancel = nil
 	r.loading = false
 	r.mu.Unlock()
 
+	if cancel != nil {
+		cancel()
+	}
 	r.dep.notify()
 }

--- a/resource_test.go
+++ b/resource_test.go
@@ -1,8 +1,10 @@
 package tue
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -101,6 +103,86 @@ func TestResourceReloadClearsValueAndLoadsLatestResult(t *testing.T) {
 	}
 }
 
+func TestResourceReloadCancelsPreviousContextLoad(t *testing.T) {
+	firstStarted := make(chan struct{})
+	firstCanceled := make(chan struct{})
+	secondStarted := make(chan struct{})
+	releaseSecond := make(chan struct{})
+	var loads int32
+	resource := ResourceOfContextFunc(nil, func(ctx context.Context) (string, error) {
+		switch atomic.AddInt32(&loads, 1) {
+		case 1:
+			close(firstStarted)
+			<-ctx.Done()
+			close(firstCanceled)
+			return "", ctx.Err()
+		case 2:
+			close(secondStarted)
+			<-releaseSecond
+			return "second", nil
+		default:
+			return "", fmt.Errorf("unexpected resource load")
+		}
+	})
+	if err := waitClosed(firstStarted, "first resource load start"); err != nil {
+		t.Fatalf("wait first resource load start: %v", err)
+	}
+
+	resource.Reload()
+
+	if err := waitClosed(secondStarted, "second resource load start"); err != nil {
+		t.Fatalf("wait second resource load start: %v", err)
+	}
+	if err := waitClosed(firstCanceled, "first resource load cancellation"); err != nil {
+		t.Fatalf("wait first resource load cancellation: %v", err)
+	}
+
+	close(releaseSecond)
+	actual, err := waitForResourceSnapshot(resource, func(snapshot resourceSnapshot[string]) bool {
+		return snapshot.HasValue && snapshot.Value == "second"
+	})
+	if err != nil {
+		t.Fatalf("wait second resource snapshot: %v", err)
+	}
+	expected := resourceSnapshot[string]{Value: "second", HasValue: true}
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Errorf("mismatch second resource snapshot (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestResourceReloadIgnoresCanceledLoadThatFinishesLate(t *testing.T) {
+	resource := &ResourceValue[string]{
+		load: func(context.Context) (string, error) {
+			return "", nil
+		},
+	}
+
+	_, _, staleRunID, ok := resource.beginLoad()
+	if !ok {
+		t.Fatal("begin first resource load returned ok=false")
+	}
+	_, _, currentRunID, ok := resource.beginLoad()
+	if !ok {
+		t.Fatal("begin second resource load returned ok=false")
+	}
+
+	// This models a context-aware loader that was canceled on reload but still
+	// kept running long enough to return after a newer load started.
+	resource.finishLoad(staleRunID, "stale", nil)
+
+	expected := resourceSnapshot[string]{Loading: true}
+	if diff := cmp.Diff(expected, snapshotResource(resource)); diff != "" {
+		t.Errorf("mismatch stale resource snapshot (-expected, +actual):\n%s", diff)
+	}
+
+	resource.finishLoad(currentRunID, "current", nil)
+
+	expected = resourceSnapshot[string]{Value: "current", HasValue: true}
+	if diff := cmp.Diff(expected, snapshotResource(resource)); diff != "" {
+		t.Errorf("mismatch current resource snapshot (-expected, +actual):\n%s", diff)
+	}
+}
+
 func TestResourceReloadNotifiesWatchersWhenLoadingStarts(t *testing.T) {
 	started := make(chan struct{}, 2)
 	release := make(chan struct{})
@@ -189,6 +271,42 @@ func TestResourceUnmountIgnoresLateInFlightLoad(t *testing.T) {
 	}
 }
 
+func TestResourceUnmountCancelsInFlightContextLoad(t *testing.T) {
+	fixture := &resourceContextUnmountFixture{
+		started:  make(chan struct{}),
+		canceled: make(chan error, 1),
+	}
+	mounted, err := mountComponent(CompOf(fixture, func(*resourceContextUnmountFixture) VNode {
+		return Text("resource")
+	}), newStubDOMTarget())
+	if err != nil {
+		t.Fatalf("mountComponent returned error: %v", err)
+	}
+	if err := waitClosed(fixture.started, "resource load start"); err != nil {
+		t.Fatalf("wait resource load start: %v", err)
+	}
+
+	expected := resourceSnapshot[string]{Loading: true}
+	if diff := cmp.Diff(expected, snapshotResource(fixture.resource)); diff != "" {
+		t.Errorf("mismatch mounted resource snapshot (-expected, +actual):\n%s", diff)
+	}
+
+	if err := mounted.Unmount(); err != nil {
+		t.Fatalf("Unmount returned error: %v", err)
+	}
+	cancelErr, err := receiveError(fixture.canceled, "resource load cancellation")
+	if err != nil {
+		t.Fatalf("wait resource load cancellation: %v", err)
+	}
+	if !errors.Is(cancelErr, context.Canceled) {
+		t.Errorf("resource load cancellation actual = %v, expected %v", cancelErr, context.Canceled)
+	}
+	expected = resourceSnapshot[string]{}
+	if diff := cmp.Diff(expected, snapshotResource(fixture.resource)); diff != "" {
+		t.Errorf("mismatch canceled resource snapshot (-expected, +actual):\n%s", diff)
+	}
+}
+
 type resourceSnapshot[T any] struct {
 	Value    T
 	HasValue bool
@@ -246,6 +364,15 @@ func waitClosed(done <-chan struct{}, subject string) error {
 	}
 }
 
+func receiveError(done <-chan error, subject string) (error, error) {
+	select {
+	case err := <-done:
+		return err, nil
+	case <-time.After(time.Second):
+		return nil, fmt.Errorf("timed out waiting for %s", subject)
+	}
+}
+
 type resourceUnmountFixture struct {
 	resource Resource[string]
 	started  chan struct{}
@@ -259,5 +386,20 @@ func (f *resourceUnmountFixture) Init(ctx Context) {
 		<-f.release
 		close(f.finished)
 		return "late", nil
+	})
+}
+
+type resourceContextUnmountFixture struct {
+	resource Resource[string]
+	started  chan struct{}
+	canceled chan error
+}
+
+func (f *resourceContextUnmountFixture) Init(ctx Context) {
+	f.resource = ResourceOfContextFunc(ctx, func(loadCtx context.Context) (string, error) {
+		close(f.started)
+		<-loadCtx.Done()
+		f.canceled <- loadCtx.Err()
+		return "late", loadCtx.Err()
 	})
 }


### PR DESCRIPTION
## Summary
- Added ResourceOfContextFunc for loaders that accept context.Context.
- Canceled the previous context-aware load on Reload and canceled in-flight context-aware loads during component cleanup.
- Documented cooperative cancellation and guarded stale context-aware load completions after reload.
- Kept ResourceOfFunc source-compatible for context-free loaders.

## Validation
- go fmt ./...
- go test ./... -run 'TestResource'
- go test ./...
- go test -race ./...
- git diff --check && git diff --cached --check
- no golangci-lint config found