### PR TITLE
Reworked component events with typed On wrappers.

### DIFF
--- a/event.go
+++ b/event.go
@@ -12,8 +12,38 @@ type EventBinding struct {
 	Handler func(Event)
 }
 
-// On returns a native DOM event binding.
-func On(name string, handler func()) EventBinding {
+// On is an optional component event callback.
+//
+// F must be a function type. Go does not provide a constraint that accepts
+// every function signature, so the compiler validates this requirement for
+// component fields.
+type On[F any] struct {
+	fn F
+	ok bool
+}
+
+// OnOf returns a component event callback backed by fn.
+func OnOf[F any](fn F) On[F] {
+	return On[F]{fn: fn, ok: true}
+}
+
+// Func returns the wrapped component event callback.
+func (on On[F]) Func() F {
+	return on.fn
+}
+
+// Ok reports whether the component event callback was initialized by OnOf.
+func (on On[F]) Ok() bool {
+	return on.ok
+}
+
+// FuncOk returns the wrapped callback and whether it was initialized by OnOf.
+func (on On[F]) FuncOk() (F, bool) {
+	return on.Func(), on.Ok()
+}
+
+// EventOf returns a native DOM event binding.
+func EventOf(name string, handler func()) EventBinding {
 	return EventBinding{Name: name, Handler: func(Event) {
 		if handler != nil {
 			handler()

--- a/event_test.go
+++ b/event_test.go
@@ -1,0 +1,66 @@
+package tue
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestOnWrapsOptionalComponentEventCallbacks(t *testing.T) {
+	tests := []struct {
+		name     string
+		on       On[func(string)]
+		expected bool
+	}{
+		{name: "zero value", expected: false},
+		{name: "callback", on: OnOf(func(string) {}), expected: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if diff := cmp.Diff(test.expected, test.on.Ok()); diff != "" {
+				t.Errorf("mismatch callback presence (-expected, +actual):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestOnFuncOkReturnsComponentEventCallbackAndPresence(t *testing.T) {
+	var zero On[func(string)]
+	zeroFunc, zeroOK := zero.FuncOk()
+	if zeroFunc != nil {
+		t.Error("zero callback actual = non-nil, expected nil")
+	}
+	if zeroOK {
+		t.Error("zero callback actual = present, expected absent")
+	}
+
+	var actual string
+	on := OnOf(func(value string) {
+		actual = value
+	})
+	callback, ok := on.FuncOk()
+	if !ok {
+		t.Fatal("wrapped callback is absent")
+	}
+	callback("selected")
+
+	expected := "selected"
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Errorf("mismatch callback value (-expected, +actual):\n%s", diff)
+	}
+}
+
+func TestOnFuncReturnsComponentEventCallback(t *testing.T) {
+	var actual string
+	on := OnOf(func(value string) {
+		actual = value
+	})
+
+	on.Func()("selected")
+
+	expected := "selected"
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Errorf("mismatch callback value (-expected, +actual):\n%s", diff)
+	}
+}

--- a/internal/compiler/checker/checker_test.go
+++ b/internal/compiler/checker/checker_test.go
@@ -102,9 +102,11 @@ func TestCheckProjectReportsUnsupportedComponentEventShapes(t *testing.T) {
 	diagnostics := CheckProject(project)
 	if diff := cmp.Diff([]diagnosticSummary{
 		{Path: "testdata/invalid_component_event/Parent.tue", Message: `component "UserBadge" has no event "missing"`, Line: 5, Column: 5},
-		{Path: "testdata/invalid_component_event/Parent.tue", Message: `component "UserBadge" event "payload" must have signature func()`, Line: 6, Column: 5},
+		{Path: "testdata/invalid_component_event/Parent.tue", Message: `event handler "selectUser" must have signature func(string)`, Line: 6, Column: 14},
 		{Path: "testdata/invalid_component_event/Parent.tue", Message: `event handler "selectUser" does not accept arguments`, Line: 7, Column: 20},
 		{Path: "testdata/invalid_component_event/Parent.tue", Message: `event handler "needsValue" must have signature func()`, Line: 8, Column: 16},
+		{Path: "testdata/invalid_component_event/Parent.tue", Message: `event handler "needsValue" must have signature func(int)`, Line: 9, Column: 19},
+		{Path: "testdata/invalid_component_event/Parent.tue", Message: `component "UserBadge" event "result" must not return values`, Line: 10, Column: 5},
 	}, summarizeDiagnostics(diagnostics)); diff != "" {
 		t.Errorf("mismatch diagnostics (-expected, +actual):\n%s", diff)
 	}

--- a/internal/compiler/checker/directive.go
+++ b/internal/compiler/checker/directive.go
@@ -133,6 +133,47 @@ func (c *fileChecker) checkEvent(attr gotemplate.Attr, scope *scope) {
 	}
 }
 
+func (c *fileChecker) checkComponentEventHandler(attr gotemplate.Attr, scope *scope, signature *typecap.FunctionSignature) {
+	expr, exprChecker, ok := c.parseExpression(attr.Expression, attr.ExpressionSpan, scope)
+	if !ok {
+		return
+	}
+
+	var name string
+	var span sfc.Span
+	switch typed := expr.(type) {
+	case *ast.Ident:
+		name = typed.Name
+		span = exprChecker.nodeSpan(typed)
+	case *ast.CallExpr:
+		for _, argument := range typed.Args {
+			exprChecker.eval(argument)
+		}
+		ident, ok := typed.Fun.(*ast.Ident)
+		if !ok {
+			exprChecker.eval(typed.Fun)
+			return
+		}
+		if len(typed.Args) != 0 {
+			c.add(fmt.Sprintf("event handler %q does not accept arguments", ident.Name), exprChecker.nodeSpan(typed))
+			return
+		}
+		name = ident.Name
+		span = exprChecker.nodeSpan(ident)
+	default:
+		value := exprChecker.eval(expr)
+		if value.Type != unknownType && value.Type != funcType {
+			c.add(fmt.Sprintf("event handler must be a method, got %s", displayType(value.Type)), exprChecker.nodeSpan(expr))
+		}
+		return
+	}
+
+	method, ok := c.expectEventMethod(name, span, scope, false)
+	if ok && !signature.Matches(method.Parameters, method.Results) {
+		c.add(fmt.Sprintf("event handler %q must have signature %s", name, signature.String()), span)
+	}
+}
+
 func (c *fileChecker) checkCallEvent(call *ast.CallExpr, exprChecker *exprChecker, scope *scope) {
 	for _, arg := range call.Args {
 		exprChecker.eval(arg)
@@ -211,7 +252,7 @@ func (c *fileChecker) expectEventMethod(name string, span sfc.Span, scope *scope
 		c.add(fmt.Sprintf("event handler %q is not a method on %s", name, c.component.Name), span)
 		return nil, false
 	}
-	if requireFuncSignature && (method.Parameters != 0 || method.Results != 0) {
+	if requireFuncSignature && (len(method.Parameters) != 0 || len(method.Results) != 0) {
 		c.add(fmt.Sprintf("event handler %q must have signature func()", name), span)
 		return nil, false
 	}

--- a/internal/compiler/checker/expression.go
+++ b/internal/compiler/checker/expression.go
@@ -208,7 +208,7 @@ func (c *exprChecker) call(call *ast.CallExpr) value {
 		if !symbol.Method {
 			return value{Type: unknownType}
 		}
-		if len(call.Args) != 0 || symbol.Parameters != 0 || symbol.Results != 1 {
+		if len(call.Args) != 0 || len(symbol.Parameters) != 0 || len(symbol.Results) != 1 {
 			c.fileChecker.add(fmt.Sprintf("method call %q must have signature func() T", ident.Name), c.nodeSpan(call))
 			return value{Type: unknownType}
 		}

--- a/internal/compiler/checker/file.go
+++ b/internal/compiler/checker/file.go
@@ -203,11 +203,16 @@ func (c *fileChecker) checkComponentEvent(node *gotemplate.Node, child component
 		return
 	}
 
-	if !typecap.NoArgFunc(event.Type) {
-		c.add(fmt.Sprintf("component %q event %q must have signature func()", node.Tag, attr.Argument), attr.ArgumentSpan)
+	signature, ok := typecap.ParseFunction(event.ValueType)
+	if !ok {
+		c.add(fmt.Sprintf("component %q event %q has invalid function type %q", node.Tag, attr.Argument, event.ValueType), attr.ArgumentSpan)
 		return
 	}
-	c.checkEvent(attr, scope)
+	if len(signature.Results) != 0 {
+		c.add(fmt.Sprintf("component %q event %q must not return values", node.Tag, attr.Argument), attr.ArgumentSpan)
+		return
+	}
+	c.checkComponentEventHandler(attr, scope, signature)
 }
 
 func (c *fileChecker) expectType(expected string, actual string, subject string, span sfc.Span) {

--- a/internal/compiler/checker/scope.go
+++ b/internal/compiler/checker/scope.go
@@ -21,8 +21,8 @@ type symbol struct {
 	ResultType string
 	Writable   bool
 	Method     bool
-	Parameters int
-	Results    int
+	Parameters []string
+	Results    []string
 }
 
 func componentScope(component *script.Component) *scope {
@@ -49,8 +49,8 @@ func componentScope(component *script.Component) *scope {
 			Type:       funcType,
 			ResultType: methodResultType(method),
 			Method:     true,
-			Parameters: len(method.Parameters),
-			Results:    len(method.Results),
+			Parameters: method.ParameterTypes(),
+			Results:    method.ResultTypes(),
 		})
 	}
 	return scope

--- a/internal/compiler/checker/testdata/invalid_component_event/Parent.tue
+++ b/internal/compiler/checker/testdata/invalid_component_event/Parent.tue
@@ -6,6 +6,8 @@
 			@payload="selectUser"
 			@selectWithArg="selectUser(1)"
 			@selectBad="needsValue"
+			@wrongPayload="needsValue"
+			@result="returnsValue"
 		/>
 	</main>
 </template>
@@ -16,6 +18,8 @@ package fixtures
 func (p *Parent) selectUser() {}
 
 func (p *Parent) needsValue(value string) {}
+
+func (p *Parent) returnsValue() string { return "result" }
 
 type Parent struct{}
 </script>

--- a/internal/compiler/checker/testdata/invalid_component_event/UserBadge.tue
+++ b/internal/compiler/checker/testdata/invalid_component_event/UserBadge.tue
@@ -8,9 +8,11 @@ package fixtures
 import tue "github.com/norunners/tue"
 
 type UserBadge struct {
-	name            tue.Prop[string] `prop:"name,required"`
-	onPayload       func(string)
-	onSelectWithArg func()
-	onSelectBad     func()
+	name            tue.Prop[string]       `prop:"name,required"`
+	onPayload       tue.On[func(string)]
+	onSelectWithArg tue.On[func()]
+	onSelectBad     tue.On[func()]
+	onWrongPayload  tue.On[func(int)]
+	onResult        tue.On[func() string]
 }
 </script>

--- a/internal/compiler/checker/testdata/valid/Parent.tue
+++ b/internal/compiler/checker/testdata/valid/Parent.tue
@@ -1,6 +1,6 @@
 <template>
 	<main>
-		<UserBadge :name="name" :isAdmin='role == "admin"' @select="selectUser" />
+		<UserBadge :name="name" :isAdmin='role == "admin"' @select="selectUser" @tags="selectTags" />
 			<ul>
 				<li v-for="todo in visibleTodos()" :key="todo.ID">{{ todo.Text }}</li>
 			</ul>
@@ -33,7 +33,9 @@ type Parent struct {
 
 func (p *Parent) increment() {}
 
-func (p *Parent) selectUser() {}
+func (p *Parent) selectUser(name string) {}
+
+func (p *Parent) selectTags(tags ...string) {}
 
 func (p *Parent) visibleTodos() []Todo {
 	return p.todos

--- a/internal/compiler/checker/testdata/valid/UserBadge.tue
+++ b/internal/compiler/checker/testdata/valid/UserBadge.tue
@@ -11,8 +11,9 @@ package fixtures
 import tue "github.com/norunners/tue"
 
 type UserBadge struct {
-	name    tue.Prop[string] `prop:"name,required"`
-	isAdmin tue.Prop[bool]   `prop:"isAdmin"`
-	onSelect func()
+	name     tue.Prop[string]       `prop:"name,required"`
+	isAdmin  tue.Prop[bool]         `prop:"isAdmin"`
+	onSelect tue.On[func(string)]
+	onTags   tue.On[func(...string)]
 }
 </script>

--- a/internal/compiler/gogen/generate.go
+++ b/internal/compiler/gogen/generate.go
@@ -943,7 +943,13 @@ func (g *fileGenerator) renderComponentFields(node *gotemplate.Node, child compo
 	for _, event := range child.component.Events {
 		value, found := events[event.Name]
 		if !found {
-			value = jen.Nil()
+			var valueOK bool
+			value, valueOK = zeroComponentEventValue(event)
+			if !valueOK {
+				g.add(fmt.Sprintf("component %q event %q has unsupported function type %q", node.Tag, event.Name, event.ValueType), event.TypeSpan)
+				ok = false
+				continue
+			}
 		}
 		fields = append(fields, componentField{Name: event.Name, Value: value})
 	}
@@ -961,8 +967,13 @@ func (g *fileGenerator) renderComponentEventField(node *gotemplate.Node, child c
 		g.add(fmt.Sprintf("component %q has no event %q", node.Tag, attr.Argument), attr.ArgumentSpan)
 		return nil, false
 	}
-	if !typecap.NoArgFunc(event.Type) {
-		g.add(fmt.Sprintf("component %q event %q must have signature func()", node.Tag, attr.Argument), attr.ArgumentSpan)
+	signature, ok := typecap.ParseFunction(event.ValueType)
+	if !ok {
+		g.add(fmt.Sprintf("component %q event %q has invalid function type %q", node.Tag, attr.Argument, event.ValueType), attr.ArgumentSpan)
+		return nil, false
+	}
+	if len(signature.Results) != 0 {
+		g.add(fmt.Sprintf("component %q event %q must not return values", node.Tag, attr.Argument), attr.ArgumentSpan)
 		return nil, false
 	}
 
@@ -980,14 +991,14 @@ func (g *fileGenerator) renderComponentEventField(node *gotemplate.Node, child c
 		g.add(fmt.Sprintf("event handler %q is not a method on %s", methodName, g.component.Name), attr.ExpressionSpan)
 		return nil, false
 	}
-	if len(method.Parameters) != 0 || len(method.Results) != 0 {
-		g.add(fmt.Sprintf("event handler %q must have signature func()", methodName), attr.ExpressionSpan)
+	if !signature.Matches(method.ParameterTypes(), method.ResultTypes()) {
+		g.add(fmt.Sprintf("event handler %q must have signature %s", methodName, signature.String()), attr.ExpressionSpan)
 		return nil, false
 	}
 
 	return &componentEventField{
 		Name:  event.Name,
-		Value: jen.Id("component").Dot(methodName),
+		Value: jen.Qual(tueImportPath, "OnOf").Call(jen.Id("component").Dot(methodName)),
 	}, true
 }
 
@@ -1374,7 +1385,7 @@ func (g *fileGenerator) renderEvent(attr gotemplate.Attr) (jen.Code, bool) {
 		return nil, false
 	}
 
-	return jen.Qual(tueImportPath, "On").Call(
+	return jen.Qual(tueImportPath, "EventOf").Call(
 		jen.Lit(attr.Argument),
 		jen.Id("component").Dot(methodName),
 	), true
@@ -1842,6 +1853,14 @@ func renderTypeExpression(typ string) (jen.Code, bool) {
 	return renderType(expr)
 }
 
+func zeroComponentEventValue(event script.Field) (jen.Code, bool) {
+	callbackType, ok := renderTypeExpression(event.ValueType)
+	if !ok {
+		return nil, false
+	}
+	return jen.Qual(tueImportPath, "On").Types(callbackType).Values(), true
+}
+
 func renderType(expr ast.Expr) (jen.Code, bool) {
 	switch typed := expr.(type) {
 	case *ast.Ident:
@@ -1878,9 +1897,55 @@ func renderType(expr ast.Expr) (jen.Code, bool) {
 			return nil, false
 		}
 		return jen.Map(key).Add(value), true
+	case *ast.Ellipsis:
+		element, ok := renderType(typed.Elt)
+		if !ok {
+			return nil, false
+		}
+		return jen.Op("...").Add(element), true
+	case *ast.FuncType:
+		parameters, ok := renderFunctionFields(typed.Params)
+		if !ok {
+			return nil, false
+		}
+		results, ok := renderFunctionFields(typed.Results)
+		if !ok {
+			return nil, false
+		}
+		function := jen.Func().Params(parameters...)
+		switch len(results) {
+		case 0:
+			return function, true
+		case 1:
+			return function.Add(results[0]), true
+		default:
+			return function.Params(results...), true
+		}
 	default:
 		return nil, false
 	}
+}
+
+func renderFunctionFields(fields *ast.FieldList) ([]jen.Code, bool) {
+	if fields == nil {
+		return nil, true
+	}
+
+	var rendered []jen.Code
+	for _, field := range fields.List {
+		fieldType, ok := renderType(field.Type)
+		if !ok {
+			return nil, false
+		}
+		count := len(field.Names)
+		if count == 0 {
+			count = 1
+		}
+		for range count {
+			rendered = append(rendered, fieldType)
+		}
+	}
+	return rendered, true
 }
 
 func displayType(typ string) string {

--- a/internal/compiler/gogen/generate_test.go
+++ b/internal/compiler/gogen/generate_test.go
@@ -935,9 +935,11 @@ func TestGenerateProjectReportsUnsupportedComponentEvents(t *testing.T) {
 
 	if diff := cmp.Diff([]diagnosticSummary{
 		{Path: "Parent.tue", Message: `component "UserBadge" has no event "missing"`, Line: 5, Column: 4},
-		{Path: "Parent.tue", Message: `component "UserBadge" event "payload" must have signature func()`, Line: 6, Column: 4},
+		{Path: "Parent.tue", Message: `event handler "selectUser" must have signature func(string)`, Line: 6, Column: 13},
 		{Path: "Parent.tue", Message: `event handler "selectUser" does not accept arguments`, Line: 7, Column: 19},
 		{Path: "Parent.tue", Message: `event handler "needsValue" must have signature func()`, Line: 8, Column: 15},
+		{Path: "Parent.tue", Message: `event handler "needsValue" must have signature func(int)`, Line: 9, Column: 18},
+		{Path: "Parent.tue", Message: `component "UserBadge" event "result" must not return values`, Line: 10, Column: 4},
 	}, summarizeDiagnostics(diagnostics)); diff != "" {
 		t.Errorf("mismatch diagnostics (-expected, +actual):\n%s", diff)
 	}

--- a/internal/compiler/gogen/testdata/components/Parent.tue
+++ b/internal/compiler/gogen/testdata/components/Parent.tue
@@ -1,6 +1,6 @@
 <template>
 <main>
-	<UserBadge v-if="showBadge" :name="name" active @select="selectUser" />
+	<UserBadge v-if="showBadge" :name="name" active @select="selectUser" @range="selectRange" @tags="selectTags" />
 </main>
 </template>
 
@@ -18,5 +18,9 @@ func (p *Parent) Init(tue.Context) {
 	p.name = tue.RefOf("Ada")
 }
 
-func (p *Parent) selectUser() {}
+func (p *Parent) selectUser(name string) {}
+
+func (p *Parent) selectRange(name string, count int) {}
+
+func (p *Parent) selectTags(tags ...string) {}
 </script>

--- a/internal/compiler/gogen/testdata/components/UserBadge.tue
+++ b/internal/compiler/gogen/testdata/components/UserBadge.tue
@@ -8,15 +8,27 @@ package fixtures
 import tue "github.com/norunners/tue"
 
 type UserBadge struct {
-	name   tue.Prop[string] `prop:"name,required"`
-	active tue.Prop[bool]   `prop:"active"`
-	label  tue.Prop[string] `prop:"label"`
-	onSelect func()
+	name     tue.Prop[string] `prop:"name,required"`
+	active   tue.Prop[bool]   `prop:"active"`
+	label    tue.Prop[string] `prop:"label"`
+	onSelect tue.On[func(string)]
+	onRange  tue.On[func(string, int)]
+	onTags   tue.On[func(...string)]
+	onDismiss tue.On[func(reason string)]
 }
 
 func (u *UserBadge) choose() {
-	if u.onSelect != nil {
-		u.onSelect()
+	if onSelect, ok := u.onSelect.FuncOk(); ok {
+		onSelect(u.name.Get())
+	}
+	if onRange, ok := u.onRange.FuncOk(); ok {
+		onRange(u.name.Get(), 1)
+	}
+	if onTags, ok := u.onTags.FuncOk(); ok {
+		onTags("featured", "active")
+	}
+	if onDismiss, ok := u.onDismiss.FuncOk(); ok {
+		onDismiss("dismissed")
 	}
 }
 </script>

--- a/internal/compiler/gogen/testdata/golden/Counter_render_tue.go
+++ b/internal/compiler/gogen/testdata/golden/Counter_render_tue.go
@@ -13,5 +13,5 @@ func NewCounter() *tue.Comp {
 }
 
 func renderCounter(component *Counter) tue.VNode {
-	return tue.Element("main", nil, []tue.VNode{tue.Element("p", nil, []tue.VNode{tue.Text("Count: "), tue.Text(fmt.Sprint(component.count.Get()))}), tue.ElementWithEvents("button", []tue.Attribute{tue.Attr("type", "button")}, []tue.EventBinding{tue.On("click", component.increment)}, []tue.VNode{tue.Text("Increment")})})
+	return tue.Element("main", nil, []tue.VNode{tue.Element("p", nil, []tue.VNode{tue.Text("Count: "), tue.Text(fmt.Sprint(component.count.Get()))}), tue.ElementWithEvents("button", []tue.Attribute{tue.Attr("type", "button")}, []tue.EventBinding{tue.EventOf("click", component.increment)}, []tue.VNode{tue.Text("Increment")})})
 }

--- a/internal/compiler/gogen/testdata/golden/Loop_render_tue.go
+++ b/internal/compiler/gogen/testdata/golden/Loop_render_tue.go
@@ -34,7 +34,7 @@ func renderApp(component *App) tue.VNode {
 		__tueNodes := make([]tue.VNode, 0, len(__tueItems))
 		for _, __tueItem := range __tueItems {
 			__tueNodes = append(__tueNodes, func() tue.VNode {
-				__tueVNode := tue.ElementWithEvents("li", nil, []tue.EventBinding{tue.On("click", component.selectUser)}, []tue.VNode{tue.Text(fmt.Sprint(__tueItem.Text))})
+				__tueVNode := tue.ElementWithEvents("li", nil, []tue.EventBinding{tue.EventOf("click", component.selectUser)}, []tue.VNode{tue.Text(fmt.Sprint(__tueItem.Text))})
 				__tueVNode.Key = fmt.Sprint(__tueItem.ID)
 				return __tueVNode
 			}())
@@ -59,7 +59,7 @@ func renderApp(component *App) tue.VNode {
 				__tueVNode := tue.ComponentWithUpdate("UserBadge", func() *tue.Comp {
 					child := &UserBadge{name: tue.PropOfFunc(func() string {
 						return __tueItem.Text
-					}), active: tue.PropOf(true), onSelect: component.selectUser}
+					}), active: tue.PropOf(true), onSelect: tue.OnOf(component.selectUser)}
 					childComp := tue.CompOf(child, renderUserBadge)
 					return childComp
 				}, func(childComp *tue.Comp) {
@@ -68,7 +68,7 @@ func renderApp(component *App) tue.VNode {
 						return __tueItem.Text
 					})
 					child.active = tue.PropOf(true)
-					child.onSelect = component.selectUser
+					child.onSelect = tue.OnOf(component.selectUser)
 					childComp.DefaultSlot = nil
 				})
 				__tueVNode.Key = fmt.Sprint(__tueItem.ID)

--- a/internal/compiler/gogen/testdata/golden/ModelBinding_render_tue.go
+++ b/internal/compiler/gogen/testdata/golden/ModelBinding_render_tue.go
@@ -15,7 +15,7 @@ func NewApp() *tue.Comp {
 func renderApp(component *App) tue.VNode {
 	return tue.Element("main", nil, []tue.VNode{tue.ElementWithEvents("input", []tue.Attribute{tue.Attr("value", component.query)}, []tue.EventBinding{tue.OnValue("input", func(value string) {
 		component.query = value
-	}), tue.On("input", component.touch)}, nil), tue.ElementWithEvents("input", []tue.Attribute{tue.Attr("type", "checkbox"), tue.BoolStateAttr("checked", component.enabled.Get())}, []tue.EventBinding{tue.OnChecked("change", func(checked bool) {
+	}), tue.EventOf("input", component.touch)}, nil), tue.ElementWithEvents("input", []tue.Attribute{tue.Attr("type", "checkbox"), tue.BoolStateAttr("checked", component.enabled.Get())}, []tue.EventBinding{tue.OnChecked("change", func(checked bool) {
 		component.enabled.Set(checked)
 	})}, nil), tue.ElementWithEvents("select", []tue.Attribute{tue.Attr("value", component.choice)}, []tue.EventBinding{tue.OnValue("change", func(value string) {
 		component.choice = value

--- a/internal/compiler/gogen/testdata/golden/Parent_render_tue.go
+++ b/internal/compiler/gogen/testdata/golden/Parent_render_tue.go
@@ -15,7 +15,7 @@ func renderParent(component *Parent) tue.VNode {
 			return tue.ComponentWithUpdate("UserBadge", func() *tue.Comp {
 				child := &UserBadge{name: tue.PropOfFunc(func() string {
 					return component.name.Get()
-				}), active: tue.PropOf(true), label: tue.PropOf(""), onSelect: component.selectUser}
+				}), active: tue.PropOf(true), label: tue.PropOf(""), onSelect: tue.OnOf(component.selectUser), onRange: tue.OnOf(component.selectRange), onTags: tue.OnOf(component.selectTags), onDismiss: tue.On[func(string)]{}}
 				childComp := tue.CompOf(child, renderUserBadge)
 				return childComp
 			}, func(childComp *tue.Comp) {
@@ -25,7 +25,10 @@ func renderParent(component *Parent) tue.VNode {
 				})
 				child.active = tue.PropOf(true)
 				child.label = tue.PropOf("")
-				child.onSelect = component.selectUser
+				child.onSelect = tue.OnOf(component.selectUser)
+				child.onRange = tue.OnOf(component.selectRange)
+				child.onTags = tue.OnOf(component.selectTags)
+				child.onDismiss = tue.On[func(string)]{}
 				childComp.DefaultSlot = nil
 			})
 		}

--- a/internal/compiler/gogen/testdata/invalid_component_events/Parent.tue
+++ b/internal/compiler/gogen/testdata/invalid_component_events/Parent.tue
@@ -6,6 +6,8 @@
 		@payload="selectUser"
 		@selectWithArg="selectUser(1)"
 		@selectBad="needsValue"
+		@wrongPayload="needsValue"
+		@result="returnsValue"
 	/>
 </main>
 </template>
@@ -16,6 +18,8 @@ package fixtures
 func (p *Parent) selectUser() {}
 
 func (p *Parent) needsValue(value string) {}
+
+func (p *Parent) returnsValue() string { return "result" }
 
 type Parent struct{}
 </script>

--- a/internal/compiler/gogen/testdata/invalid_component_events/UserBadge.tue
+++ b/internal/compiler/gogen/testdata/invalid_component_events/UserBadge.tue
@@ -8,9 +8,11 @@ package fixtures
 import tue "github.com/norunners/tue"
 
 type UserBadge struct {
-	name            tue.Prop[string] `prop:"name,required"`
-	onPayload       func(string)
-	onSelectWithArg func()
-	onSelectBad     func()
+	name            tue.Prop[string]       `prop:"name,required"`
+	onPayload       tue.On[func(string)]
+	onSelectWithArg tue.On[func()]
+	onSelectBad     tue.On[func()]
+	onWrongPayload  tue.On[func(int)]
+	onResult        tue.On[func() string]
 }
 </script>

--- a/internal/compiler/gogen/testdata/loops/UserBadge.tue
+++ b/internal/compiler/gogen/testdata/loops/UserBadge.tue
@@ -10,6 +10,6 @@ import tue "github.com/norunners/tue"
 type UserBadge struct {
 	name     tue.Prop[string] `prop:"name,required"`
 	active   tue.Prop[bool]
-	onSelect func()
+	onSelect tue.On[func()]
 }
 </script>

--- a/internal/compiler/script/contract.go
+++ b/internal/compiler/script/contract.go
@@ -90,6 +90,24 @@ type Method struct {
 	ReceiverSpan    sfc.Span
 }
 
+// ParameterTypes returns the method parameter types in declaration order.
+func (m Method) ParameterTypes() []string {
+	return parameterTypes(m.Parameters)
+}
+
+// ResultTypes returns the method result types in declaration order.
+func (m Method) ResultTypes() []string {
+	return parameterTypes(m.Results)
+}
+
+func parameterTypes(parameters []Parameter) []string {
+	types := make([]string, len(parameters))
+	for index, parameter := range parameters {
+		types[index] = parameter.Type
+	}
+	return types
+}
+
 // Parameter is a method parameter or result.
 type Parameter struct {
 	Name     string

--- a/internal/compiler/script/parse.go
+++ b/internal/compiler/script/parse.go
@@ -413,8 +413,11 @@ func (e *extractor) fieldFromAST(name *ast.Ident, astField *ast.Field) Field {
 
 func (e *extractor) classifyField(fieldName string, expr ast.Expr) (FieldKind, string) {
 	if _, ok := expr.(*ast.FuncType); ok {
-		if _, ok := eventNameFromFieldName(fieldName); ok {
-			return FieldKindEvent, ""
+		if _, eventNameOK := eventNameFromFieldName(fieldName); eventNameOK {
+			e.addDiagnostic(
+				fmt.Sprintf("component event field %q must use tue.On[func(...)]", fieldName),
+				e.nodeSpan(expr),
+			)
 		}
 		return FieldKindState, ""
 	}
@@ -428,12 +431,32 @@ func (e *extractor) classifyField(fieldName string, expr ast.Expr) (FieldKind, s
 	if !ok {
 		return FieldKindState, ""
 	}
+	if kind == FieldKindEvent {
+		if _, eventNameOK := eventNameFromFieldName(fieldName); !eventNameOK {
+			e.addDiagnostic(
+				fmt.Sprintf("component event field %q must start with on followed by an uppercase event name", fieldName),
+				e.nodeSpan(expr),
+			)
+		}
+	}
 	if len(args) != 1 {
+		typeParameter := "T"
+		if kind == FieldKindEvent {
+			typeParameter = "F"
+		}
 		e.addDiagnostic(
-			fmt.Sprintf("field %q must use tue.%s[T] with exactly one type argument", fieldName, typeName),
+			fmt.Sprintf("field %q must use tue.%s[%s] with exactly one type argument", fieldName, typeName, typeParameter),
 			e.nodeSpan(expr),
 		)
 		return kind, ""
+	}
+	if kind == FieldKindEvent {
+		if _, ok := args[0].(*ast.FuncType); !ok {
+			e.addDiagnostic(
+				fmt.Sprintf("field %q must use tue.On[F] with a function type", fieldName),
+				e.nodeSpan(args[0]),
+			)
+		}
 	}
 	return kind, e.nodeString(args[0])
 }
@@ -478,6 +501,8 @@ func (e *extractor) tueTypeName(expr ast.Expr) (string, bool) {
 
 func fieldKindForTueType(name string) (FieldKind, bool) {
 	switch name {
+	case "On":
+		return FieldKindEvent, true
 	case "Prop":
 		return FieldKindProp, true
 	case "Ref":

--- a/internal/compiler/script/parse_test.go
+++ b/internal/compiler/script/parse_test.go
@@ -54,7 +54,7 @@ func TestParseExtractsComponentContract(t *testing.T) {
 			{Kind: FieldKindState, Name: "count", Type: "tue.Ref[int]"},
 			{Kind: FieldKindState, Name: "total", Type: "tue.Computed[int]"},
 			{Kind: FieldKindState, Name: "user", Type: "tue.Resource[User]"},
-			{Kind: FieldKindState, Name: "onSave", Type: "func()"},
+			{Kind: FieldKindState, Name: "onSave", Type: "tue.On[func()]"},
 			{Kind: FieldKindState, Name: "label", Type: "string"},
 		}},
 	}, summarizeStructs(file.Structs)); diff != "" {
@@ -91,7 +91,7 @@ func TestParseExtractsComponentContract(t *testing.T) {
 	assertField(t, component.Refs, "count", FieldKindRef, "tue.Ref[int]", "int")
 	assertField(t, component.Computed, "total", FieldKindComputed, "tue.Computed[int]", "int")
 	assertField(t, component.Resources, "user", FieldKindResource, "tue.Resource[User]", "User")
-	assertField(t, component.Events, "onSave", FieldKindEvent, "func()", "")
+	assertField(t, component.Events, "onSave", FieldKindEvent, "tue.On[func()]", "func()")
 	assertField(t, component.State, "label", FieldKindState, "string", "")
 
 	init, err := requireInit(component)
@@ -264,6 +264,24 @@ func TestParseDiagnostics(t *testing.T) {
 			fixture:   "testdata/diagnostics/prop_with_too_many_type_arguments.go",
 			component: "App",
 			expected:  []string{`field "name" must use tue.Prop[T] with exactly one type argument`},
+		},
+		{
+			name:      "legacy component event",
+			fixture:   "testdata/diagnostics/legacy_component_event.go",
+			component: "App",
+			expected:  []string{`component event field "onSave" must use tue.On[func(...)]`},
+		},
+		{
+			name:      "component event requires function type",
+			fixture:   "testdata/diagnostics/component_event_non_function.go",
+			component: "App",
+			expected:  []string{`field "onSave" must use tue.On[F] with a function type`},
+		},
+		{
+			name:      "component event requires event field name",
+			fixture:   "testdata/diagnostics/component_event_invalid_name.go",
+			component: "App",
+			expected:  []string{`component event field "save" must start with on followed by an uppercase event name`},
 		},
 		{
 			name:      "invalid Init value receiver",

--- a/internal/compiler/script/testdata/contracts/dashboard.go
+++ b/internal/compiler/script/testdata/contracts/dashboard.go
@@ -9,8 +9,8 @@ type Dashboard struct {
 	count tue.Ref[int]
 	total tue.Computed[int]
 	user  tue.Resource[User]
-	onSave func()
-	label string
+	onSave tue.On[func()]
+	label  string
 }
 
 func (d *Dashboard) Init(ctx tue.Context) {}

--- a/internal/compiler/script/testdata/diagnostics/component_event_invalid_name.go
+++ b/internal/compiler/script/testdata/diagnostics/component_event_invalid_name.go
@@ -1,0 +1,7 @@
+package fixtures
+
+import tue "github.com/norunners/tue"
+
+type App struct {
+	save tue.On[func()]
+}

--- a/internal/compiler/script/testdata/diagnostics/component_event_non_function.go
+++ b/internal/compiler/script/testdata/diagnostics/component_event_non_function.go
@@ -1,0 +1,7 @@
+package fixtures
+
+import tue "github.com/norunners/tue"
+
+type App struct {
+	onSave tue.On[string]
+}

--- a/internal/compiler/script/testdata/diagnostics/legacy_component_event.go
+++ b/internal/compiler/script/testdata/diagnostics/legacy_component_event.go
@@ -1,0 +1,5 @@
+package fixtures
+
+type App struct {
+	onSave func()
+}

--- a/internal/compiler/script/types.go
+++ b/internal/compiler/script/types.go
@@ -54,6 +54,16 @@ func stubTuePackage() *types.Package {
 		scope.Insert(typeName)
 	}
 
+	onTypeName := types.NewTypeName(token.NoPos, pkg, "On", nil)
+	onTypeParamName := types.NewTypeName(token.NoPos, pkg, "F", nil)
+	onTypeParam := types.NewTypeParam(onTypeParamName, anyType)
+	onStruct := types.NewStruct([]*types.Var{
+		types.NewField(token.NoPos, pkg, "fn", onTypeParam, false),
+	}, nil)
+	onType := types.NewNamed(onTypeName, onStruct, nil)
+	onType.SetTypeParams([]*types.TypeParam{onTypeParam})
+	scope.Insert(onTypeName)
+
 	for _, name := range []string{"Context", "Route", "RouteMatch", "Router", "TrustedHTML", "VNode"} {
 		typeName := types.NewTypeName(token.NoPos, pkg, name, nil)
 		types.NewNamed(typeName, emptyInterface, nil)

--- a/internal/compiler/typecap/function.go
+++ b/internal/compiler/typecap/function.go
@@ -1,0 +1,104 @@
+package typecap
+
+import (
+	"bytes"
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"strings"
+)
+
+// FunctionSignature describes the parameter and result types of a Go function.
+type FunctionSignature struct {
+	Parameters []string
+	Results    []string
+}
+
+// String returns the canonical Go spelling of the function signature.
+func (s *FunctionSignature) String() string {
+	if s == nil {
+		return ""
+	}
+	signature := "func(" + strings.Join(s.Parameters, ", ") + ")"
+	switch len(s.Results) {
+	case 0:
+		return signature
+	case 1:
+		return signature + " " + s.Results[0]
+	default:
+		return signature + " (" + strings.Join(s.Results, ", ") + ")"
+	}
+}
+
+// ParseFunction parses typ as a Go function type. When ok is false, the
+// returned signature is nil.
+func ParseFunction(typ string) (*FunctionSignature, bool) {
+	expression, err := parser.ParseExpr(strings.TrimSpace(typ))
+	if err != nil {
+		return nil, false
+	}
+	function, ok := expression.(*ast.FuncType)
+	if !ok {
+		return nil, false
+	}
+
+	parameters, ok := functionFieldTypes(function.Params)
+	if !ok {
+		return nil, false
+	}
+	results, ok := functionFieldTypes(function.Results)
+	if !ok {
+		return nil, false
+	}
+	return &FunctionSignature{Parameters: parameters, Results: results}, true
+}
+
+// Matches reports whether parameters and results exactly match the parsed
+// function signature. Pointer distinctions are intentionally preserved.
+func (s *FunctionSignature) Matches(parameters []string, results []string) bool {
+	if s == nil || len(s.Parameters) != len(parameters) || len(s.Results) != len(results) {
+		return false
+	}
+	for index, expected := range s.Parameters {
+		if expected != strings.TrimSpace(parameters[index]) {
+			return false
+		}
+	}
+	for index, expected := range s.Results {
+		if expected != strings.TrimSpace(results[index]) {
+			return false
+		}
+	}
+	return true
+}
+
+func functionFieldTypes(fields *ast.FieldList) ([]string, bool) {
+	if fields == nil {
+		return nil, true
+	}
+
+	var types []string
+	for _, field := range fields.List {
+		fieldType, ok := functionFieldType(field.Type)
+		if !ok {
+			return nil, false
+		}
+		count := len(field.Names)
+		if count == 0 {
+			count = 1
+		}
+		for range count {
+			types = append(types, fieldType)
+		}
+	}
+	return types, true
+}
+
+func functionFieldType(expression ast.Expr) (string, bool) {
+	var source bytes.Buffer
+	if err := printer.Fprint(&source, token.NewFileSet(), expression); err != nil {
+		return "", false
+	}
+	return source.String(), true
+}

--- a/internal/compiler/typecap/function_test.go
+++ b/internal/compiler/typecap/function_test.go
@@ -1,0 +1,86 @@
+package typecap
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseFunction(t *testing.T) {
+	tests := []struct {
+		name       string
+		typ        string
+		expected   *FunctionSignature
+		expectedOK bool
+	}{
+		{name: "no arguments", typ: "func()", expected: &FunctionSignature{}, expectedOK: true},
+		{name: "one argument", typ: "func(string)", expected: &FunctionSignature{Parameters: []string{"string"}}, expectedOK: true},
+		{name: "named arguments", typ: "func(value string, count int)", expected: &FunctionSignature{Parameters: []string{"string", "int"}}, expectedOK: true},
+		{name: "grouped arguments", typ: "func(first, second string)", expected: &FunctionSignature{Parameters: []string{"string", "string"}}, expectedOK: true},
+		{name: "variadic argument", typ: "func(...string)", expected: &FunctionSignature{Parameters: []string{"...string"}}, expectedOK: true},
+		{name: "results", typ: "func(string) (int, error)", expected: &FunctionSignature{Parameters: []string{"string"}, Results: []string{"int", "error"}}, expectedOK: true},
+		{name: "not function", typ: "string", expected: nil, expectedOK: false},
+		{name: "malformed", typ: "func(", expected: nil, expectedOK: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, ok := ParseFunction(test.typ)
+			if diff := cmp.Diff(test.expectedOK, ok); diff != "" {
+				t.Errorf("mismatch parse ok (-expected, +actual):\n%s", diff)
+			}
+			if diff := cmp.Diff(test.expected, actual); diff != "" {
+				t.Errorf("mismatch function signature (-expected, +actual):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFunctionSignatureMatches(t *testing.T) {
+	signature, ok := ParseFunction("func(string, *User)")
+	if !ok {
+		t.Fatal("parse function signature failed")
+	}
+
+	tests := []struct {
+		name       string
+		parameters []string
+		results    []string
+		expected   bool
+	}{
+		{name: "exact", parameters: []string{"string", "*User"}, expected: true},
+		{name: "trimmed", parameters: []string{" string ", " *User "}, expected: true},
+		{name: "pointer mismatch", parameters: []string{"string", "User"}, expected: false},
+		{name: "parameter count", parameters: []string{"string"}, expected: false},
+		{name: "unexpected result", parameters: []string{"string", "*User"}, results: []string{"error"}, expected: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if diff := cmp.Diff(test.expected, signature.Matches(test.parameters, test.results)); diff != "" {
+				t.Errorf("mismatch signature match (-expected, +actual):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFunctionSignatureString(t *testing.T) {
+	tests := []struct {
+		name      string
+		signature *FunctionSignature
+		expected  string
+	}{
+		{name: "nil", signature: nil, expected: ""},
+		{name: "no results", signature: &FunctionSignature{Parameters: []string{"string", "int"}}, expected: "func(string, int)"},
+		{name: "one result", signature: &FunctionSignature{Results: []string{"error"}}, expected: "func() error"},
+		{name: "multiple results", signature: &FunctionSignature{Parameters: []string{"string"}, Results: []string{"int", "error"}}, expected: "func(string) (int, error)"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if diff := cmp.Diff(test.expected, test.signature.String()); diff != "" {
+				t.Errorf("mismatch function signature string (-expected, +actual):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/compiler/typecap/typecap.go
+++ b/internal/compiler/typecap/typecap.go
@@ -116,11 +116,6 @@ func Scalar(typ string) bool {
 	}
 }
 
-// NoArgFunc reports whether typ is exactly a no-argument function.
-func NoArgFunc(typ string) bool {
-	return strings.TrimSpace(typ) == "func()"
-}
-
 func closingBracket(typ string, open int) int {
 	if open < 0 || open >= len(typ) || typ[open] != '[' {
 		return -1

--- a/internal/compiler/typecap/typecap_test.go
+++ b/internal/compiler/typecap/typecap_test.go
@@ -124,8 +124,6 @@ func TestTypeCapabilities(t *testing.T) {
 		{name: "non-numeric", actual: Numeric("string"), expected: false},
 		{name: "scalar", actual: Scalar("bool"), expected: true},
 		{name: "non-scalar", actual: Scalar("[]string"), expected: false},
-		{name: "no-arg function", actual: NoArgFunc(" func() "), expected: true},
-		{name: "function with arguments", actual: NoArgFunc("func(string)"), expected: false},
 	}
 
 	for _, test := range tests {

--- a/patch_test.go
+++ b/patch_test.go
@@ -100,7 +100,7 @@ func TestMountedUpdatePatchesTrustedHTMLContent(t *testing.T) {
 			return Element("main", nil, []VNode{Text("Back")})
 		default:
 			return Element("main", nil, []VNode{
-				ElementWithEvents("button", nil, []EventBinding{On("click", func() {})}, []VNode{Text("Save")}),
+				ElementWithEvents("button", nil, []EventBinding{EventOf("click", func() {})}, []VNode{Text("Save")}),
 			})
 		}
 	}), target)
@@ -442,7 +442,7 @@ func TestMountedUpdateReplacesSameKeyDifferentType(t *testing.T) {
 		if renderText {
 			child = VNode{Type: VNodeTypeText, Key: "a", Text: "Saved"}
 		} else {
-			child = ElementWithEvents("button", nil, []EventBinding{On("click", func() {
+			child = ElementWithEvents("button", nil, []EventBinding{EventOf("click", func() {
 				events = append(events, "click")
 			})}, []VNode{Text("Save")})
 			child.Key = "a"
@@ -691,7 +691,7 @@ func TestMountedEventHandlerRunsAndUpdatesInPlace(t *testing.T) {
 				events = append(events, "second")
 			}
 		}
-		return ElementWithEvents("button", nil, []EventBinding{On("click", handler)}, []VNode{Text("Save")})
+		return ElementWithEvents("button", nil, []EventBinding{EventOf("click", handler)}, []VNode{Text("Save")})
 	}), target)
 	if err != nil {
 		t.Fatalf("mountComponent returned error: %v", err)
@@ -735,7 +735,7 @@ func TestMountedDuplicateEventHandlersRunModelBeforeUserHandler(t *testing.T) {
 				query = value
 				events = append(events, "model:"+query)
 			}),
-			On("input", func() {
+			EventOf("input", func() {
 				events = append(events, "user:"+query)
 			}),
 		}, nil)
@@ -762,11 +762,11 @@ func TestMountedEventListenersCleanUpWhenNodeIsReplaced(t *testing.T) {
 	target := newStubDOMTarget()
 	mounted, err := mountComponent(CompOf(&patchFixture{}, func(*patchFixture) VNode {
 		if replace {
-			return ElementWithEvents("a", nil, []EventBinding{On("click", func() {
+			return ElementWithEvents("a", nil, []EventBinding{EventOf("click", func() {
 				events = append(events, "link")
 			})}, []VNode{Text("Link")})
 		}
-		return ElementWithEvents("button", nil, []EventBinding{On("click", func() {
+		return ElementWithEvents("button", nil, []EventBinding{EventOf("click", func() {
 			events = append(events, "button")
 		})}, []VNode{Text("Save")})
 	}), target)
@@ -803,7 +803,7 @@ func TestMountedEventListenersCleanUpOnUnmount(t *testing.T) {
 	events := []string{}
 	target := newStubDOMTarget()
 	mounted, err := mountComponent(CompOf(&patchFixture{}, func(*patchFixture) VNode {
-		return ElementWithEvents("button", nil, []EventBinding{On("click", func() {
+		return ElementWithEvents("button", nil, []EventBinding{EventOf("click", func() {
 			events = append(events, "click")
 		})}, []VNode{Text("Save")})
 	}), target)


### PR DESCRIPTION
## Summary

- Replaced raw child callback fields with typed `tue.On[F]` component event fields.
- Added `OnOf`, `Func`, `Ok`, and `FuncOk` so generated parents bind methods while children explicitly retrieve optional callbacks.
- Removed reflection from callback presence checks and preserved safe zero-value behavior with explicit internal presence state.
- Preserved typed payload validation for zero, multiple, pointer, named, and variadic callback parameters while continuing to reject callback results.
- Generated zero `tue.On[F]` values for omitted handlers on both component creation and patching.
- Added declaration diagnostics for legacy raw callbacks, non-function `On` arguments, and invalid event field names.
- Renamed the native zero-payload DOM binding constructor from `On` to `EventOf` because Go cannot export both a generic type and function named `On`.

## Component contract

A child declares and invokes an event as:

```go
type UserBadge struct {
    onSelect tue.On[func(string)]
}

if onSelect, ok := u.onSelect.FuncOk(); ok {
    onSelect("selected")
}
```

`Func` and `Ok` are also available independently. A parent binding such as `@select="selectUser"` generates `tue.OnOf(component.selectUser)`. The parent method must exactly match the wrapped function signature. The child supplies callback payloads, so argument-bearing template calls such as `@select="selectUser(user)"` remain unsupported.

Presence is stored explicitly because converting a typed nil function to `any` produces a non-nil interface; a direct `any(fn) != nil` check would incorrectly mark a zero `On[func(...)]` value as present.

## Migration

- Replace child `on<Event> func(...)` fields with `on<Event> tue.On[func(...)]`.
- Replace nil checks and direct calls with `FuncOk()`, or with separate `Ok()` and `Func()` calls.
- Replace direct native runtime calls to `tue.On(name, handler)` with `tue.EventOf(name, handler)`.

Cross-package component adapters remain deferred; this change applies to the existing same-package component model.

## Verification

- `go fmt ./...`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`
- `git diff --cached --check`
- GoGraph MCP uncommitted review and risk checks

Local design and implementation-plan updates remain excluded from this pull request.