### PR TITLE
Added conditional chain and switch directives.

### DIFF
--- a/internal/compiler/checker/checker_test.go
+++ b/internal/compiler/checker/checker_test.go
@@ -29,6 +29,19 @@ func TestCheckProjectAcceptsValidProject(t *testing.T) {
 	}
 }
 
+func TestCheckProjectAcceptsConditionalControlFlow(t *testing.T) {
+	project, err := parseProjectFixture("testdata/conditional_control_flow")
+	if err != nil {
+		t.Fatalf("parse project fixture: %v", err)
+	}
+
+	diagnostics := CheckProject(project)
+	expected := []diagnosticSummary{}
+	if diff := cmp.Diff(expected, summarizeDiagnostics(diagnostics)); diff != "" {
+		t.Errorf("mismatch diagnostics (-expected, +actual):\n%s", diff)
+	}
+}
+
 func TestCheckProjectReportsTemplateDiagnostics(t *testing.T) {
 	project, err := parseProjectFixture("testdata/invalid")
 	if err != nil {
@@ -196,9 +209,40 @@ func TestCheckProjectReportsControlFlowDiagnostics(t *testing.T) {
 
 	diagnostics := CheckProject(project)
 	expected := []diagnosticSummary{
-		{Path: "testdata/invalid_control_flow/Parent.tue", Message: `v-else must follow v-if`, Line: 3, Column: 6},
-		{Path: "testdata/invalid_control_flow/Parent.tue", Message: `v-else cannot follow v-if on an element that also has v-for; use a <template v-for> wrapper`, Line: 6, Column: 8},
-		{Path: "testdata/invalid_control_flow/Parent.tue", Message: `v-else must follow v-if`, Line: 9, Column: 8},
+		{Path: "testdata/invalid_control_flow/Parent.tue", Message: `v-else must follow v-if or v-else-if`, Line: 3, Column: 6},
+		{Path: "testdata/invalid_control_flow/Parent.tue", Message: `v-else cannot follow a conditional branch that also has v-for; use a <template v-for> wrapper`, Line: 6, Column: 8},
+		{Path: "testdata/invalid_control_flow/Parent.tue", Message: `v-else must follow v-if or v-else-if`, Line: 9, Column: 8},
+	}
+	if diff := cmp.Diff(expected, summarizeDiagnostics(diagnostics)); diff != "" {
+		t.Errorf("mismatch diagnostics (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestCheckProjectReportsConditionalControlFlowDiagnostics(t *testing.T) {
+	project, err := parseProjectFixture("testdata/invalid_conditional_control_flow")
+	if err != nil {
+		t.Fatalf("parse project fixture: %v", err)
+	}
+
+	diagnostics := CheckProject(project)
+	expected := []diagnosticSummary{
+		{Path: "testdata/invalid_conditional_control_flow/Parent.tue", Message: `v-else-if must follow v-if or v-else-if`, Line: 3, Column: 6},
+		{Path: "testdata/invalid_conditional_control_flow/Parent.tue", Message: `v-else must follow v-if or v-else-if`, Line: 4, Column: 6},
+		{Path: "testdata/invalid_conditional_control_flow/Parent.tue", Message: `v-else-if expects bool, got string`, Line: 7, Column: 17},
+		{Path: "testdata/invalid_conditional_control_flow/Parent.tue", Message: `v-else-if cannot be combined with v-for; use a <template v-for> wrapper`, Line: 8, Column: 6},
+		{Path: "testdata/invalid_conditional_control_flow/Parent.tue", Message: `v-switch children must use v-case or v-default`, Line: 12, Column: 4},
+		{Path: "testdata/invalid_conditional_control_flow/Parent.tue", Message: `v-case expects string, got int`, Line: 13, Column: 15},
+		{Path: "testdata/invalid_conditional_control_flow/Parent.tue", Message: `v-case must appear before v-default`, Line: 15, Column: 7},
+		{Path: "testdata/invalid_conditional_control_flow/Parent.tue", Message: `v-switch may only have one v-default`, Line: 16, Column: 7},
+		{Path: "testdata/invalid_conditional_control_flow/Parent.tue", Message: `v-case must appear before v-default`, Line: 17, Column: 7},
+		{Path: "testdata/invalid_conditional_control_flow/Parent.tue", Message: `v-switch branches cannot combine v-case or v-default with v-if, v-else-if, or v-else`, Line: 17, Column: 24},
+		{Path: "testdata/invalid_conditional_control_flow/Parent.tue", Message: `v-switch is only supported on <template>`, Line: 20, Column: 8},
+		{Path: "testdata/invalid_conditional_control_flow/Parent.tue", Message: `v-case must be a direct child of v-switch`, Line: 21, Column: 6},
+		{Path: "testdata/invalid_conditional_control_flow/Parent.tue", Message: `v-default must be a direct child of v-switch`, Line: 22, Column: 6},
+		{Path: "testdata/invalid_conditional_control_flow/Parent.tue", Message: `v-switch expression type []string is not comparable`, Line: 23, Column: 23},
+		{Path: "testdata/invalid_conditional_control_flow/Parent.tue", Message: `v-switch requires at least one v-case or v-default child`, Line: 23, Column: 13},
+		{Path: "testdata/invalid_conditional_control_flow/Parent.tue", Message: `v-switch expression type Filter is not comparable`, Line: 24, Column: 23},
+		{Path: "testdata/invalid_conditional_control_flow/Parent.tue", Message: `v-switch expression type bytes.Buffer is not comparable`, Line: 27, Column: 23},
 	}
 	if diff := cmp.Diff(expected, summarizeDiagnostics(diagnostics)); diff != "" {
 		t.Errorf("mismatch diagnostics (-expected, +actual):\n%s", diff)

--- a/internal/compiler/checker/directive.go
+++ b/internal/compiler/checker/directive.go
@@ -3,6 +3,7 @@ package checker
 import (
 	"fmt"
 	"go/ast"
+	"strings"
 
 	"github.com/norunners/tue/internal/compiler/sfc"
 	gotemplate "github.com/norunners/tue/internal/compiler/template"
@@ -17,16 +18,89 @@ func (c *fileChecker) checkCommonAttrs(node *gotemplate.Node, scope *scope, chec
 			}
 		case gotemplate.AttrDirective:
 			switch attr.Directive {
-			case gotemplate.DirectiveIf:
+			case gotemplate.DirectiveIf, gotemplate.DirectiveElseIf:
 				value := c.checkExpression(attr.Expression, attr.ExpressionSpan, scope)
-				c.expectType("bool", value.Type, "v-if", attr.ExpressionSpan)
+				c.expectType("bool", value.Type, attr.RawName, attr.ExpressionSpan)
 			case gotemplate.DirectiveHTML:
 				c.checkHTML(node, attr, scope)
 			case gotemplate.DirectiveModel:
 				c.checkModel(node, attr, scope)
-			case gotemplate.DirectiveFor, gotemplate.DirectiveElse:
+			case gotemplate.DirectiveFor, gotemplate.DirectiveElse, gotemplate.DirectiveSwitch, gotemplate.DirectiveCase, gotemplate.DirectiveDefault:
 			}
 		}
+	}
+}
+
+func (c *fileChecker) checkSwitch(node *gotemplate.Node, attr gotemplate.Attr, scope *scope) {
+	hostValid := node != nil && node.Tag == "template" && !node.IsComponent
+	if !hostValid {
+		c.add("v-switch is only supported on <template>", attr.DirectiveSpan)
+	}
+	if conditionalAttr, ok := firstConditionalDirective(node); ok {
+		c.add("v-switch cannot be combined with v-if, v-else-if, or v-else", conditionalAttr.DirectiveSpan)
+	}
+	if caseAttr, ok := directiveAttr(node, gotemplate.DirectiveCase); ok {
+		c.add("v-switch cannot be combined with v-case on the same element", caseAttr.DirectiveSpan)
+	}
+	if defaultAttr, ok := directiveAttr(node, gotemplate.DirectiveDefault); ok {
+		c.add("v-switch cannot be combined with v-default on the same element", defaultAttr.DirectiveSpan)
+	}
+
+	switchValue := c.checkExpression(attr.Expression, attr.ExpressionSpan, scope)
+	if !isSwitchComparableType(switchValue.Type, c.comparable) {
+		c.add(fmt.Sprintf("v-switch expression type %s is not comparable", displayType(switchValue.Type)), attr.ExpressionSpan)
+	}
+	if !hostValid {
+		return
+	}
+
+	branchCount := 0
+	defaultSeen := false
+	for _, branch := range node.Children {
+		if ignorableControlSibling(branch) {
+			continue
+		}
+		branchCount++
+
+		caseAttr, hasCase := directiveAttr(branch, gotemplate.DirectiveCase)
+		defaultAttr, hasDefault := directiveAttr(branch, gotemplate.DirectiveDefault)
+		switch {
+		case hasCase && hasDefault:
+			c.add("v-switch branch cannot use both v-case and v-default", defaultAttr.DirectiveSpan)
+		case hasCase:
+			if defaultSeen {
+				c.add("v-case must appear before v-default", caseAttr.DirectiveSpan)
+			}
+			caseValue := c.checkExpression(caseAttr.Expression, caseAttr.ExpressionSpan, scope)
+			if !switchTypesCompatible(switchValue.Type, caseValue.Type) {
+				c.add(
+					fmt.Sprintf("v-case expects %s, got %s", displayType(switchValue.Type), displayType(caseValue.Type)),
+					caseAttr.ExpressionSpan,
+				)
+			}
+		case hasDefault:
+			if defaultSeen {
+				c.add("v-switch may only have one v-default", defaultAttr.DirectiveSpan)
+			}
+			defaultSeen = true
+		default:
+			c.add("v-switch children must use v-case or v-default", branch.Span)
+		}
+
+		if conditionalAttr, ok := firstConditionalDirective(branch); ok {
+			c.add("v-switch branches cannot combine v-case or v-default with v-if, v-else-if, or v-else", conditionalAttr.DirectiveSpan)
+		}
+		checkBranch := true
+		if nestedSwitch, ok := directiveAttr(branch, gotemplate.DirectiveSwitch); ok {
+			c.add("a v-switch branch must nest another v-switch inside its content", nestedSwitch.DirectiveSpan)
+			checkBranch = false
+		}
+		if checkBranch {
+			c.checkNode(branch, scope)
+		}
+	}
+	if branchCount == 0 {
+		c.add("v-switch requires at least one v-case or v-default child", attr.DirectiveSpan)
 	}
 }
 
@@ -219,6 +293,56 @@ func directiveAttr(node *gotemplate.Node, kind gotemplate.DirectiveKind) (gotemp
 func hasDirective(node *gotemplate.Node, kind gotemplate.DirectiveKind) bool {
 	_, ok := directiveAttr(node, kind)
 	return ok
+}
+
+func isControlDirective(kind gotemplate.DirectiveKind) bool {
+	switch kind {
+	case gotemplate.DirectiveIf,
+		gotemplate.DirectiveElseIf,
+		gotemplate.DirectiveElse,
+		gotemplate.DirectiveFor,
+		gotemplate.DirectiveSwitch,
+		gotemplate.DirectiveCase,
+		gotemplate.DirectiveDefault:
+		return true
+	default:
+		return false
+	}
+}
+
+func firstConditionalDirective(node *gotemplate.Node) (gotemplate.Attr, bool) {
+	for _, kind := range []gotemplate.DirectiveKind{
+		gotemplate.DirectiveIf,
+		gotemplate.DirectiveElseIf,
+		gotemplate.DirectiveElse,
+	} {
+		if attr, ok := directiveAttr(node, kind); ok {
+			return attr, true
+		}
+	}
+	return gotemplate.Attr{}, false
+}
+
+func switchTypesCompatible(switchType string, caseType string) bool {
+	return assignable(switchType, caseType) || assignable(caseType, switchType)
+}
+
+func isSwitchComparableType(typ string, comparable map[string]bool) bool {
+	typ = strings.TrimSpace(typ)
+	if strings.HasPrefix(typ, "*") {
+		return true
+	}
+	typ = normalizeType(typ)
+	if typ == "" || typ == unknownType {
+		return true
+	}
+	if declared, ok := comparable[typ]; ok {
+		return declared
+	}
+	return typ != "any" && typ != "interface{}" &&
+		!strings.HasPrefix(typ, "[]") &&
+		!strings.HasPrefix(typ, "map[") &&
+		!strings.HasPrefix(typ, "func(")
 }
 
 func hasBoundKey(node *gotemplate.Node) bool {

--- a/internal/compiler/checker/file.go
+++ b/internal/compiler/checker/file.go
@@ -14,27 +14,59 @@ type fileChecker struct {
 	component   *script.Component
 	components  map[string]componentBinding
 	structs     map[string]map[string]script.Field
+	comparable  map[string]bool
 	diagnostics []Diagnostic
 }
 
 func (c *fileChecker) checkNodes(nodes []*gotemplate.Node, scope *scope) {
-	previousIf := false
-	previousIfHasFor := false
+	previousConditional := false
+	previousConditionalHasFor := false
 	for _, node := range nodes {
 		if ignorableControlSibling(node) {
 			continue
 		}
-		if attr, ok := directiveAttr(node, gotemplate.DirectiveElse); ok {
+
+		if attr, ok := directiveAttr(node, gotemplate.DirectiveCase); ok {
+			c.add("v-case must be a direct child of v-switch", attr.DirectiveSpan)
+		}
+		if attr, ok := directiveAttr(node, gotemplate.DirectiveDefault); ok {
+			c.add("v-default must be a direct child of v-switch", attr.DirectiveSpan)
+		}
+
+		if attr, ok := directiveAttr(node, gotemplate.DirectiveElseIf); ok {
 			switch {
-			case !previousIf:
-				c.add("v-else must follow v-if", attr.DirectiveSpan)
-			case previousIfHasFor:
-				c.add("v-else cannot follow v-if on an element that also has v-for; use a <template v-for> wrapper", attr.DirectiveSpan)
+			case !previousConditional:
+				c.add("v-else-if must follow v-if or v-else-if", attr.DirectiveSpan)
+			case previousConditionalHasFor:
+				c.add("v-else-if cannot follow a conditional branch that also has v-for; use a <template v-for> wrapper", attr.DirectiveSpan)
+			}
+			if hasDirective(node, gotemplate.DirectiveFor) {
+				c.add("v-else-if cannot be combined with v-for; use a <template v-for> wrapper", attr.DirectiveSpan)
+			}
+		} else if attr, ok := directiveAttr(node, gotemplate.DirectiveElse); ok {
+			switch {
+			case !previousConditional:
+				c.add("v-else must follow v-if or v-else-if", attr.DirectiveSpan)
+			case previousConditionalHasFor:
+				c.add("v-else cannot follow a conditional branch that also has v-for; use a <template v-for> wrapper", attr.DirectiveSpan)
+			}
+			if hasDirective(node, gotemplate.DirectiveFor) {
+				c.add("v-else cannot be combined with v-for; use a <template v-for> wrapper", attr.DirectiveSpan)
 			}
 		}
 		c.checkNode(node, scope)
-		previousIf = hasDirective(node, gotemplate.DirectiveIf)
-		previousIfHasFor = previousIf && hasDirective(node, gotemplate.DirectiveFor)
+
+		switch {
+		case hasDirective(node, gotemplate.DirectiveIf):
+			previousConditional = true
+			previousConditionalHasFor = hasDirective(node, gotemplate.DirectiveFor)
+		case hasDirective(node, gotemplate.DirectiveElseIf) && previousConditional:
+			previousConditional = true
+			previousConditionalHasFor = false
+		default:
+			previousConditional = false
+			previousConditionalHasFor = false
+		}
 	}
 }
 
@@ -55,6 +87,10 @@ func (c *fileChecker) checkElement(node *gotemplate.Node, scope *scope) {
 	elementScope := scope
 	if attr, ok := directiveAttr(node, gotemplate.DirectiveFor); ok {
 		elementScope = c.checkFor(node, attr, scope)
+	}
+	if attr, ok := directiveAttr(node, gotemplate.DirectiveSwitch); ok {
+		c.checkSwitch(node, attr, elementScope)
+		return
 	}
 
 	if node.IsComponent {
@@ -95,7 +131,7 @@ func (c *fileChecker) checkNativeAttrs(node *gotemplate.Node, scope *scope) {
 
 func (c *fileChecker) checkSlot(node *gotemplate.Node) {
 	for _, attr := range node.Attrs {
-		if attr.Kind == gotemplate.AttrDirective && (attr.Directive == gotemplate.DirectiveIf || attr.Directive == gotemplate.DirectiveFor) {
+		if attr.Kind == gotemplate.AttrDirective && isControlDirective(attr.Directive) {
 			continue
 		}
 		if isNamedSlotAttr(attr) {

--- a/internal/compiler/checker/project.go
+++ b/internal/compiler/checker/project.go
@@ -81,6 +81,7 @@ func (c *projectChecker) checkFile(file File) {
 		component:  file.Script.Component,
 		components: c.components,
 		structs:    structFieldMaps(file.Script.Structs),
+		comparable: comparableTypeMap(file.Script.Types),
 	}
 	fileChecker.checkNodes(file.Template.Nodes, componentScope(file.Script.Component))
 	c.diagnostics = append(c.diagnostics, fileChecker.diagnostics...)

--- a/internal/compiler/checker/scope.go
+++ b/internal/compiler/checker/scope.go
@@ -115,6 +115,14 @@ func structFieldMaps(structs []script.Struct) map[string]map[string]script.Field
 	return byType
 }
 
+func comparableTypeMap(types []script.TypeInfo) map[string]bool {
+	comparable := make(map[string]bool, len(types))
+	for _, info := range types {
+		comparable[info.Expression] = info.Comparable
+	}
+	return comparable
+}
+
 func iterableTypesFor(typ string) (iterableTypes, bool) {
 	typ = normalizeType(typ)
 	if typ == unknownType || typ == "" {

--- a/internal/compiler/checker/testdata/conditional_control_flow/Parent.tue
+++ b/internal/compiler/checker/testdata/conditional_control_flow/Parent.tue
@@ -1,0 +1,26 @@
+<template>
+	<main>
+		<p v-if="loading">Loading</p>
+		<p v-else-if="failed">Failed</p>
+		<p v-else>Ready</p>
+
+		<template v-switch="status">
+			<p v-case='"loading"'>Loading status</p>
+			<template v-case='"ready"'>
+				<strong>Ready status</strong>
+				<span>{{ status }}</span>
+			</template>
+			<p v-default>Unknown status</p>
+		</template>
+	</main>
+</template>
+
+<script lang="go">
+package fixtures
+
+type Parent struct {
+	loading bool
+	failed  bool
+	status  string
+}
+</script>

--- a/internal/compiler/checker/testdata/invalid_conditional_control_flow/Parent.tue
+++ b/internal/compiler/checker/testdata/invalid_conditional_control_flow/Parent.tue
@@ -1,0 +1,52 @@
+<template>
+	<main>
+		<p v-else-if="ready">Orphan else-if</p>
+		<p v-else>Orphan else</p>
+
+		<p v-if="ready">Ready</p>
+		<p v-else-if="status">Wrong condition type</p>
+		<p v-else-if="ready" v-for="item in items" :key="item">Loop branch</p>
+		<p v-else>Done</p>
+
+		<template v-switch="status">
+			<p>Missing branch directive</p>
+			<p v-case="count">Wrong case type</p>
+			<p v-default>Default</p>
+			<p v-case='"late"'>Late case</p>
+			<p v-default>Duplicate default</p>
+			<p v-case='"mixed"' v-if="ready">Mixed controls</p>
+		</template>
+
+		<div v-switch="status"></div>
+		<p v-case='"orphan"'>Orphan case</p>
+		<p v-default>Orphan default</p>
+		<template v-switch="items"></template>
+		<template v-switch="selected">
+			<p v-case="candidate">Struct case</p>
+		</template>
+		<template v-switch="buffer">
+			<p v-case="candidateBuffer">Imported struct case</p>
+		</template>
+	</main>
+</template>
+
+<script lang="go">
+package fixtures
+
+import "bytes"
+
+type Filter struct {
+	Tags []string
+}
+
+type Parent struct {
+	ready           bool
+	status          string
+	count           int
+	items           []string
+	selected        Filter
+	candidate       Filter
+	buffer          bytes.Buffer
+	candidateBuffer bytes.Buffer
+}
+</script>

--- a/internal/compiler/gogen/generate.go
+++ b/internal/compiler/gogen/generate.go
@@ -247,6 +247,7 @@ func (g *projectGenerator) generatedRenderSource(file File, scopeAttr string) ([
 		fields:     componentFields(file.Script.Component),
 		methods:    componentMethods(file.Script.Component),
 		typeFields: structFieldMaps(file.Script.Structs),
+		comparable: comparableTypeMap(file.Script.Types),
 		scopeAttr:  scopeAttr,
 		assets:     g.assets,
 	}
@@ -275,6 +276,7 @@ type fileGenerator struct {
 	fields      map[string]script.Field
 	methods     map[string]script.Method
 	typeFields  map[string]map[string]script.Field
+	comparable  map[string]bool
 	scopeAttr   string
 	assets      *assetPipeline
 	locals      map[string]string
@@ -310,24 +312,29 @@ func (g *fileGenerator) renderNodeList(nodes []*gotemplate.Node) []jen.Code {
 		if g.ignorableControlSibling(node) {
 			continue
 		}
+		if attr := nodeDirectiveAttr(node, gotemplate.DirectiveCase); attr != nil {
+			g.add("v-case must be a direct child of v-switch", attr.DirectiveSpan)
+			continue
+		}
+		if attr := nodeDirectiveAttr(node, gotemplate.DirectiveDefault); attr != nil {
+			g.add("v-default must be a direct child of v-switch", attr.DirectiveSpan)
+			continue
+		}
+		if attr := nodeDirectiveAttr(node, gotemplate.DirectiveElseIf); attr != nil {
+			g.add("v-else-if must follow v-if or v-else-if", attr.DirectiveSpan)
+			continue
+		}
 		if attr := nodeDirectiveAttr(node, gotemplate.DirectiveElse); attr != nil {
-			g.add("v-else must follow v-if", attr.DirectiveSpan)
+			g.add("v-else must follow v-if or v-else-if", attr.DirectiveSpan)
 			continue
 		}
 		if attr := nodeDirectiveAttr(node, gotemplate.DirectiveIf); attr != nil {
-			elseIndex := g.nextElseNode(nodes, index+1)
-			if elseIndex != -1 {
-				if nodeDirectiveAttr(node, gotemplate.DirectiveFor) != nil {
-					if elseAttr := nodeDirectiveAttr(nodes[elseIndex], gotemplate.DirectiveElse); elseAttr != nil {
-						g.add("v-else cannot follow v-if on an element that also has v-for; use a <template v-for> wrapper", elseAttr.DirectiveSpan)
-					}
-					index = elseIndex
-					continue
-				}
-				if code, ok := g.renderIfElse(node, *attr, nodes[elseIndex]); ok {
+			branches, end := g.conditionalChain(nodes, index, *attr)
+			if len(branches) > 1 {
+				if code, ok := g.renderConditionalChain(branches); ok {
 					rendered = append(rendered, code)
 				}
-				index = elseIndex
+				index = end
 				continue
 			}
 		}
@@ -338,18 +345,31 @@ func (g *fileGenerator) renderNodeList(nodes []*gotemplate.Node) []jen.Code {
 	return rendered
 }
 
-func (g *fileGenerator) nextElseNode(nodes []*gotemplate.Node, start int) int {
-	for index := start; index < len(nodes); index++ {
+type conditionalBranch struct {
+	node *gotemplate.Node
+	attr gotemplate.Attr
+}
+
+func (g *fileGenerator) conditionalChain(nodes []*gotemplate.Node, start int, ifAttr gotemplate.Attr) ([]conditionalBranch, int) {
+	branches := []conditionalBranch{{node: nodes[start], attr: ifAttr}}
+	end := start
+	for index := start + 1; index < len(nodes); index++ {
 		node := nodes[index]
 		if g.ignorableControlSibling(node) {
 			continue
 		}
-		if nodeDirectiveAttr(node, gotemplate.DirectiveElse) != nil {
-			return index
+		if attr := nodeDirectiveAttr(node, gotemplate.DirectiveElseIf); attr != nil {
+			branches = append(branches, conditionalBranch{node: node, attr: *attr})
+			end = index
+			continue
 		}
-		return -1
+		if attr := nodeDirectiveAttr(node, gotemplate.DirectiveElse); attr != nil {
+			branches = append(branches, conditionalBranch{node: node, attr: *attr})
+			end = index
+		}
+		break
 	}
-	return -1
+	return branches, end
 }
 
 func (g *fileGenerator) ignorableControlSibling(node *gotemplate.Node) bool {
@@ -379,6 +399,9 @@ func (g *fileGenerator) renderNode(node *gotemplate.Node) (jen.Code, bool) {
 }
 
 func (g *fileGenerator) renderNodeAfterFor(node *gotemplate.Node) (jen.Code, bool) {
+	if attr := nodeDirectiveAttr(node, gotemplate.DirectiveSwitch); attr != nil {
+		return g.renderSwitch(node, *attr)
+	}
 	attr := nodeDirectiveAttr(node, gotemplate.DirectiveIf)
 	if attr != nil {
 		return g.renderIf(node, *attr)
@@ -469,7 +492,7 @@ func (g *fileGenerator) renderNodeBody(node *gotemplate.Node) (jen.Code, bool) {
 }
 
 func (g *fileGenerator) renderIf(node *gotemplate.Node, attr gotemplate.Attr) (jen.Code, bool) {
-	condition, conditionOK := g.renderExpressionFor("v-if", attr.Expression, attr.ExpressionSpan)
+	condition, conditionOK := g.renderConditionalExpression(attr)
 	rendered, nodeOK := g.renderNodeBody(node)
 	if !conditionOK || !nodeOK {
 		return nil, false
@@ -483,20 +506,196 @@ func (g *fileGenerator) renderIf(node *gotemplate.Node, attr gotemplate.Attr) (j
 	).Call(), true
 }
 
-func (g *fileGenerator) renderIfElse(ifNode *gotemplate.Node, ifAttr gotemplate.Attr, elseNode *gotemplate.Node) (jen.Code, bool) {
-	condition, conditionOK := g.renderExpressionFor("v-if", ifAttr.Expression, ifAttr.ExpressionSpan)
-	ifTrue, trueOK := g.renderNodeBody(ifNode)
-	ifFalse, falseOK := g.renderNodeBody(elseNode)
-	if !conditionOK || !trueOK || !falseOK {
+func (g *fileGenerator) renderConditionalChain(branches []conditionalBranch) (jen.Code, bool) {
+	ok := true
+	statements := make([]jen.Code, 0, len(branches)+1)
+	for index, branch := range branches {
+		if switchAttr := nodeDirectiveAttr(branch.node, gotemplate.DirectiveSwitch); switchAttr != nil {
+			g.add("v-switch cannot be combined with v-if, v-else-if, or v-else", switchAttr.DirectiveSpan)
+			ok = false
+		}
+		if caseAttr := nodeDirectiveAttr(branch.node, gotemplate.DirectiveCase); caseAttr != nil {
+			g.add("v-case must be a direct child of v-switch", caseAttr.DirectiveSpan)
+			ok = false
+		}
+		if defaultAttr := nodeDirectiveAttr(branch.node, gotemplate.DirectiveDefault); defaultAttr != nil {
+			g.add("v-default must be a direct child of v-switch", defaultAttr.DirectiveSpan)
+			ok = false
+		}
+		if nodeDirectiveAttr(branch.node, gotemplate.DirectiveFor) != nil {
+			switch {
+			case index == 0 && len(branches) > 1:
+				next := branches[1].attr
+				g.add(fmt.Sprintf("%s cannot follow a conditional branch that also has v-for; use a <template v-for> wrapper", next.RawName), next.DirectiveSpan)
+			case branch.attr.Directive == gotemplate.DirectiveElseIf:
+				g.add("v-else-if cannot be combined with v-for; use a <template v-for> wrapper", branch.attr.DirectiveSpan)
+			case branch.attr.Directive == gotemplate.DirectiveElse:
+				g.add("v-else cannot be combined with v-for; use a <template v-for> wrapper", branch.attr.DirectiveSpan)
+			}
+			ok = false
+		}
+	}
+	if !ok {
 		return nil, false
 	}
 
-	return jen.Func().Params().Qual(tueImportPath, "VNode").Block(
-		jen.If(condition).Block(
-			jen.Return(ifTrue),
-		),
-		jen.Return(ifFalse),
-	).Call(), true
+	for _, branch := range branches {
+		rendered, renderedOK := g.renderNodeBody(branch.node)
+		if !renderedOK {
+			ok = false
+			continue
+		}
+		if branch.attr.Directive == gotemplate.DirectiveElse {
+			statements = append(statements, jen.Return(rendered))
+			continue
+		}
+		condition, conditionOK := g.renderConditionalExpression(branch.attr)
+		if !conditionOK {
+			ok = false
+			continue
+		}
+		statements = append(statements, jen.If(condition).Block(jen.Return(rendered)))
+	}
+	if !ok {
+		return nil, false
+	}
+	if branches[len(branches)-1].attr.Directive != gotemplate.DirectiveElse {
+		statements = append(statements, jen.Return(g.emptyFragment()))
+	}
+	return jen.Func().Params().Qual(tueImportPath, "VNode").Block(statements...).Call(), true
+}
+
+func (g *fileGenerator) renderConditionalExpression(attr gotemplate.Attr) (jen.Code, bool) {
+	condition, ok := g.renderExpressionFor(attr.RawName, attr.Expression, attr.ExpressionSpan)
+	if !ok {
+		return nil, false
+	}
+	conditionType := g.expressionType(attr.Expression)
+	if !assignableType("bool", conditionType) {
+		g.add(fmt.Sprintf("%s expects bool, got %s", attr.RawName, displayType(conditionType)), attr.ExpressionSpan)
+		return nil, false
+	}
+	return condition, true
+}
+
+func (g *fileGenerator) renderSwitch(node *gotemplate.Node, attr gotemplate.Attr) (jen.Code, bool) {
+	ok := true
+	hostValid := node.Tag == "template" && !node.IsComponent
+	if !hostValid {
+		g.add("v-switch is only supported on <template>", attr.DirectiveSpan)
+		ok = false
+	}
+	if conditionalAttr := nodeConditionalAttr(node); conditionalAttr != nil {
+		g.add("v-switch cannot be combined with v-if, v-else-if, or v-else", conditionalAttr.DirectiveSpan)
+		ok = false
+	}
+	if caseAttr := nodeDirectiveAttr(node, gotemplate.DirectiveCase); caseAttr != nil {
+		g.add("v-switch cannot be combined with v-case on the same element", caseAttr.DirectiveSpan)
+		ok = false
+	}
+	if defaultAttr := nodeDirectiveAttr(node, gotemplate.DirectiveDefault); defaultAttr != nil {
+		g.add("v-switch cannot be combined with v-default on the same element", defaultAttr.DirectiveSpan)
+		ok = false
+	}
+
+	switchValue, valueOK := g.renderExpressionFor("v-switch", attr.Expression, attr.ExpressionSpan)
+	switchType := g.expressionType(attr.Expression)
+	if !isSwitchComparableType(switchType, g.comparable) {
+		g.add(fmt.Sprintf("v-switch expression type %s is not comparable", displayType(switchType)), attr.ExpressionSpan)
+		ok = false
+	}
+	if !valueOK {
+		ok = false
+	}
+	if !hostValid {
+		return nil, false
+	}
+
+	branchCount := 0
+	defaultSeen := false
+	switchName := freshIdentifier(g.usedGeneratedNames(), "__tueSwitch")
+	caseStatements := make([]jen.Code, 0, len(node.Children))
+	var defaultRendered jen.Code
+	for _, branch := range node.Children {
+		if g.ignorableControlSibling(branch) {
+			continue
+		}
+		branchCount++
+
+		caseAttr := nodeDirectiveAttr(branch, gotemplate.DirectiveCase)
+		defaultAttr := nodeDirectiveAttr(branch, gotemplate.DirectiveDefault)
+		branchRenderable := true
+		if conditionalAttr := nodeConditionalAttr(branch); conditionalAttr != nil {
+			g.add("v-switch branches cannot combine v-case or v-default with v-if, v-else-if, or v-else", conditionalAttr.DirectiveSpan)
+			branchRenderable = false
+			ok = false
+		}
+		if nestedSwitch := nodeDirectiveAttr(branch, gotemplate.DirectiveSwitch); nestedSwitch != nil {
+			g.add("a v-switch branch must nest another v-switch inside its content", nestedSwitch.DirectiveSpan)
+			branchRenderable = false
+			ok = false
+		}
+		switch {
+		case caseAttr != nil && defaultAttr != nil:
+			g.add("v-switch branch cannot use both v-case and v-default", defaultAttr.DirectiveSpan)
+			ok = false
+		case caseAttr != nil:
+			if defaultSeen {
+				g.add("v-case must appear before v-default", caseAttr.DirectiveSpan)
+				ok = false
+			}
+			caseValue, caseOK := g.renderExpressionFor("v-case", caseAttr.Expression, caseAttr.ExpressionSpan)
+			caseType := g.expressionType(caseAttr.Expression)
+			if !switchTypesCompatible(switchType, caseType) {
+				g.add(fmt.Sprintf("v-case expects %s, got %s", displayType(switchType), displayType(caseType)), caseAttr.ExpressionSpan)
+				caseOK = false
+			}
+			var rendered jen.Code
+			renderedOK := false
+			if branchRenderable {
+				rendered, renderedOK = g.renderNode(branch)
+			}
+			if caseOK && renderedOK {
+				caseStatements = append(caseStatements, jen.If(jen.Id(switchName).Op("==").Add(caseValue)).Block(jen.Return(rendered)))
+			} else {
+				ok = false
+			}
+		case defaultAttr != nil:
+			if defaultSeen {
+				g.add("v-switch may only have one v-default", defaultAttr.DirectiveSpan)
+				ok = false
+			}
+			defaultSeen = true
+			var rendered jen.Code
+			renderedOK := false
+			if branchRenderable {
+				rendered, renderedOK = g.renderNode(branch)
+			}
+			if renderedOK {
+				defaultRendered = rendered
+			} else {
+				ok = false
+			}
+		default:
+			g.add("v-switch children must use v-case or v-default", branch.Span)
+			ok = false
+		}
+	}
+	if branchCount == 0 {
+		g.add("v-switch requires at least one v-case or v-default child", attr.DirectiveSpan)
+		ok = false
+	}
+	if !ok {
+		return nil, false
+	}
+
+	statements := append([]jen.Code{jen.Id(switchName).Op(":=").Add(switchValue)}, caseStatements...)
+	if defaultSeen {
+		statements = append(statements, jen.Return(defaultRendered))
+	} else {
+		statements = append(statements, jen.Return(g.emptyFragment()))
+	}
+	return jen.Func().Params().Qual(tueImportPath, "VNode").Block(statements...).Call(), true
 }
 
 func (g *fileGenerator) renderElement(node *gotemplate.Node) (jen.Code, bool) {
@@ -1297,6 +1496,19 @@ func nodeDirectiveAttr(node *gotemplate.Node, kind gotemplate.DirectiveKind) *go
 	return nil
 }
 
+func nodeConditionalAttr(node *gotemplate.Node) *gotemplate.Attr {
+	for _, kind := range []gotemplate.DirectiveKind{
+		gotemplate.DirectiveIf,
+		gotemplate.DirectiveElseIf,
+		gotemplate.DirectiveElse,
+	} {
+		if attr := nodeDirectiveAttr(node, kind); attr != nil {
+			return attr
+		}
+	}
+	return nil
+}
+
 func nodeBindAttr(node *gotemplate.Node, argument string) *gotemplate.Attr {
 	if node == nil || node.Kind != gotemplate.NodeElement {
 		return nil
@@ -1312,7 +1524,13 @@ func nodeBindAttr(node *gotemplate.Node, argument string) *gotemplate.Attr {
 
 func isControlDirective(kind gotemplate.DirectiveKind) bool {
 	switch kind {
-	case gotemplate.DirectiveIf, gotemplate.DirectiveElse, gotemplate.DirectiveFor:
+	case gotemplate.DirectiveIf,
+		gotemplate.DirectiveElseIf,
+		gotemplate.DirectiveElse,
+		gotemplate.DirectiveFor,
+		gotemplate.DirectiveSwitch,
+		gotemplate.DirectiveCase,
+		gotemplate.DirectiveDefault:
 		return true
 	default:
 		return false
@@ -1587,6 +1805,14 @@ func structFieldMaps(structs []script.Struct) map[string]map[string]script.Field
 	return byType
 }
 
+func comparableTypeMap(types []script.TypeInfo) map[string]bool {
+	comparable := make(map[string]bool, len(types))
+	for _, info := range types {
+		comparable[info.Expression] = info.Comparable
+	}
+	return comparable
+}
+
 func propValueType(prop script.Prop) string {
 	if prop.Field.ValueType != "" {
 		return prop.Field.ValueType
@@ -1668,6 +1894,28 @@ func assignableType(expected string, actual string) bool {
 		return true
 	}
 	return expected == actual
+}
+
+func switchTypesCompatible(switchType string, caseType string) bool {
+	return assignableType(switchType, caseType) || assignableType(caseType, switchType)
+}
+
+func isSwitchComparableType(typ string, comparable map[string]bool) bool {
+	typ = strings.TrimSpace(typ)
+	if strings.HasPrefix(typ, "*") {
+		return true
+	}
+	typ = normalizeType(typ)
+	if typ == "" || typ == "unknown" {
+		return true
+	}
+	if declared, ok := comparable[typ]; ok {
+		return declared
+	}
+	return typ != "any" && typ != "interface{}" &&
+		!strings.HasPrefix(typ, "[]") &&
+		!strings.HasPrefix(typ, "map[") &&
+		!strings.HasPrefix(typ, "func(")
 }
 
 func normalizeType(typ string) string {

--- a/internal/compiler/gogen/generate_test.go
+++ b/internal/compiler/gogen/generate_test.go
@@ -154,6 +154,38 @@ func TestGenerateProjectReportsUnsupportedConditionalExpressions(t *testing.T) {
 	}
 }
 
+func TestGenerateProjectReportsConditionalControlDiagnostics(t *testing.T) {
+	project, err := parseProjectFixture("testdata/invalid_conditional_controls/App.tue")
+	if err != nil {
+		t.Fatalf("parse project fixture: %v", err)
+	}
+
+	_, diagnostics := GenerateProject(*project)
+
+	expected := []diagnosticSummary{
+		{Path: "App.tue", Message: `v-else-if must follow v-if or v-else-if`, Line: 3, Column: 6},
+		{Path: "App.tue", Message: `v-else must follow v-if or v-else-if`, Line: 4, Column: 6},
+		{Path: "App.tue", Message: `v-if expects bool, got string`, Line: 6, Column: 12},
+		{Path: "App.tue", Message: `v-else-if expression is not supported in the static render slice`, Line: 7, Column: 17},
+		{Path: "App.tue", Message: `v-switch expression type []string is not comparable`, Line: 9, Column: 23},
+		{Path: "App.tue", Message: `v-switch requires at least one v-case or v-default child`, Line: 9, Column: 13},
+		{Path: "App.tue", Message: `v-switch is only supported on <template>`, Line: 10, Column: 8},
+		{Path: "App.tue", Message: `v-switch children must use v-case or v-default`, Line: 12, Column: 4},
+		{Path: "App.tue", Message: `v-case expects string, got int`, Line: 13, Column: 15},
+		{Path: "App.tue", Message: `v-case must appear before v-default`, Line: 15, Column: 7},
+		{Path: "App.tue", Message: `v-switch may only have one v-default`, Line: 16, Column: 7},
+		{Path: "App.tue", Message: `v-switch branches cannot combine v-case or v-default with v-if, v-else-if, or v-else`, Line: 17, Column: 24},
+		{Path: "App.tue", Message: `v-case must appear before v-default`, Line: 17, Column: 7},
+		{Path: "App.tue", Message: `v-case must be a direct child of v-switch`, Line: 20, Column: 6},
+		{Path: "App.tue", Message: `v-default must be a direct child of v-switch`, Line: 21, Column: 6},
+		{Path: "App.tue", Message: `v-switch expression type Filter is not comparable`, Line: 22, Column: 23},
+		{Path: "App.tue", Message: `v-switch expression type bytes.Buffer is not comparable`, Line: 25, Column: 23},
+	}
+	if diff := cmp.Diff(expected, summarizeDiagnostics(diagnostics)); diff != "" {
+		t.Errorf("mismatch diagnostics (-expected, +actual):\n%s", diff)
+	}
+}
+
 func TestGenerateProjectEmitsLoopRenderFiles(t *testing.T) {
 	project, err := parseProjectFixture("testdata/loops")
 	if err != nil {
@@ -271,7 +303,7 @@ func TestGenerateProjectReportsUnsupportedLoopConstructs(t *testing.T) {
 		{Path: "App.tue", Message: `v-for requires a :key attribute`, Line: 4, Column: 6},
 		{Path: "App.tue", Message: `v-for source expression is not supported in the static render slice`, Line: 5, Column: 21},
 		{Path: "App.tue", Message: `v-for key expression is not supported in the static render slice`, Line: 6, Column: 34},
-		{Path: "App.tue", Message: `v-else cannot follow v-if on an element that also has v-for; use a <template v-for> wrapper`, Line: 8, Column: 6},
+		{Path: "App.tue", Message: `v-else cannot follow a conditional branch that also has v-for; use a <template v-for> wrapper`, Line: 8, Column: 6},
 	}, summarizeDiagnostics(diagnostics)); diff != "" {
 		t.Errorf("mismatch diagnostics (-expected, +actual):\n%s", diff)
 	}

--- a/internal/compiler/gogen/testdata/conditionals/App.tue
+++ b/internal/compiler/gogen/testdata/conditionals/App.tue
@@ -1,10 +1,27 @@
 <template>
-<main>
-	<p v-if="visible">Visible: {{ name }}</p>
-	<section v-if="count > 0">
-		<span>{{ count }}</span>
-	</section>
-</main>
+	<main>
+		<p v-if="visible">Visible: {{ name }}</p>
+		<!-- comments and whitespace do not break a conditional chain -->
+		<p v-else-if="count > 0">Count: {{ count }}</p>
+		<p v-else>Hidden</p>
+
+		<template v-switch="status">
+			<p v-case='"loading"'>Loading</p>
+			<p v-case='"error"'>Error</p>
+			<template v-case='"success"'>
+				<strong>Done</strong>
+				<span>{{ name }}</span>
+			</template>
+			<p v-default>Unknown</p>
+		</template>
+
+		<template v-switch="count">
+			<span v-case="1">One</span>
+		</template>
+
+		<section v-if="count == 1">One item</section>
+		<section v-else-if="count == 2">Two items</section>
+	</main>
 </template>
 
 <script lang="go">
@@ -14,5 +31,6 @@ type App struct {
 	visible bool
 	name    string
 	count   int
+	status  string
 }
 </script>

--- a/internal/compiler/gogen/testdata/golden/Conditional_render_tue.go
+++ b/internal/compiler/gogen/testdata/golden/Conditional_render_tue.go
@@ -17,10 +17,34 @@ func renderApp(component *App) tue.VNode {
 		if component.visible {
 			return tue.Element("p", nil, []tue.VNode{tue.Text("Visible: "), tue.Text(fmt.Sprint(component.name))})
 		}
+		if component.count > 0 {
+			return tue.Element("p", nil, []tue.VNode{tue.Text("Count: "), tue.Text(fmt.Sprint(component.count))})
+		}
+		return tue.Element("p", nil, []tue.VNode{tue.Text("Hidden")})
+	}(), func() tue.VNode {
+		__tueSwitch := component.status
+		if __tueSwitch == "loading" {
+			return tue.Element("p", nil, []tue.VNode{tue.Text("Loading")})
+		}
+		if __tueSwitch == "error" {
+			return tue.Element("p", nil, []tue.VNode{tue.Text("Error")})
+		}
+		if __tueSwitch == "success" {
+			return tue.Fragment([]tue.VNode{tue.Element("strong", nil, []tue.VNode{tue.Text("Done")}), tue.Element("span", nil, []tue.VNode{tue.Text(fmt.Sprint(component.name))})})
+		}
+		return tue.Element("p", nil, []tue.VNode{tue.Text("Unknown")})
+	}(), func() tue.VNode {
+		__tueSwitch := component.count
+		if __tueSwitch == 1 {
+			return tue.Element("span", nil, []tue.VNode{tue.Text("One")})
+		}
 		return tue.Fragment(nil)
 	}(), func() tue.VNode {
-		if component.count > 0 {
-			return tue.Element("section", nil, []tue.VNode{tue.Element("span", nil, []tue.VNode{tue.Text(fmt.Sprint(component.count))})})
+		if component.count == 1 {
+			return tue.Element("section", nil, []tue.VNode{tue.Text("One item")})
+		}
+		if component.count == 2 {
+			return tue.Element("section", nil, []tue.VNode{tue.Text("Two items")})
 		}
 		return tue.Fragment(nil)
 	}()})

--- a/internal/compiler/gogen/testdata/invalid_conditional_controls/App.tue
+++ b/internal/compiler/gogen/testdata/invalid_conditional_controls/App.tue
@@ -1,0 +1,54 @@
+<template>
+	<main>
+		<p v-else-if="ready">Orphan else-if</p>
+		<p v-else>Orphan else</p>
+
+		<p v-if="status">Wrong if type</p>
+		<p v-else-if="isReady(true)">Unsupported else-if</p>
+
+		<template v-switch="items"></template>
+		<div v-switch="status"></div>
+		<template v-switch="status">
+			<p>Missing branch directive</p>
+			<p v-case="count">Wrong case type</p>
+			<p v-default>Default</p>
+			<p v-case='"late"'>Late case</p>
+			<p v-default>Duplicate default</p>
+			<p v-case='"mixed"' v-if="ready">Mixed controls</p>
+		</template>
+
+		<p v-case='"orphan"'>Orphan case</p>
+		<p v-default>Orphan default</p>
+		<template v-switch="selected">
+			<p v-case="candidate">Struct case</p>
+		</template>
+		<template v-switch="buffer">
+			<p v-case="candidateBuffer">Imported struct case</p>
+		</template>
+	</main>
+</template>
+
+<script lang="go">
+package app
+
+import "bytes"
+
+type Filter struct {
+	Tags []string
+}
+
+type App struct {
+	ready           bool
+	status          string
+	count           int
+	items           []string
+	selected        Filter
+	candidate       Filter
+	buffer          bytes.Buffer
+	candidateBuffer bytes.Buffer
+}
+
+func (a *App) isReady(enabled bool) bool {
+	return enabled
+}
+</script>

--- a/internal/compiler/script/contract.go
+++ b/internal/compiler/script/contract.go
@@ -8,6 +8,7 @@ type File struct {
 	PackageName string
 	PackageSpan sfc.Span
 	Imports     []Import
+	Types       []TypeInfo
 	Structs     []Struct
 	Component   *Component
 }
@@ -19,6 +20,12 @@ type Import struct {
 	Span     sfc.Span
 	NameSpan sfc.Span
 	PathSpan sfc.Span
+}
+
+// TypeInfo records Go type information used to validate template expressions.
+type TypeInfo struct {
+	Expression string
+	Comparable bool
 }
 
 // Component is the contract extracted from the expected component struct.

--- a/internal/compiler/script/parse.go
+++ b/internal/compiler/script/parse.go
@@ -131,7 +131,8 @@ func (e *extractor) parse(componentName string) (*File, []Diagnostic) {
 	file.PackageName = astFile.Name.Name
 	file.PackageSpan = e.posSpan(astFile.Pos(), astFile.Name.End())
 	file.Imports = e.extractImports(astFile)
-	e.typeCheck(astFile)
+	typesPackage, typesInfo := e.typeCheck(astFile)
+	file.Types = e.extractTypes(astFile, typesPackage, typesInfo)
 	file.Structs = e.extractStructs(astFile)
 
 	if componentName != "" {
@@ -202,8 +203,11 @@ func (e *extractor) extractImports(file *ast.File) []Import {
 	return imports
 }
 
-func (e *extractor) typeCheck(file *ast.File) {
+func (e *extractor) typeCheck(file *ast.File) (*types.Package, *types.Info) {
 	var diagnostics []Diagnostic
+	info := &types.Info{
+		Types: make(map[ast.Expr]types.TypeAndValue),
+	}
 	config := types.Config{
 		GoVersion:                "go1.26",
 		IgnoreFuncBodies:         true,
@@ -221,8 +225,58 @@ func (e *extractor) typeCheck(file *ast.File) {
 			diagnostics = append(diagnostics, diagnostic)
 		},
 	}
-	_, _ = config.Check(e.path, e.fset, []*ast.File{file}, nil)
+	pkg, _ := config.Check(e.path, e.fset, []*ast.File{file}, info)
 	e.diagnostics = append(e.diagnostics, diagnostics...)
+	return pkg, info
+}
+
+func (e *extractor) extractTypes(file *ast.File, pkg *types.Package, info *types.Info) []TypeInfo {
+	if pkg == nil || info == nil {
+		return nil
+	}
+
+	comparability := make(map[string]bool)
+	record := func(expression string, typ types.Type) {
+		comparable := types.Comparable(typ)
+		if previous, ok := comparability[expression]; ok {
+			comparable = previous && comparable
+		}
+		comparability[expression] = comparable
+	}
+
+	scope := pkg.Scope()
+	for _, name := range scope.Names() {
+		typeName, ok := scope.Lookup(name).(*types.TypeName)
+		if ok {
+			record(name, typeName.Type())
+		}
+	}
+	ast.Inspect(file, func(node ast.Node) bool {
+		expr, ok := node.(ast.Expr)
+		if !ok {
+			return true
+		}
+		typeAndValue, ok := info.Types[expr]
+		if ok && typeAndValue.IsType() && typeAndValue.Type != nil {
+			record(e.nodeString(expr), typeAndValue.Type)
+		}
+		return true
+	})
+
+	expressions := make([]string, 0, len(comparability))
+	for expression := range comparability {
+		expressions = append(expressions, expression)
+	}
+	sort.Strings(expressions)
+
+	extracted := make([]TypeInfo, len(expressions))
+	for i, expression := range expressions {
+		extracted[i] = TypeInfo{
+			Expression: expression,
+			Comparable: comparability[expression],
+		}
+	}
+	return extracted
 }
 
 func (e *extractor) extractComponent(file *File, astFile *ast.File, componentName string) {

--- a/internal/compiler/script/parse_test.go
+++ b/internal/compiler/script/parse_test.go
@@ -29,6 +29,19 @@ func TestParseExtractsComponentContract(t *testing.T) {
 	}}, summarizeImports(file.Imports)); diff != "" {
 		t.Errorf("mismatch imports (-expected, +actual):\n%s", diff)
 	}
+	expectedTypes := map[string]bool{
+		"Dashboard": false,
+		"User":      true,
+	}
+	actualTypes := make(map[string]bool, len(expectedTypes))
+	for _, info := range file.Types {
+		if _, ok := expectedTypes[info.Expression]; ok {
+			actualTypes[info.Expression] = info.Comparable
+		}
+	}
+	if diff := cmp.Diff(expectedTypes, actualTypes); diff != "" {
+		t.Errorf("mismatch declared types (-expected, +actual):\n%s", diff)
+	}
 	if diff := cmp.Diff([]structSummary{
 		{Name: "User", Fields: []fieldSummary{}},
 		{Name: "Dashboard", Fields: []fieldSummary{

--- a/internal/compiler/template/ast.go
+++ b/internal/compiler/template/ast.go
@@ -26,11 +26,15 @@ const (
 type DirectiveKind string
 
 const (
-	DirectiveIf    DirectiveKind = "if"
-	DirectiveElse  DirectiveKind = "else"
-	DirectiveFor   DirectiveKind = "for"
-	DirectiveModel DirectiveKind = "model"
-	DirectiveHTML  DirectiveKind = "html"
+	DirectiveIf      DirectiveKind = "if"
+	DirectiveElseIf  DirectiveKind = "else-if"
+	DirectiveElse    DirectiveKind = "else"
+	DirectiveFor     DirectiveKind = "for"
+	DirectiveModel   DirectiveKind = "model"
+	DirectiveHTML    DirectiveKind = "html"
+	DirectiveSwitch  DirectiveKind = "switch"
+	DirectiveCase    DirectiveKind = "case"
+	DirectiveDefault DirectiveKind = "default"
 )
 
 // Tree is a parsed template AST.

--- a/internal/compiler/template/parse.go
+++ b/internal/compiler/template/parse.go
@@ -536,6 +536,9 @@ func (p *parser) classifyAttr(syntax attrSyntax) (Attr, []Diagnostic) {
 		case DirectiveIf:
 			attr.Directive = DirectiveIf
 			diagnostics = append(diagnostics, p.requireExpression(&attr, "v-if requires an expression")...)
+		case DirectiveElseIf:
+			attr.Directive = DirectiveElseIf
+			diagnostics = append(diagnostics, p.requireExpression(&attr, "v-else-if requires an expression")...)
 		case DirectiveElse:
 			attr.Directive = DirectiveElse
 			if attr.HasValue {
@@ -553,6 +556,20 @@ func (p *parser) classifyAttr(syntax attrSyntax) (Attr, []Diagnostic) {
 		case DirectiveHTML:
 			attr.Directive = DirectiveHTML
 			diagnostics = append(diagnostics, p.requireExpression(&attr, "v-html requires an expression")...)
+		case DirectiveSwitch:
+			attr.Directive = DirectiveSwitch
+			diagnostics = append(diagnostics, p.requireExpression(&attr, "v-switch requires an expression")...)
+		case DirectiveCase:
+			attr.Directive = DirectiveCase
+			diagnostics = append(diagnostics, p.requireExpression(&attr, "v-case requires an expression")...)
+		case DirectiveDefault:
+			attr.Directive = DirectiveDefault
+			if attr.HasValue {
+				diagnostics = append(diagnostics, Diagnostic{
+					Message: "v-default must not have a value",
+					Span:    attr.ValueSpan,
+				})
+			}
 		default:
 			diagnostics = append(diagnostics, Diagnostic{
 				Message: fmt.Sprintf("unsupported directive %q", syntax.rawName),

--- a/internal/compiler/template/parse_test.go
+++ b/internal/compiler/template/parse_test.go
@@ -107,6 +107,39 @@ element section component=false selfClosing=false
 	}
 }
 
+func TestParseConditionalControlDirectives(t *testing.T) {
+	source := `<main><p v-if="ready">Ready</p><p v-else-if="failed">Failed</p><p v-else>Unknown</p><template v-switch="status"><p v-case='"loading"'>Loading</p><p v-default>Done</p></template></main>`
+
+	tree, diagnostics := Parse([]byte(source))
+	if len(diagnostics) != 0 {
+		t.Fatalf("Parse diagnostics = %#v, expected none", diagnosticMessages(diagnostics))
+	}
+
+	expected := strings.TrimSpace(`
+element main component=false selfClosing=false
+  element p component=false selfClosing=false
+    directive if expr="ready"
+    text "Ready"
+  element p component=false selfClosing=false
+    directive else-if expr="failed"
+    text "Failed"
+  element p component=false selfClosing=false
+    directive else
+    text "Unknown"
+  element template component=false selfClosing=false
+    directive switch expr="status"
+    element p component=false selfClosing=false
+      directive case expr="\"loading\""
+      text "Loading"
+    element p component=false selfClosing=false
+      directive default
+      text "Done"
+`)
+	if actual := dumpNodes(tree.Nodes); actual != expected {
+		t.Errorf("mismatch AST dump (-expected, +actual):\nexpected:\n%s\nactual:\n%s", expected, actual)
+	}
+}
+
 func TestParseBlockUsesSFCSourceSpans(t *testing.T) {
 	source := `<template>
 <p>{{ name }}</p>
@@ -206,9 +239,29 @@ func TestParseDiagnostics(t *testing.T) {
 			want: []string{"v-if requires an expression"},
 		},
 		{
+			name: "v-else-if without expression",
+			src:  `<p v-else-if></p>`,
+			want: []string{"v-else-if requires an expression"},
+		},
+		{
 			name: "v-else with value",
 			src:  `<p v-else="ok"></p>`,
 			want: []string{"v-else must not have a value"},
+		},
+		{
+			name: "v-switch without expression",
+			src:  `<template v-switch></template>`,
+			want: []string{"v-switch requires an expression"},
+		},
+		{
+			name: "v-case without expression",
+			src:  `<p v-case></p>`,
+			want: []string{"v-case requires an expression"},
+		},
+		{
+			name: "v-default with value",
+			src:  `<p v-default="ok"></p>`,
+			want: []string{"v-default must not have a value"},
 		},
 		{
 			name: "unsupported directive",


### PR DESCRIPTION
## Summary
- Added `v-else-if` support for immediate `v-if` / `v-else-if` / `v-else` sibling chains, including boolean checks, orphan diagnostics, comment/whitespace handling, and `v-for` interaction guards.
- Added template-only `v-switch` with ordered `v-case` branches and an optional final `v-default`, including placement, type compatibility, comparability, and malformed-branch diagnostics in both checker and generator paths.
- Lowered switch selection to a once-evaluated subject plus ordered equality checks, preserving first-match behavior without requiring compile-time duplicate-case analysis or a new runtime primitive.
- Added parser, checker, generator, golden-output, negative-fixture, and WASM compile coverage.

## Validation
- `go fmt ./...`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`
- `git diff --cached --check`
- No `golangci-lint` configuration was present.

## Scope
- `v-switch` is limited to `<template>` wrappers.
- Case expressions use Go syntax and must be type-compatible and comparable with the switch expression.
- Fallthrough and pattern matching are not included.