### PR TITLE
Added raw router query state.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -17,12 +17,13 @@ Replace `todo` with any example directory:
 - `user-table`: text filtering, checkbox state, method-derived lists, and table rendering
 - `settings-form`: string and boolean `v-model` controls, including textarea, with save/dirty feedback
 - `dashboard`: component props, default slots, scoped styles, and child components
-- `router`: explicit hash routes, `router.Href` links, route params, and not-found state
+- `router`: explicit hash routes, `router.Href` links, route params, raw query strings with parsed query helpers, and not-found state
 
 The router example intentionally uses Tue's small hash router, not a Vue Router
-replacement. It matches normalized paths only, does not expose query helpers
-yet, and creates the router in `Init(ctx)` so the browser hash listener can be
-cleaned up when the component unmounts.
+replacement. It matches normalized paths, exposes the raw query string plus
+parsed query helpers without typed parsing, and creates the router in
+`Init(ctx)` so the browser hash listener can be cleaned up when the component
+unmounts.
 
 `tue dev` serves the generated `dist/` directory and rebuilds as files change.
 `tue build` writes production output to the example's `dist/` directory.

--- a/examples/router/App.tue
+++ b/examples/router/App.tue
@@ -9,6 +9,7 @@
 		<nav>
 			<a :href="homeHref" :class="homeClass">Overview</a>
 			<a :href="userHref" :class="userClass">User 42</a>
+			<a :href="userProfileHref" :class="userClass">User 42 profile</a>
 			<a :href="settingsHref" :class="settingsClass">Settings</a>
 			<a :href="missingHref">Missing route</a>
 		</nav>
@@ -21,6 +22,7 @@
 		<section v-if="userActive" class="panel">
 			<h2>User detail</h2>
 			<p>User ID: {{ currentUserID }}</p>
+			<p>Tab: {{ currentTab }}</p>
 		</section>
 
 		<section v-if="settingsActive" class="panel">
@@ -44,10 +46,12 @@ type App struct {
 	router          *tue.Router
 	homeHref        string
 	userHref        string
+	userProfileHref string
 	settingsHref    string
 	missingHref     string
 	routeLabel      tue.Computed[string]
 	currentUserID   tue.Computed[string]
+	currentTab      tue.Computed[string]
 	notFoundMessage tue.Computed[string]
 	homeActive      tue.Computed[bool]
 	userActive      tue.Computed[bool]
@@ -68,6 +72,7 @@ func (a *App) Init(ctx tue.Context) {
 	})
 	a.homeHref = a.router.Href("/")
 	a.userHref = a.router.Href("/users/42")
+	a.userProfileHref = a.router.Href("/users/42?tab=profile")
 	a.settingsHref = a.router.Href("/settings")
 	a.missingHref = a.router.Href("/missing")
 	a.routeLabel = tue.ComputedOfFunc(func() string {
@@ -79,6 +84,13 @@ func (a *App) Init(ctx tue.Context) {
 	})
 	a.currentUserID = tue.ComputedOfFunc(func() string {
 		return a.router.Current().Param("id")
+	})
+	a.currentTab = tue.ComputedOfFunc(func() string {
+		tab := a.router.Current().QueryParam("tab")
+		if tab == "" {
+			return "summary"
+		}
+		return tab
 	})
 	a.notFoundMessage = tue.ComputedOfFunc(func() string {
 		return "No route matched " + a.router.Current().Path

--- a/router.go
+++ b/router.go
@@ -12,13 +12,16 @@ type Route struct {
 	Render func(RouteMatch) VNode
 }
 
-// RouteMatch is the current matched route state. The first router matches path
-// segments only; query strings and fragments are not preserved in RouteMatch.
+// RouteMatch is the current matched route state. The router matches path
+// segments only. RawQuery preserves the query string, while Query and
+// QueryParam expose parsed url.Values when the query is valid.
 type RouteMatch struct {
-	Path    string
-	Pattern string
-	Params  map[string]string
-	Found   bool
+	Path     string
+	Pattern  string
+	Params   map[string]string
+	RawQuery string
+	Query    url.Values
+	Found    bool
 }
 
 // Param returns a matched path parameter by name.
@@ -27,6 +30,14 @@ func (m RouteMatch) Param(name string) string {
 		return ""
 	}
 	return m.Params[name]
+}
+
+// QueryParam returns the first query value by name.
+func (m RouteMatch) QueryParam(name string) string {
+	if m.Query == nil {
+		return ""
+	}
+	return m.Query.Get(name)
 }
 
 // Router keeps reactive route state for a small explicit route table.
@@ -92,7 +103,7 @@ func (r *Router) Navigate(path string) {
 	if r == nil {
 		return
 	}
-	path = normalizeRoutePath(path)
+	path = normalizeRouteTarget(path).String()
 	if r.location != nil {
 		r.location.SetPath(path)
 	}
@@ -101,7 +112,7 @@ func (r *Router) Navigate(path string) {
 
 // Href returns the link target for a route path.
 func (r *Router) Href(path string) string {
-	path = normalizeRoutePath(path)
+	path = normalizeRouteTarget(path).String()
 	if r == nil || r.location == nil {
 		return "#" + path
 	}
@@ -145,18 +156,20 @@ func (r *Router) setPath(path string) {
 }
 
 func (r *Router) match(path string) RouteMatch {
-	path = normalizeRoutePath(path)
+	target := normalizeRouteTarget(path)
 	for _, route := range r.routes {
-		if params, ok := matchRouteSegments(route.segments, routeSegments(path)); ok {
+		if params, ok := matchRouteSegments(route.segments, routeSegments(target.Path)); ok {
 			return RouteMatch{
-				Path:    path,
-				Pattern: route.pattern,
-				Params:  params,
-				Found:   true,
+				Path:     target.Path,
+				Pattern:  route.pattern,
+				Params:   params,
+				RawQuery: target.RawQuery,
+				Query:    target.Query,
+				Found:    true,
 			}
 		}
 	}
-	return RouteMatch{Path: path}
+	return RouteMatch{Path: target.Path, RawQuery: target.RawQuery, Query: target.Query}
 }
 
 func (r *Router) routeForPattern(pattern string) *Route {
@@ -241,6 +254,48 @@ func normalizeRoutePath(path string) string {
 	return cleaned
 }
 
+type routeTarget struct {
+	Path     string
+	RawQuery string
+	Query    url.Values
+}
+
+func (t routeTarget) String() string {
+	if t.RawQuery == "" {
+		return t.Path
+	}
+	return t.Path + "?" + t.RawQuery
+}
+
+func normalizeRouteTarget(path string) routeTarget {
+	path = strings.TrimSpace(path)
+	path = strings.TrimPrefix(path, "#")
+	if path == "" {
+		return routeTarget{Path: "/"}
+	}
+
+	parsed, err := url.Parse(path)
+	if err != nil {
+		return routeTarget{Path: normalizeRoutePath(path)}
+	}
+	routePath := parsed.EscapedPath()
+	if routePath == "" {
+		routePath = parsed.Path
+	}
+
+	target := routeTarget{
+		Path:     normalizeRoutePath(routePath),
+		RawQuery: parsed.RawQuery,
+	}
+	if target.RawQuery != "" {
+		query, err := url.ParseQuery(target.RawQuery)
+		if err == nil {
+			target.Query = query
+		}
+	}
+	return target
+}
+
 func routeSegments(path string) []string {
 	path = strings.Trim(normalizeRoutePath(path), "/")
 	if path == "" {
@@ -259,6 +314,7 @@ func decodeRouteSegment(segment string) string {
 
 func cloneRouteMatch(match RouteMatch) RouteMatch {
 	match.Params = cloneRouteParams(match.Params)
+	match.Query = cloneRouteQuery(match.Query)
 	return match
 }
 
@@ -273,8 +329,19 @@ func cloneRouteParams(params map[string]string) map[string]string {
 	return cloned
 }
 
+func cloneRouteQuery(query url.Values) url.Values {
+	if len(query) == 0 {
+		return nil
+	}
+	cloned := make(url.Values, len(query))
+	for name, values := range query {
+		cloned[name] = append([]string(nil), values...)
+	}
+	return cloned
+}
+
 func sameRouteMatch(left RouteMatch, right RouteMatch) bool {
-	if left.Path != right.Path || left.Pattern != right.Pattern || left.Found != right.Found {
+	if left.Path != right.Path || left.Pattern != right.Pattern || left.RawQuery != right.RawQuery || left.Found != right.Found {
 		return false
 	}
 	if len(left.Params) != len(right.Params) {

--- a/router_location.go
+++ b/router_location.go
@@ -14,18 +14,18 @@ func (l *memoryRouteLocation) Path() string {
 	if l == nil {
 		return "/"
 	}
-	return normalizeRoutePath(l.path)
+	return normalizeRouteTarget(l.path).String()
 }
 
 func (l *memoryRouteLocation) SetPath(path string) {
 	if l == nil {
 		return
 	}
-	l.path = normalizeRoutePath(path)
+	l.path = normalizeRouteTarget(path).String()
 }
 
 func (l *memoryRouteLocation) Href(path string) string {
-	return "#" + normalizeRoutePath(path)
+	return "#" + normalizeRouteTarget(path).String()
 }
 
 func (l *memoryRouteLocation) Watch(func(string)) func() {

--- a/router_location_js.go
+++ b/router_location_js.go
@@ -15,7 +15,7 @@ func (hashRouteLocation) Path() string {
 	if location.IsUndefined() || location.IsNull() {
 		return "/"
 	}
-	return normalizeRoutePath(location.Get("hash").String())
+	return normalizeRouteTarget(location.Get("hash").String()).String()
 }
 
 func (hashRouteLocation) SetPath(path string) {
@@ -23,11 +23,11 @@ func (hashRouteLocation) SetPath(path string) {
 	if location.IsUndefined() || location.IsNull() {
 		return
 	}
-	location.Set("hash", normalizeRoutePath(path))
+	location.Set("hash", normalizeRouteTarget(path).String())
 }
 
 func (hashRouteLocation) Href(path string) string {
-	return "#" + normalizeRoutePath(path)
+	return "#" + normalizeRouteTarget(path).String()
 }
 
 func (l hashRouteLocation) Watch(handler func(string)) func() {

--- a/router_test.go
+++ b/router_test.go
@@ -2,6 +2,7 @@ package tue
 
 import (
 	"fmt"
+	"net/url"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -51,19 +52,43 @@ func TestRouterReportsNotFoundRoute(t *testing.T) {
 	}
 }
 
-func TestRouterMatchesPathsWithoutQueryOrFragment(t *testing.T) {
+func TestRouterPreservesQueryAndDropsFragmentForMatching(t *testing.T) {
 	router := RouterOf(nil, []Route{{Path: "/users/:id"}}, nil)
 
-	router.Navigate("/users/42?tab=profile#bio")
+	router.Navigate("/users/42?tab=profile&filter=active#bio")
 
 	expected := RouteMatch{
-		Path:    "/users/42",
-		Pattern: "/users/:id",
-		Params:  map[string]string{"id": "42"},
-		Found:   true,
+		Path:     "/users/42",
+		Pattern:  "/users/:id",
+		Params:   map[string]string{"id": "42"},
+		RawQuery: "tab=profile&filter=active",
+		Query:    url.Values{"filter": []string{"active"}, "tab": []string{"profile"}},
+		Found:    true,
 	}
 	if diff := cmp.Diff(expected, router.Current()); diff != "" {
-		t.Errorf("mismatch normalized route without query or fragment (-expected, +actual):\n%s", diff)
+		t.Errorf("mismatch route with query and fragment (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff("profile", router.Current().QueryParam("tab")); diff != "" {
+		t.Errorf("mismatch route query param (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestRouterPreservesInvalidRawQueryWithoutParsedValues(t *testing.T) {
+	router := RouterOf(nil, []Route{{Path: "/search"}}, nil)
+
+	router.Navigate("/search?q=%zz&ok=true")
+
+	expected := RouteMatch{
+		Path:     "/search",
+		Pattern:  "/search",
+		RawQuery: "q=%zz&ok=true",
+		Found:    true,
+	}
+	if diff := cmp.Diff(expected, router.Current()); diff != "" {
+		t.Errorf("mismatch route with invalid query escape (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff("", router.Current().QueryParam("ok")); diff != "" {
+		t.Errorf("mismatch invalid route query param (-expected, +actual):\n%s", diff)
 	}
 }
 
@@ -132,6 +157,46 @@ func TestRouterCurrentIsReactive(t *testing.T) {
 	}
 }
 
+func TestRouterCurrentReactsToQueryChanges(t *testing.T) {
+	router := RouterOf(nil, []Route{{Path: "/search"}}, nil)
+	renderCount := 0
+	target := newStubDOMTarget()
+
+	mounted, err := mountComponent(CompOf(&routerFixture{router: router}, func(fixture *routerFixture) VNode {
+		renderCount++
+		return Text(fixture.router.Current().QueryParam("q"))
+	}), target)
+	if err != nil {
+		t.Fatalf("mountComponent returned error: %v", err)
+	}
+
+	if diff := cmp.Diff("", target.html()); diff != "" {
+		t.Errorf("mismatch initial query render (-expected, +actual):\n%s", diff)
+	}
+
+	router.Navigate("/search?q=alpha")
+
+	if diff := cmp.Diff("alpha", target.html()); diff != "" {
+		t.Errorf("mismatch first query render (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff(2, renderCount); diff != "" {
+		t.Errorf("mismatch first query render count (-expected, +actual):\n%s", diff)
+	}
+
+	router.Navigate("/search?q=beta")
+
+	if diff := cmp.Diff("beta", target.html()); diff != "" {
+		t.Errorf("mismatch second query render (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff(3, renderCount); diff != "" {
+		t.Errorf("mismatch second query render count (-expected, +actual):\n%s", diff)
+	}
+
+	if err := mounted.Unmount(); err != nil {
+		t.Fatalf("Unmount returned error: %v", err)
+	}
+}
+
 func TestRouterLinkReturnsHashAnchor(t *testing.T) {
 	router := RouterOf(nil, nil, nil)
 	actual := RenderHTML(router.Link("/settings", []Attribute{Attr("class", "nav-link")}, []VNode{Text("Settings")}))
@@ -139,6 +204,14 @@ func TestRouterLinkReturnsHashAnchor(t *testing.T) {
 	expected := `<a class="nav-link" href="#/settings">Settings</a>`
 	if diff := cmp.Diff(expected, actual); diff != "" {
 		t.Errorf("mismatch router link (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestRouterHrefPreservesQuery(t *testing.T) {
+	router := RouterOf(nil, nil, nil)
+
+	if diff := cmp.Diff("#/settings?tab=profile", router.Href("/settings?tab=profile")); diff != "" {
+		t.Errorf("mismatch router href with query (-expected, +actual):\n%s", diff)
 	}
 }
 
@@ -151,6 +224,22 @@ func TestRouterCurrentReturnsCopyOfParams(t *testing.T) {
 
 	if diff := cmp.Diff("42", router.Current().Param("id")); diff != "" {
 		t.Errorf("mismatch copied route params (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestRouterCurrentReturnsCopyOfQuery(t *testing.T) {
+	router := RouterOf(nil, []Route{{Path: "/search"}}, nil)
+	router.Navigate("/search?tag=go&tag=wasm")
+
+	match := router.Current()
+	match.Query["tag"][0] = "mutated"
+	match.Query.Set("new", "value")
+
+	if diff := cmp.Diff("go", router.Current().QueryParam("tag")); diff != "" {
+		t.Errorf("mismatch copied route query value (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff("", router.Current().QueryParam("new")); diff != "" {
+		t.Errorf("mismatch copied route query key (-expected, +actual):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Preserved raw query strings in RouteMatch while keeping route matching path-only.
- Added Query and QueryParam access for router state, with defensive copies from Current().
- Preserved query strings in Router.Href, memory routing, and hash routing.
- Updated the router example to demonstrate query-driven UI.

## Validation
- go fmt ./...
- go test ./... -run 'TestRouter'
- go run ./cmd/tue check examples/router
- go run ./cmd/tue build examples/router
- go test ./...
- go test -race ./...
- git diff --check && git diff --cached --check
- no golangci-lint config found