### PR TITLE
[codex] Added generated component computed fields

### DIFF
--- a/comp.go
+++ b/comp.go
@@ -1,6 +1,7 @@
 package tue
 
 // Comp declares generated component fields for compiler discovery.
-// T must be an anonymous struct whose fields use prop, event, or state tags.
+// T must be an anonymous struct whose fields use prop, event, state, or
+// computed tags.
 // The marker has no runtime state and does not require initialization.
 type Comp[T any] struct{}

--- a/examples/router/App.tue
+++ b/examples/router/App.tue
@@ -3,36 +3,36 @@
 		<header>
 			<p class="eyebrow">Hash router</p>
 			<h1>Router</h1>
-			<p>Current route: {{ routeLabel }}</p>
+			<p>Current route: {{ RouteLabel }}</p>
 		</header>
 
 		<nav>
-			<a :href="HomeHref" :class="homeClass">Overview</a>
-			<a :href="UserHref" :class="userClass">User 42</a>
-			<a :href="UserProfileHref" :class="userClass">User 42 profile</a>
-			<a :href="SettingsHref" :class="settingsClass">Settings</a>
+			<a :href="HomeHref" :class="HomeClass">Overview</a>
+			<a :href="UserHref" :class="UserClass">User 42</a>
+			<a :href="UserProfileHref" :class="UserClass">User 42 profile</a>
+			<a :href="SettingsHref" :class="SettingsClass">Settings</a>
 			<a :href="MissingHref">Missing route</a>
 		</nav>
 
-		<section v-if="homeActive" class="panel">
+		<section v-if="HomeActive" class="panel">
 			<h2>Overview</h2>
 			<p>The explicit route table matched the static home route.</p>
 		</section>
 
-		<section v-if="userActive" class="panel">
+		<section v-if="UserActive" class="panel">
 			<h2>User detail</h2>
-			<p>User ID: {{ currentUserID }}</p>
-			<p>Tab: {{ currentTab }}</p>
+			<p>User ID: {{ CurrentUserID }}</p>
+			<p>Tab: {{ CurrentTab }}</p>
 		</section>
 
-		<section v-if="settingsActive" class="panel">
+		<section v-if="SettingsActive" class="panel">
 			<h2>Settings</h2>
 			<p>Settings use a static route with the same reactive current-route state.</p>
 		</section>
 
-		<section v-if="notFoundActive" class="panel warning">
+		<section v-if="NotFoundActive" class="panel warning">
 			<h2>Not found</h2>
-			<p>{{ notFoundMessage }}</p>
+			<p>{{ NotFoundMessage }}</p>
 		</section>
 	</main>
 </template>
@@ -49,19 +49,19 @@ type App struct {
 		UserProfileHref string `state:""`
 		SettingsHref    string `state:""`
 		MissingHref     string `state:""`
+		RouteLabel      string `computed:"routeLabel"`
+		CurrentUserID   string `computed:"currentUserID"`
+		CurrentTab      string `computed:"currentTab"`
+		NotFoundMessage string `computed:"notFoundMessage"`
+		HomeActive      bool   `computed:"homeActive"`
+		UserActive      bool   `computed:"userActive"`
+		SettingsActive  bool   `computed:"settingsActive"`
+		NotFoundActive  bool   `computed:"notFoundActive"`
+		HomeClass       string `computed:"homeClass"`
+		UserClass       string `computed:"userClass"`
+		SettingsClass   string `computed:"settingsClass"`
 	}]
-	router          *tue.Router
-	routeLabel      tue.Computed[string]
-	currentUserID   tue.Computed[string]
-	currentTab      tue.Computed[string]
-	notFoundMessage tue.Computed[string]
-	homeActive      tue.Computed[bool]
-	userActive      tue.Computed[bool]
-	settingsActive  tue.Computed[bool]
-	notFoundActive  tue.Computed[bool]
-	homeClass       tue.Computed[string]
-	userClass       tue.Computed[string]
-	settingsClass   tue.Computed[string]
+	router *tue.Router
 }
 
 func (a *App) Init(ctx tue.Context) {
@@ -77,47 +77,58 @@ func (a *App) Init(ctx tue.Context) {
 	a.UserProfileHrefSet(a.router.Href("/users/42?tab=profile"))
 	a.SettingsHrefSet(a.router.Href("/settings"))
 	a.MissingHrefSet(a.router.Href("/missing"))
-	a.routeLabel = tue.ComputedOfFunc(func() string {
-		match := a.router.Current()
-		if !match.Found {
-			return "not found"
-		}
-		return match.Pattern
-	})
-	a.currentUserID = tue.ComputedOfFunc(func() string {
-		return a.router.Current().Param("id")
-	})
-	a.currentTab = tue.ComputedOfFunc(func() string {
-		tab := a.router.Current().QueryParam("tab")
-		if tab == "" {
-			return "summary"
-		}
-		return tab
-	})
-	a.notFoundMessage = tue.ComputedOfFunc(func() string {
-		return "No route matched " + a.router.Current().Path
-	})
-	a.homeActive = tue.ComputedOfFunc(func() bool {
-		return a.router.Current().Pattern == "/"
-	})
-	a.userActive = tue.ComputedOfFunc(func() bool {
-		return a.router.Current().Pattern == "/users/:id"
-	})
-	a.settingsActive = tue.ComputedOfFunc(func() bool {
-		return a.router.Current().Pattern == "/settings"
-	})
-	a.notFoundActive = tue.ComputedOfFunc(func() bool {
-		return !a.router.Current().Found
-	})
-	a.homeClass = tue.ComputedOfFunc(func() string {
-		return navClass(a.homeActive.Get())
-	})
-	a.userClass = tue.ComputedOfFunc(func() string {
-		return navClass(a.userActive.Get())
-	})
-	a.settingsClass = tue.ComputedOfFunc(func() string {
-		return navClass(a.settingsActive.Get())
-	})
+}
+
+func (a *App) routeLabel() string {
+	match := a.router.Current()
+	if !match.Found {
+		return "not found"
+	}
+	return match.Pattern
+}
+
+func (a *App) currentUserID() string {
+	return a.router.Current().Param("id")
+}
+
+func (a *App) currentTab() string {
+	tab := a.router.Current().QueryParam("tab")
+	if tab == "" {
+		return "summary"
+	}
+	return tab
+}
+
+func (a *App) notFoundMessage() string {
+	return "No route matched " + a.router.Current().Path
+}
+
+func (a *App) homeActive() bool {
+	return a.router.Current().Pattern == "/"
+}
+
+func (a *App) userActive() bool {
+	return a.router.Current().Pattern == "/users/:id"
+}
+
+func (a *App) settingsActive() bool {
+	return a.router.Current().Pattern == "/settings"
+}
+
+func (a *App) notFoundActive() bool {
+	return !a.router.Current().Found
+}
+
+func (a *App) homeClass() string {
+	return navClass(a.HomeActive())
+}
+
+func (a *App) userClass() string {
+	return navClass(a.UserActive())
+}
+
+func (a *App) settingsClass() string {
+	return navClass(a.SettingsActive())
 }
 
 func navClass(active bool) string {

--- a/internal/compiler/checker/checker_test.go
+++ b/internal/compiler/checker/checker_test.go
@@ -312,6 +312,7 @@ func TestCheckProjectReportsModelBindingDiagnostics(t *testing.T) {
 		{Path: "testdata/invalid_model_binding/Parent.tue", Message: `v-model expects string, got bool`, Line: 4, Column: 20},
 		{Path: "testdata/invalid_model_binding/Parent.tue", Message: `v-model is not supported for input type "number"`, Line: 9, Column: 24},
 		{Path: "testdata/invalid_model_binding/Parent.tue", Message: `type string has no field "Text"`, Line: 11, Column: 25},
+		{Path: "testdata/invalid_model_binding/Parent.tue", Message: `v-model target "Label" is not writable`, Line: 12, Column: 19},
 	}
 	if diff := cmp.Diff(expected, summarizeDiagnostics(diagnostics)); diff != "" {
 		t.Errorf("mismatch diagnostics (-expected, +actual):\n%s", diff)

--- a/internal/compiler/checker/scope.go
+++ b/internal/compiler/checker/scope.go
@@ -31,9 +31,6 @@ func componentScope(component *script.Component) *scope {
 	for _, field := range component.LocalFields {
 		scope.add(symbol{Name: field.Name, Type: fieldType(field), Writable: true})
 	}
-	for _, field := range component.Computed {
-		scope.add(symbol{Name: field.Name, Type: fieldType(field)})
-	}
 	for _, field := range component.Resources {
 		scope.add(symbol{Name: field.Name, Type: fieldType(field)})
 	}

--- a/internal/compiler/checker/testdata/invalid_model_binding/Parent.tue
+++ b/internal/compiler/checker/testdata/invalid_model_binding/Parent.tue
@@ -9,14 +9,24 @@
 		<input type="number" v-model="query" />
 
 		<input v-model="query.Text" />
+		<input v-model="Label" />
 	</main>
 </template>
 
 <script lang="go">
 package fixtures
 
+import tue "github.com/norunners/tue"
+
 type Parent struct {
+	tue.Comp[struct {
+		Label string `computed:"label"`
+	}]
 	query   string
 	enabled bool
+}
+
+func (p *Parent) label() string {
+	return p.query
 }
 </script>

--- a/internal/compiler/gogen/expression.go
+++ b/internal/compiler/gogen/expression.go
@@ -140,7 +140,7 @@ func (g expressionGenerator) ident(ident *ast.Ident) jen.Code {
 
 	access := jen.Id("component").Dot(field.Name)
 	switch field.Kind {
-	case script.FieldKindComputed, script.FieldKindResource:
+	case script.FieldKindResource:
 		return access.Dot("Get").Call()
 	default:
 		return access

--- a/internal/compiler/gogen/generate.go
+++ b/internal/compiler/gogen/generate.go
@@ -302,7 +302,7 @@ func (g *projectGenerator) generatedComponentSource(file File) ([]byte, bool) {
 	for alias, path := range imports {
 		generated.ImportName(path, alias)
 	}
-	fields := make([]jen.Code, 0, len(component.Props)+len(component.Events)+len(component.States))
+	fields := make([]jen.Code, 0, len(component.Props)+len(component.Events)+len(component.States)+len(component.Computed))
 	for _, prop := range component.Props {
 		valueType, ok := renderGeneratedTypeExpression(prop.Type, imports)
 		if !ok {
@@ -326,6 +326,14 @@ func (g *projectGenerator) generatedComponentSource(file File) ([]byte, bool) {
 			return nil, false
 		}
 		fields = append(fields, jen.Id(script.StateFieldName(state.GoName)).Qual(tueImportPath, "State").Types(valueType))
+	}
+	for _, computed := range component.Computed {
+		valueType, ok := renderGeneratedTypeExpression(computed.Type, imports)
+		if !ok {
+			g.add(filePath(file), fmt.Sprintf("component computed %q has unsupported type %q", computed.Name, computed.Type), computed.TypeSpan)
+			return nil, false
+		}
+		fields = append(fields, jen.Id(script.ComputedFieldName(computed.GoName)).Qual(tueImportPath, "Computed").Types(valueType))
 	}
 	generated.Type().Id(component.GeneratedType).Struct(fields...)
 	initialValues := make([]jen.Code, 0, len(component.States))
@@ -390,6 +398,19 @@ func (g *projectGenerator) generatedComponentSource(file File) ([]byte, bool) {
 				jen.Id("component").Op("==").Nil().Op("||").Id("component").Dot(script.GeneratedFieldName()).Dot(fieldName).Op("==").Nil(),
 			).Block(jen.Return()),
 			jen.Id("component").Dot(script.GeneratedFieldName()).Dot(fieldName).Dot("Set").Call(jen.Id("value")),
+		)
+	}
+	for _, computed := range component.Computed {
+		valueType, _ := renderGeneratedTypeExpression(computed.Type, imports)
+		fieldName := script.ComputedFieldName(computed.GoName)
+		generated.Func().Params(jen.Id("component").Op("*").Id(component.Name)).Id(script.ComputedGetterName(computed.GoName)).Params().Add(valueType).Block(
+			jen.If(
+				jen.Id("component").Op("==").Nil().Op("||").Id("component").Dot(script.GeneratedFieldName()).Dot(fieldName).Op("==").Nil(),
+			).Block(
+				jen.Var().Id("zero").Add(valueType),
+				jen.Return(jen.Id("zero")),
+			),
+			jen.Return(jen.Id("component").Dot(script.GeneratedFieldName()).Dot(fieldName).Dot("Get").Call()),
 		)
 	}
 
@@ -497,9 +518,13 @@ func (g *fileGenerator) generate(tree *gotemplate.Tree) {
 			jen.Id(script.GeneratedFieldName()).Op(":").Id(script.GeneratedConstructorName(g.component.Name)).Call(),
 		)
 	}
+	compArgs := []jen.Code{jen.Id("component"), jen.Id("render" + componentName)}
+	if initializer := generatedComputedInitializer(g.component, "component"); initializer != nil {
+		compArgs = append(compArgs, initializer)
+	}
 	g.file.Func().Id("New"+componentName).Params().Op("*").Qual(tueImportPath, "CompInstance").Block(
 		jen.Id("component").Op(":=").Op("&").Id(componentName).Values(componentValues...),
-		jen.Return(jen.Qual(tueImportPath, "CompOf").Call(jen.Id("component"), jen.Id("render"+componentName))),
+		jen.Return(jen.Qual(tueImportPath, "CompOf").Call(compArgs...)),
 	)
 	g.file.Line()
 	g.file.Func().Id("render"+componentName).Params(jen.Id("component").Op("*").Id(componentName)).Qual(tueImportPath, "VNode").Block(
@@ -1014,8 +1039,12 @@ func (g *fileGenerator) renderComponent(node *gotemplate.Node) (jen.Code, bool) 
 	for _, field := range fields {
 		statements = append(statements, jen.Id("child").Dot(script.GeneratedFieldName()).Dot(field.Name).Op("=").Add(field.Value))
 	}
+	compArgs := []jen.Code{jen.Id("child"), jen.Id("render" + child.component.Name)}
+	if initializer := generatedComputedInitializer(child.component, "child"); initializer != nil {
+		compArgs = append(compArgs, initializer)
+	}
 	statements = append(statements,
-		jen.Id("childComp").Op(":=").Qual(tueImportPath, "CompOf").Call(jen.Id("child"), jen.Id("render"+child.component.Name)),
+		jen.Id("childComp").Op(":=").Qual(tueImportPath, "CompOf").Call(compArgs...),
 	)
 	if defaultSlot != nil {
 		statements = append(statements, jen.Id("childComp").Dot("DefaultSlot").Op("=").Add(defaultSlot))
@@ -1978,13 +2007,25 @@ func componentFields(component *script.Component) map[string]script.Field {
 	for _, field := range component.LocalFields {
 		fields[field.Name] = field
 	}
-	for _, field := range component.Computed {
-		fields[field.Name] = field
-	}
 	for _, field := range component.Resources {
 		fields[field.Name] = field
 	}
 	return fields
+}
+
+func generatedComputedInitializer(component *script.Component, variable string) jen.Code {
+	if component == nil || len(component.Computed) == 0 {
+		return nil
+	}
+	statements := make([]jen.Code, 0, len(component.Computed))
+	for _, computed := range component.Computed {
+		statements = append(statements,
+			jen.Id(variable).Dot(script.GeneratedFieldName()).Dot(script.ComputedFieldName(computed.GoName)).Op("=").Qual(tueImportPath, "ComputedOfFunc").Call(
+				jen.Id(variable).Dot(computed.MethodName),
+			),
+		)
+	}
+	return jen.Func().Params().Block(statements...)
 }
 
 func componentMethods(component *script.Component) map[string]script.Method {

--- a/internal/compiler/gogen/generate.go
+++ b/internal/compiler/gogen/generate.go
@@ -302,7 +302,7 @@ func (g *projectGenerator) generatedComponentSource(file File) ([]byte, bool) {
 	for alias, path := range imports {
 		generated.ImportName(path, alias)
 	}
-	fields := make([]jen.Code, 0, len(component.Props)+len(component.Events)+len(component.States)+len(component.Computed))
+	fields := make([]jen.Code, 0, len(component.Props)+len(component.Events)+len(component.States)+len(component.Computed)+1)
 	for _, prop := range component.Props {
 		valueType, ok := renderGeneratedTypeExpression(prop.Type, imports)
 		if !ok {
@@ -310,6 +310,9 @@ func (g *projectGenerator) generatedComponentSource(file File) ([]byte, bool) {
 			return nil, false
 		}
 		fields = append(fields, jen.Id(script.PropFieldName(prop.GoName)).Func().Params().Params(valueType, jen.Bool()))
+	}
+	if len(component.Props) != 0 {
+		fields = append(fields, jen.Id(script.InputVersionFieldName()).Qual(tueImportPath, "State").Types(jen.Int()))
 	}
 	for _, event := range component.Events {
 		callbackType, ok := renderGeneratedTypeExpression(event.FunctionType(), imports)
@@ -336,7 +339,12 @@ func (g *projectGenerator) generatedComponentSource(file File) ([]byte, bool) {
 		fields = append(fields, jen.Id(script.ComputedFieldName(computed.GoName)).Qual(tueImportPath, "Computed").Types(valueType))
 	}
 	generated.Type().Id(component.GeneratedType).Struct(fields...)
-	initialValues := make([]jen.Code, 0, len(component.States))
+	initialValues := make([]jen.Code, 0, len(component.States)+1)
+	if len(component.Props) != 0 {
+		initialValues = append(initialValues,
+			jen.Id(script.InputVersionFieldName()).Op(":").Qual(tueImportPath, "StateOf").Call(jen.Lit(0)),
+		)
+	}
 	for _, state := range component.States {
 		valueType, _ := renderGeneratedTypeExpression(state.Type, imports)
 		initialValues = append(initialValues,
@@ -352,7 +360,14 @@ func (g *projectGenerator) generatedComponentSource(file File) ([]byte, bool) {
 		fieldName := script.PropFieldName(prop.GoName)
 		presenceName := script.PropOKName(prop.GoName)
 		presenceStatements := []jen.Code{
-			jen.If(jen.Id("component").Op("==").Nil().Op("||").Id("component").Dot(script.GeneratedFieldName()).Dot(fieldName).Op("==").Nil()).Block(
+			jen.If(jen.Id("component").Op("==").Nil()).Block(
+				jen.Var().Id("zero").Add(valueType),
+				jen.Return(jen.Id("zero"), jen.False()),
+			),
+			jen.If(jen.Id("component").Dot(script.GeneratedFieldName()).Dot(script.InputVersionFieldName()).Op("!=").Nil()).Block(
+				jen.Id("_").Op("=").Id("component").Dot(script.GeneratedFieldName()).Dot(script.InputVersionFieldName()).Dot("Get").Call(),
+			),
+			jen.If(jen.Id("component").Dot(script.GeneratedFieldName()).Dot(fieldName).Op("==").Nil()).Block(
 				jen.Var().Id("zero").Add(valueType),
 				jen.Return(jen.Id("zero"), jen.False()),
 			),
@@ -1080,6 +1095,16 @@ func (g *fileGenerator) renderComponentUpdater(child componentBinding, fields []
 		)
 		for _, field := range fields {
 			statements = append(statements, jen.Id("child").Dot(script.GeneratedFieldName()).Dot(field.Name).Op("=").Add(field.Value))
+		}
+		if len(child.component.Props) != 0 {
+			inputVersion := func() *jen.Statement {
+				return jen.Id("child").Dot(script.GeneratedFieldName()).Dot(script.InputVersionFieldName())
+			}
+			statements = append(statements,
+				jen.If(inputVersion().Op("!=").Nil()).Block(
+					inputVersion().Dot("Set").Call(inputVersion().Dot("Get").Call().Op("+").Lit(1)),
+				),
+			)
 		}
 	}
 	if defaultSlot == nil {

--- a/internal/compiler/gogen/generate_test.go
+++ b/internal/compiler/gogen/generate_test.go
@@ -1034,6 +1034,9 @@ func TestGeneratedComponentAPI(t *testing.T) {
 	if actual := child.InitialLabel(); actual != "Ada expanded" {
 		t.Errorf("InitialLabel() actual = %q, expected Init to read Ada expanded", actual)
 	}
+	if actual := child.SubtitleLabel(); actual != "none" {
+		t.Errorf("SubtitleLabel() actual = %q, expected none", actual)
+	}
 	if actual := child.Label(); actual != "Ada expanded" {
 		t.Errorf("cached Label() actual = %q, expected Ada expanded", actual)
 	}
@@ -1084,6 +1087,29 @@ func TestGeneratedComponentAPI(t *testing.T) {
 	}
 	if child.Expanded() {
 		t.Error("generated state was reset while patching parent bindings")
+	}
+
+	parent.UseAlternateSet(true)
+	patched = renderParent(parent).Children[0]
+	patched.ComponentUpdater(childInstance)
+	if actual := child.Name(); actual != "Zoe" {
+		t.Errorf("Name() after prop source swap actual = %q, expected Zoe", actual)
+	}
+	if actual := child.Label(); actual != "Zoe" {
+		t.Errorf("Label() after prop source swap actual = %q, expected Zoe", actual)
+	}
+	if actual := child.SubtitleLabel(); actual != "alternate" {
+		t.Errorf("SubtitleLabel() after optional prop appears actual = %q, expected alternate", actual)
+	}
+
+	parent.UseAlternateSet(false)
+	patched = renderParent(parent).Children[0]
+	patched.ComponentUpdater(childInstance)
+	if actual := child.Name(); actual != "Lin" {
+		t.Errorf("Name() after prop source swap back actual = %q, expected Lin", actual)
+	}
+	if actual := child.SubtitleLabel(); actual != "none" {
+		t.Errorf("SubtitleLabel() after optional prop disappears actual = %q, expected none", actual)
 	}
 }
 `

--- a/internal/compiler/gogen/generate_test.go
+++ b/internal/compiler/gogen/generate_test.go
@@ -1028,11 +1028,20 @@ func TestGeneratedComponentAPI(t *testing.T) {
 	if _, ok := child.NameOk(); !ok {
 		t.Error("NameOk() did not report the supplied prop")
 	}
-	if actual := child.Label(); actual != "" {
-		t.Errorf("Label() actual = %q, expected zero value", actual)
+	if actual := child.Label(); actual != "Ada expanded" {
+		t.Errorf("Label() actual = %q, expected Ada expanded", actual)
 	}
-	if _, ok := child.LabelOk(); ok {
-		t.Error("LabelOk() reported an omitted prop as supplied")
+	if actual := child.InitialLabel(); actual != "Ada expanded" {
+		t.Errorf("InitialLabel() actual = %q, expected Init to read Ada expanded", actual)
+	}
+	if actual := child.Label(); actual != "Ada expanded" {
+		t.Errorf("cached Label() actual = %q, expected Ada expanded", actual)
+	}
+	if child.labelCalls != 1 {
+		t.Errorf("label calls actual = %d, expected one cached evaluation", child.labelCalls)
+	}
+	if _, ok := child.SubtitleOk(); ok {
+		t.Error("SubtitleOk() reported an omitted prop as supplied")
 	}
 	observedNames := []string{}
 	stopNames := tue.Watch(func() {
@@ -1050,6 +1059,12 @@ func TestGeneratedComponentAPI(t *testing.T) {
 	if child.Expanded() {
 		t.Error("Expanded() actual = true after ExpandedSet(false)")
 	}
+	if actual := child.Label(); actual != "Marie" {
+		t.Errorf("Label() after state change actual = %q, expected Marie", actual)
+	}
+	if child.labelCalls != 2 {
+		t.Errorf("label calls after invalidation actual = %d, expected 2", child.labelCalls)
+	}
 	called := child.Select("Grace")
 	if !called || parent.Selected() != "Grace" {
 		t.Errorf("Select() actual = (%v, %q), expected (true, Grace)", called, parent.Selected())
@@ -1063,6 +1078,9 @@ func TestGeneratedComponentAPI(t *testing.T) {
 	patched.ComponentUpdater(childInstance)
 	if actual := child.Name(); actual != "Lin" {
 		t.Errorf("Name() after patch actual = %q, expected Lin", actual)
+	}
+	if actual := child.Label(); actual != "Lin" {
+		t.Errorf("Label() after patch actual = %q, expected Lin", actual)
 	}
 	if child.Expanded() {
 		t.Error("generated state was reset while patching parent bindings")

--- a/internal/compiler/gogen/testdata/components/Parent.tue
+++ b/internal/compiler/gogen/testdata/components/Parent.tue
@@ -1,6 +1,7 @@
 <template>
 	<main>
-		<UserBadge v-if="ShowBadge" :name="Name" active @select="selectUser" @range="selectRange" @tags="selectTags" />
+		<UserBadge v-if="ShowBadge && UseAlternate" :name="AlternateName" active subtitle="alternate" @select="selectUser" @range="selectRange" @tags="selectTags" />
+		<UserBadge v-else-if="ShowBadge" :name="Name" active @select="selectUser" @range="selectRange" @tags="selectTags" />
 	</main>
 </template>
 
@@ -11,14 +12,17 @@ import tue "github.com/norunners/tue"
 
 type Parent struct {
 	tue.Comp[struct {
-		Name      string `state:""`
-		ShowBadge bool   `state:""`
-		Selected  string `state:""`
+		Name          string `state:""`
+		AlternateName string `state:""`
+		ShowBadge     bool   `state:""`
+		UseAlternate  bool   `state:""`
+		Selected      string `state:""`
 	}]
 }
 
 func (p *Parent) Init(tue.Context) {
 	p.NameSet("Ada")
+	p.AlternateNameSet("Zoe")
 }
 
 func (p *Parent) selectUser(name string) {

--- a/internal/compiler/gogen/testdata/components/UserBadge.tue
+++ b/internal/compiler/gogen/testdata/components/UserBadge.tue
@@ -9,16 +9,17 @@ import tue "github.com/norunners/tue"
 
 type UserBadge struct {
 	tue.Comp[struct {
-		Name     string            `prop:",required"`
-		Active   bool              `prop:"active"`
-		Subtitle string            `prop:""`
-		Expanded bool              `state:""`
-		InitialLabel string        `state:""`
-		Label    string            `computed:"label"`
-		Select   func(string)      `event:""`
-		Range    func(string, int) `event:""`
-		Tags     func([]string)    `event:""`
-		Dismiss  func(string)      `event:""`
+		Name          string       `prop:",required"`
+		Active        bool         `prop:"active"`
+		Subtitle      string       `prop:""`
+		Expanded      bool         `state:""`
+		InitialLabel  string       `state:""`
+		Label         string       `computed:"label"`
+		SubtitleLabel string       `computed:"subtitleLabel"`
+		Select        func(string)      `event:""`
+		Range         func(string, int) `event:""`
+		Tags          func([]string)    `event:""`
+		Dismiss       func(string)      `event:""`
 	}]
 	labelCalls int
 }
@@ -29,6 +30,13 @@ func (u *UserBadge) label() string {
 		return u.Name() + " expanded"
 	}
 	return u.Name()
+}
+
+func (u *UserBadge) subtitleLabel() string {
+	if subtitle, ok := u.SubtitleOk(); ok {
+		return subtitle
+	}
+	return "none"
 }
 
 func (u *UserBadge) Init(tue.Context) {

--- a/internal/compiler/gogen/testdata/components/UserBadge.tue
+++ b/internal/compiler/gogen/testdata/components/UserBadge.tue
@@ -11,17 +11,29 @@ type UserBadge struct {
 	tue.Comp[struct {
 		Name     string            `prop:",required"`
 		Active   bool              `prop:"active"`
-		Label    string            `prop:""`
+		Subtitle string            `prop:""`
 		Expanded bool              `state:""`
+		InitialLabel string        `state:""`
+		Label    string            `computed:"label"`
 		Select   func(string)      `event:""`
 		Range    func(string, int) `event:""`
 		Tags     func([]string)    `event:""`
 		Dismiss  func(string)      `event:""`
 	}]
+	labelCalls int
+}
+
+func (u *UserBadge) label() string {
+	u.labelCalls++
+	if u.Expanded() {
+		return u.Name() + " expanded"
+	}
+	return u.Name()
 }
 
 func (u *UserBadge) Init(tue.Context) {
 	u.ExpandedSet(true)
+	u.InitialLabelSet(u.Label())
 }
 
 func (u *UserBadge) choose() {
@@ -29,7 +41,7 @@ func (u *UserBadge) choose() {
 	u.Select(u.Name())
 	u.Range(u.Name(), 1)
 	u.Tags([]string{"featured", "active"})
-	if _, ok := u.LabelOk(); !ok {
+	if _, ok := u.SubtitleOk(); !ok {
 		u.Dismiss("dismissed")
 	}
 }

--- a/internal/compiler/gogen/testdata/golden/App_component_tue.go
+++ b/internal/compiler/gogen/testdata/golden/App_component_tue.go
@@ -5,15 +5,23 @@ package app
 import "github.com/norunners/tue"
 
 type tueAppData struct {
-	__propName   func() (string, bool)
-	__stateCount tue.State[int]
+	__propName     func() (string, bool)
+	__inputVersion tue.State[int]
+	__stateCount   tue.State[int]
 }
 
 func newTueAppData() tueAppData {
-	return tueAppData{__stateCount: tue.StateOf(*new(int))}
+	return tueAppData{__inputVersion: tue.StateOf(0), __stateCount: tue.StateOf(*new(int))}
 }
 func (component *App) NameOk() (string, bool) {
-	if component == nil || component.__tue.__propName == nil {
+	if component == nil {
+		var zero string
+		return zero, false
+	}
+	if component.__tue.__inputVersion != nil {
+		_ = component.__tue.__inputVersion.Get()
+	}
+	if component.__tue.__propName == nil {
 		var zero string
 		return zero, false
 	}

--- a/internal/compiler/gogen/testdata/golden/Loop_render_tue.go
+++ b/internal/compiler/gogen/testdata/golden/Loop_render_tue.go
@@ -76,6 +76,9 @@ func renderApp(component *App) tue.VNode {
 						return true, true
 					}
 					child.__tue.__eventSelect = component.selectUser
+					if child.__tue.__inputVersion != nil {
+						child.__tue.__inputVersion.Set(child.__tue.__inputVersion.Get() + 1)
+					}
 					childComp.DefaultSlot = nil
 				})
 				__tueVNode.Key = fmt.Sprint(__tueItem.ID)

--- a/internal/compiler/gogen/testdata/golden/Parent_render_tue.go
+++ b/internal/compiler/gogen/testdata/golden/Parent_render_tue.go
@@ -20,12 +20,14 @@ func renderParent(component *Parent) tue.VNode {
 				child.__tue.__propActive = func() (bool, bool) {
 					return true, true
 				}
-				child.__tue.__propLabel = nil
+				child.__tue.__propSubtitle = nil
 				child.__tue.__eventSelect = component.selectUser
 				child.__tue.__eventRange = component.selectRange
 				child.__tue.__eventTags = component.selectTags
 				child.__tue.__eventDismiss = nil
-				childComp := tue.CompOf(child, renderUserBadge)
+				childComp := tue.CompOf(child, renderUserBadge, func() {
+					child.__tue.__computedLabel = tue.ComputedOfFunc(child.label)
+				})
 				return childComp
 			}, func(childComp *tue.CompInstance) {
 				child := childComp.Component.(*UserBadge)
@@ -35,7 +37,7 @@ func renderParent(component *Parent) tue.VNode {
 				child.__tue.__propActive = func() (bool, bool) {
 					return true, true
 				}
-				child.__tue.__propLabel = nil
+				child.__tue.__propSubtitle = nil
 				child.__tue.__eventSelect = component.selectUser
 				child.__tue.__eventRange = component.selectRange
 				child.__tue.__eventTags = component.selectTags

--- a/internal/compiler/gogen/testdata/golden/Parent_render_tue.go
+++ b/internal/compiler/gogen/testdata/golden/Parent_render_tue.go
@@ -11,6 +11,48 @@ func NewParent() *tue.CompInstance {
 
 func renderParent(component *Parent) tue.VNode {
 	return tue.Element("main", nil, []tue.VNode{func() tue.VNode {
+		if component.ShowBadge() && component.UseAlternate() {
+			return tue.ComponentWithUpdate("UserBadge", func() *tue.CompInstance {
+				child := &UserBadge{__tue: newTueUserBadgeData()}
+				child.__tue.__propName = func() (string, bool) {
+					return component.AlternateName(), true
+				}
+				child.__tue.__propActive = func() (bool, bool) {
+					return true, true
+				}
+				child.__tue.__propSubtitle = func() (string, bool) {
+					return "alternate", true
+				}
+				child.__tue.__eventSelect = component.selectUser
+				child.__tue.__eventRange = component.selectRange
+				child.__tue.__eventTags = component.selectTags
+				child.__tue.__eventDismiss = nil
+				childComp := tue.CompOf(child, renderUserBadge, func() {
+					child.__tue.__computedLabel = tue.ComputedOfFunc(child.label)
+					child.__tue.__computedSubtitleLabel = tue.ComputedOfFunc(child.subtitleLabel)
+				})
+				return childComp
+			}, func(childComp *tue.CompInstance) {
+				child := childComp.Component.(*UserBadge)
+				child.__tue.__propName = func() (string, bool) {
+					return component.AlternateName(), true
+				}
+				child.__tue.__propActive = func() (bool, bool) {
+					return true, true
+				}
+				child.__tue.__propSubtitle = func() (string, bool) {
+					return "alternate", true
+				}
+				child.__tue.__eventSelect = component.selectUser
+				child.__tue.__eventRange = component.selectRange
+				child.__tue.__eventTags = component.selectTags
+				child.__tue.__eventDismiss = nil
+				if child.__tue.__inputVersion != nil {
+					child.__tue.__inputVersion.Set(child.__tue.__inputVersion.Get() + 1)
+				}
+				childComp.DefaultSlot = nil
+			})
+		}
 		if component.ShowBadge() {
 			return tue.ComponentWithUpdate("UserBadge", func() *tue.CompInstance {
 				child := &UserBadge{__tue: newTueUserBadgeData()}
@@ -27,6 +69,7 @@ func renderParent(component *Parent) tue.VNode {
 				child.__tue.__eventDismiss = nil
 				childComp := tue.CompOf(child, renderUserBadge, func() {
 					child.__tue.__computedLabel = tue.ComputedOfFunc(child.label)
+					child.__tue.__computedSubtitleLabel = tue.ComputedOfFunc(child.subtitleLabel)
 				})
 				return childComp
 			}, func(childComp *tue.CompInstance) {
@@ -42,6 +85,9 @@ func renderParent(component *Parent) tue.VNode {
 				child.__tue.__eventRange = component.selectRange
 				child.__tue.__eventTags = component.selectTags
 				child.__tue.__eventDismiss = nil
+				if child.__tue.__inputVersion != nil {
+					child.__tue.__inputVersion.Set(child.__tue.__inputVersion.Get() + 1)
+				}
 				childComp.DefaultSlot = nil
 			})
 		}

--- a/internal/compiler/gogen/testdata/golden/SlotApp_render_tue.go
+++ b/internal/compiler/gogen/testdata/golden/SlotApp_render_tue.go
@@ -33,6 +33,9 @@ func renderApp(component *App) tue.VNode {
 		child.__tue.__propTitle = func() (string, bool) {
 			return "Status", true
 		}
+		if child.__tue.__inputVersion != nil {
+			child.__tue.__inputVersion.Set(child.__tue.__inputVersion.Get() + 1)
+		}
 		childComp.DefaultSlot = func() tue.VNode {
 			return tue.Fragment([]tue.VNode{tue.Element("p", []tue.Attribute{tue.Attr("class", "body")}, []tue.VNode{tue.Text(fmt.Sprint(component.message))}), func() tue.VNode {
 				if component.ready {
@@ -52,6 +55,9 @@ func renderApp(component *App) tue.VNode {
 		child := childComp.Component.(*Card)
 		child.__tue.__propTitle = func() (string, bool) {
 			return "Empty", true
+		}
+		if child.__tue.__inputVersion != nil {
+			child.__tue.__inputVersion.Set(child.__tue.__inputVersion.Get() + 1)
 		}
 		childComp.DefaultSlot = nil
 	})})

--- a/internal/compiler/gogen/testdata/golden/UserBadge_component_tue.go
+++ b/internal/compiler/gogen/testdata/golden/UserBadge_component_tue.go
@@ -5,18 +5,20 @@ package fixtures
 import "github.com/norunners/tue"
 
 type tueUserBadgeData struct {
-	__propName      func() (string, bool)
-	__propActive    func() (bool, bool)
-	__propLabel     func() (string, bool)
-	__eventSelect   func(value string)
-	__eventRange    func(value1 string, value2 int)
-	__eventTags     func(value []string)
-	__eventDismiss  func(value string)
-	__stateExpanded tue.State[bool]
+	__propName          func() (string, bool)
+	__propActive        func() (bool, bool)
+	__propSubtitle      func() (string, bool)
+	__eventSelect       func(value string)
+	__eventRange        func(value1 string, value2 int)
+	__eventTags         func(value []string)
+	__eventDismiss      func(value string)
+	__stateExpanded     tue.State[bool]
+	__stateInitialLabel tue.State[string]
+	__computedLabel     tue.Computed[string]
 }
 
 func newTueUserBadgeData() tueUserBadgeData {
-	return tueUserBadgeData{__stateExpanded: tue.StateOf(*new(bool))}
+	return tueUserBadgeData{__stateExpanded: tue.StateOf(*new(bool)), __stateInitialLabel: tue.StateOf(*new(string))}
 }
 func (component *UserBadge) NameOk() (string, bool) {
 	if component == nil || component.__tue.__propName == nil {
@@ -48,19 +50,19 @@ func (component *UserBadge) Active() bool {
 	value, _ := component.ActiveOk()
 	return value
 }
-func (component *UserBadge) LabelOk() (string, bool) {
-	if component == nil || component.__tue.__propLabel == nil {
+func (component *UserBadge) SubtitleOk() (string, bool) {
+	if component == nil || component.__tue.__propSubtitle == nil {
 		var zero string
 		return zero, false
 	}
-	value, ok := component.__tue.__propLabel()
+	value, ok := component.__tue.__propSubtitle()
 	if ok {
 		return value, true
 	}
 	return value, false
 }
-func (component *UserBadge) Label() string {
-	value, _ := component.LabelOk()
+func (component *UserBadge) Subtitle() string {
+	value, _ := component.SubtitleOk()
 	return value
 }
 func (component *UserBadge) Select(value string) bool {
@@ -103,4 +105,24 @@ func (component *UserBadge) ExpandedSet(value bool) {
 		return
 	}
 	component.__tue.__stateExpanded.Set(value)
+}
+func (component *UserBadge) InitialLabel() string {
+	if component == nil || component.__tue.__stateInitialLabel == nil {
+		var zero string
+		return zero
+	}
+	return component.__tue.__stateInitialLabel.Get()
+}
+func (component *UserBadge) InitialLabelSet(value string) {
+	if component == nil || component.__tue.__stateInitialLabel == nil {
+		return
+	}
+	component.__tue.__stateInitialLabel.Set(value)
+}
+func (component *UserBadge) Label() string {
+	if component == nil || component.__tue.__computedLabel == nil {
+		var zero string
+		return zero
+	}
+	return component.__tue.__computedLabel.Get()
 }

--- a/internal/compiler/gogen/testdata/golden/UserBadge_component_tue.go
+++ b/internal/compiler/gogen/testdata/golden/UserBadge_component_tue.go
@@ -5,23 +5,32 @@ package fixtures
 import "github.com/norunners/tue"
 
 type tueUserBadgeData struct {
-	__propName          func() (string, bool)
-	__propActive        func() (bool, bool)
-	__propSubtitle      func() (string, bool)
-	__eventSelect       func(value string)
-	__eventRange        func(value1 string, value2 int)
-	__eventTags         func(value []string)
-	__eventDismiss      func(value string)
-	__stateExpanded     tue.State[bool]
-	__stateInitialLabel tue.State[string]
-	__computedLabel     tue.Computed[string]
+	__propName              func() (string, bool)
+	__propActive            func() (bool, bool)
+	__propSubtitle          func() (string, bool)
+	__inputVersion          tue.State[int]
+	__eventSelect           func(value string)
+	__eventRange            func(value1 string, value2 int)
+	__eventTags             func(value []string)
+	__eventDismiss          func(value string)
+	__stateExpanded         tue.State[bool]
+	__stateInitialLabel     tue.State[string]
+	__computedLabel         tue.Computed[string]
+	__computedSubtitleLabel tue.Computed[string]
 }
 
 func newTueUserBadgeData() tueUserBadgeData {
-	return tueUserBadgeData{__stateExpanded: tue.StateOf(*new(bool)), __stateInitialLabel: tue.StateOf(*new(string))}
+	return tueUserBadgeData{__inputVersion: tue.StateOf(0), __stateExpanded: tue.StateOf(*new(bool)), __stateInitialLabel: tue.StateOf(*new(string))}
 }
 func (component *UserBadge) NameOk() (string, bool) {
-	if component == nil || component.__tue.__propName == nil {
+	if component == nil {
+		var zero string
+		return zero, false
+	}
+	if component.__tue.__inputVersion != nil {
+		_ = component.__tue.__inputVersion.Get()
+	}
+	if component.__tue.__propName == nil {
 		var zero string
 		return zero, false
 	}
@@ -36,7 +45,14 @@ func (component *UserBadge) Name() string {
 	return value
 }
 func (component *UserBadge) ActiveOk() (bool, bool) {
-	if component == nil || component.__tue.__propActive == nil {
+	if component == nil {
+		var zero bool
+		return zero, false
+	}
+	if component.__tue.__inputVersion != nil {
+		_ = component.__tue.__inputVersion.Get()
+	}
+	if component.__tue.__propActive == nil {
 		var zero bool
 		return zero, false
 	}
@@ -51,7 +67,14 @@ func (component *UserBadge) Active() bool {
 	return value
 }
 func (component *UserBadge) SubtitleOk() (string, bool) {
-	if component == nil || component.__tue.__propSubtitle == nil {
+	if component == nil {
+		var zero string
+		return zero, false
+	}
+	if component.__tue.__inputVersion != nil {
+		_ = component.__tue.__inputVersion.Get()
+	}
+	if component.__tue.__propSubtitle == nil {
 		var zero string
 		return zero, false
 	}
@@ -125,4 +148,11 @@ func (component *UserBadge) Label() string {
 		return zero
 	}
 	return component.__tue.__computedLabel.Get()
+}
+func (component *UserBadge) SubtitleLabel() string {
+	if component == nil || component.__tue.__computedSubtitleLabel == nil {
+		var zero string
+		return zero
+	}
+	return component.__tue.__computedSubtitleLabel.Get()
 }

--- a/internal/compiler/script/component.go
+++ b/internal/compiler/script/component.go
@@ -41,8 +41,8 @@ type Component struct {
 	Props         []Prop
 	Events        []Event
 	States        []State
+	Computed      []Computed
 	LocalFields   []Field
-	Computed      []Field
 	Resources     []Field
 	Methods       []Method
 	Init          *Method
@@ -83,6 +83,17 @@ type State struct {
 	Span     sfc.Span
 	NameSpan sfc.Span
 	TypeSpan sfc.Span
+}
+
+// Computed is a generated read-only reactive value declared by a Comp marker.
+type Computed struct {
+	Name       string
+	GoName     string
+	MethodName string
+	Type       string
+	Span       sfc.Span
+	NameSpan   sfc.Span
+	TypeSpan   sfc.Span
 }
 
 // FunctionType returns the Go callback type represented by the event.

--- a/internal/compiler/script/component_parse.go
+++ b/internal/compiler/script/component_parse.go
@@ -405,6 +405,11 @@ func PropFieldName(name string) string {
 	return "__prop" + exportedIdentifier(name)
 }
 
+// InputVersionFieldName returns the hidden generated prop binding version field.
+func InputVersionFieldName() string {
+	return "__inputVersion"
+}
+
 // EventFieldName returns the hidden generated event callback field.
 func EventFieldName(name string) string {
 	return "__event" + exportedIdentifier(name)

--- a/internal/compiler/script/component_parse.go
+++ b/internal/compiler/script/component_parse.go
@@ -92,6 +92,8 @@ func (e *extractor) extractComponentField(field *ast.Field, names map[string]boo
 		e.extractComponentEvent(field, fieldName, value, names)
 	case "state":
 		e.extractComponentState(field, fieldName, value, names)
+	case "computed":
+		e.extractComponentComputed(field, fieldName, value, names)
 	}
 }
 
@@ -198,9 +200,45 @@ func (e *extractor) extractComponentState(field *ast.Field, fieldName *ast.Ident
 	})
 }
 
+func (e *extractor) extractComponentComputed(field *ast.Field, fieldName *ast.Ident, value string, names map[string]bool) {
+	name := lowerIdentifier(fieldName.Name)
+	if names[name] {
+		e.addDiagnostic(fmt.Sprintf("duplicate component declaration name %q", name), e.nodeSpan(fieldName))
+		return
+	}
+	if value == "" {
+		e.addDiagnostic(fmt.Sprintf("component computed %q must name its source method", name), componentTagSpan(e, field))
+		return
+	}
+	if !token.IsIdentifier(value) {
+		e.addDiagnostic(fmt.Sprintf("component computed %q has invalid source method %q", name, value), componentTagSpan(e, field))
+		return
+	}
+	if _, ok := field.Type.(*ast.FuncType); ok {
+		e.addDiagnostic(fmt.Sprintf("component computed %q must not have a function type", name), e.nodeSpan(field.Type))
+		return
+	}
+	typeName, ok := formatNode(e.fset, field.Type)
+	if !ok {
+		e.addDiagnostic(fmt.Sprintf("component computed %q has an unsupported Go type", name), e.nodeSpan(field.Type))
+		return
+	}
+
+	names[name] = true
+	e.computeds = append(e.computeds, Computed{
+		Name:       name,
+		GoName:     fieldName.Name,
+		MethodName: value,
+		Type:       typeName,
+		Span:       e.nodeSpan(field),
+		NameSpan:   e.nodeSpan(fieldName),
+		TypeSpan:   e.nodeSpan(field.Type),
+	})
+}
+
 func componentFieldCategory(field *ast.Field) (string, string, error) {
 	if field.Tag == nil {
-		return "", "", fmt.Errorf("must declare exactly one prop, event, or state tag")
+		return "", "", fmt.Errorf("must declare exactly one prop, event, state, or computed tag")
 	}
 	raw, err := strconv.Unquote(field.Tag.Value)
 	if err != nil {
@@ -211,9 +249,9 @@ func componentFieldCategory(field *ast.Field) (string, string, error) {
 		return "", "", err
 	}
 	if len(tags) != 1 {
-		return "", "", fmt.Errorf("must declare exactly one prop, event, or state tag")
+		return "", "", fmt.Errorf("must declare exactly one prop, event, state, or computed tag")
 	}
-	for _, key := range []string{"prop", "event", "state"} {
+	for _, key := range []string{"prop", "event", "state", "computed"} {
 		if value, ok := tags[key]; ok {
 			return key, value, nil
 		}
@@ -221,7 +259,7 @@ func componentFieldCategory(field *ast.Field) (string, string, error) {
 	for key := range tags {
 		return "", "", fmt.Errorf("unknown component tag %q", key)
 	}
-	return "", "", fmt.Errorf("must declare exactly one prop, event, or state tag")
+	return "", "", fmt.Errorf("must declare exactly one prop, event, state, or computed tag")
 }
 
 func parseStructTags(raw string) (map[string]string, error) {
@@ -385,6 +423,16 @@ func StateSetterName(name string) string {
 // StateFieldName returns the hidden generated reactive state field.
 func StateFieldName(name string) string {
 	return "__state" + exportedIdentifier(name)
+}
+
+// ComputedGetterName returns the generated computed getter.
+func ComputedGetterName(name string) string {
+	return exportedIdentifier(name)
+}
+
+// ComputedFieldName returns the hidden generated computed field.
+func ComputedFieldName(name string) string {
+	return "__computed" + exportedIdentifier(name)
 }
 
 func lowerIdentifier(name string) string {

--- a/internal/compiler/script/enum.go
+++ b/internal/compiler/script/enum.go
@@ -5,6 +5,5 @@ type FieldKind string
 
 const (
 	FieldKindLocal    FieldKind = "local"
-	FieldKindComputed FieldKind = "computed"
 	FieldKindResource FieldKind = "resource"
 )

--- a/internal/compiler/script/parse.go
+++ b/internal/compiler/script/parse.go
@@ -92,6 +92,7 @@ type extractor struct {
 	props       []Prop
 	events      []Event
 	states      []State
+	computeds   []Computed
 	diagnostics []Diagnostic
 }
 
@@ -239,6 +240,8 @@ func (e *extractor) typeCheck(file *ast.File, componentName string) (*types.Pack
 				diagnostic.Span = e.events[0].Span
 			} else if len(e.states) != 0 {
 				diagnostic.Span = e.states[0].Span
+			} else if len(e.computeds) != 0 {
+				diagnostic.Span = e.computeds[0].Span
 			}
 			diagnostics = append(diagnostics, diagnostic)
 		},
@@ -296,6 +299,13 @@ func (e *extractor) generatedMethodDeclarations(file *ast.File, componentName st
 		if !declared[setter] {
 			fmt.Fprintf(&source, "func (*%s) %s(value %s) { panic(\"generated\") }\n", componentName, setter, state.Type)
 			declared[setter] = true
+		}
+	}
+	for _, computed := range e.computeds {
+		getter := ComputedGetterName(computed.GoName)
+		if !declared[getter] {
+			fmt.Fprintf(&source, "func (*%s) %s() %s { panic(\"generated\") }\n", componentName, getter, computed.Type)
+			declared[getter] = true
 		}
 	}
 
@@ -404,6 +414,7 @@ func (e *extractor) extractComponent(file *File, astFile *ast.File, componentNam
 		Props:    append([]Prop(nil), e.props...),
 		Events:   append([]Event(nil), e.events...),
 		States:   append([]State(nil), e.states...),
+		Computed: append([]Computed(nil), e.computeds...),
 	}
 	if e.hasComp {
 		component.GeneratedType = GeneratedTypeName(componentName)
@@ -489,8 +500,6 @@ func (e *extractor) extractFields(component *Component, structType *ast.StructTy
 		for _, name := range astField.Names {
 			field := e.fieldFromAST(name, astField)
 			switch field.Kind {
-			case FieldKindComputed:
-				component.Computed = append(component.Computed, field)
 			case FieldKindResource:
 				component.Resources = append(component.Resources, field)
 			default:
@@ -533,6 +542,13 @@ func (e *extractor) classifyField(fieldName string, expr ast.Expr) (FieldKind, s
 	if typeName == "State" {
 		e.addDiagnostic(
 			fmt.Sprintf("component state %q must be declared inside embedded tue.Comp", fieldName),
+			e.nodeSpan(expr),
+		)
+		return FieldKindLocal, ""
+	}
+	if typeName == "Computed" {
+		e.addDiagnostic(
+			fmt.Sprintf("component computed %q must be declared inside embedded tue.Comp", fieldName),
 			e.nodeSpan(expr),
 		)
 		return FieldKindLocal, ""
@@ -591,8 +607,6 @@ func (e *extractor) tueTypeName(expr ast.Expr) (string, bool) {
 
 func fieldKindForTueType(name string) (FieldKind, bool) {
 	switch name {
-	case "Computed":
-		return FieldKindComputed, true
 	case "Resource":
 		return FieldKindResource, true
 	default:
@@ -646,6 +660,7 @@ func (e *extractor) validateGeneratedMembers(component *Component) {
 		return
 	}
 
+	authoredMethods := append([]Method(nil), component.Methods...)
 	declared := make(map[string]sfc.Span)
 	if component.Init != nil {
 		declared[component.Init.Name] = component.Init.NameSpan
@@ -653,7 +668,7 @@ func (e *extractor) validateGeneratedMembers(component *Component) {
 	for _, method := range component.Methods {
 		declared[method.Name] = method.NameSpan
 	}
-	for _, fields := range [][]Field{component.LocalFields, component.Computed, component.Resources} {
+	for _, fields := range [][]Field{component.LocalFields, component.Resources} {
 		for _, field := range fields {
 			declared[field.Name] = field.NameSpan
 		}
@@ -747,6 +762,50 @@ func (e *extractor) validateGeneratedMembers(component *Component) {
 			NameSpan:        state.NameSpan,
 		})
 	}
+	e.validateGeneratedComputedMembers(component, declared, authoredMethods)
+}
+
+func (e *extractor) validateGeneratedComputedMembers(component *Component, declared map[string]sfc.Span, authoredMethods []Method) {
+	for _, computed := range component.Computed {
+		getter := ComputedGetterName(computed.GoName)
+		if _, exists := declared[getter]; exists {
+			e.addDiagnostic(fmt.Sprintf("generated computed getter %s conflicts with a component member", getter), computed.NameSpan)
+			continue
+		}
+
+		method, ok := authoredMethod(authoredMethods, computed.MethodName)
+		if !ok {
+			e.addDiagnostic(fmt.Sprintf("component computed %q source method %s was not found", computed.Name, computed.MethodName), computed.NameSpan)
+			continue
+		}
+		if len(method.Parameters) != 0 || len(method.Results) != 1 || strings.TrimSpace(method.Results[0].Type) != strings.TrimSpace(computed.Type) {
+			e.addDiagnostic(
+				fmt.Sprintf("component computed %q source method %s must have signature func() %s", computed.Name, computed.MethodName, computed.Type),
+				method.NameSpan,
+			)
+			continue
+		}
+
+		declared[getter] = computed.NameSpan
+		component.Methods = append(component.Methods, Method{
+			Name:            getter,
+			ReceiverName:    component.Name,
+			PointerReceiver: true,
+			ImplicitGetter:  true,
+			Results:         []Parameter{{Type: computed.Type, Span: computed.TypeSpan, TypeSpan: computed.TypeSpan}},
+			Span:            computed.Span,
+			NameSpan:        computed.NameSpan,
+		})
+	}
+}
+
+func authoredMethod(methods []Method, name string) (*Method, bool) {
+	for index := range methods {
+		if methods[index].Name == name {
+			return &methods[index], true
+		}
+	}
+	return nil, false
 }
 
 func (e *extractor) receiver(function *ast.FuncDecl) (string, bool, *sfc.Span, bool) {

--- a/internal/compiler/script/parse_test.go
+++ b/internal/compiler/script/parse_test.go
@@ -50,7 +50,6 @@ func TestParseExtractsComponentDeclaration(t *testing.T) {
 	if diff := cmp.Diff([]structSummary{
 		{Name: "User", Fields: []fieldSummary{}},
 		{Name: "Dashboard", Fields: []fieldSummary{
-			{Kind: FieldKindLocal, Name: "total", Type: "tue.Computed[int]"},
 			{Kind: FieldKindLocal, Name: "user", Type: "tue.Resource[User]"},
 		}},
 	}, summarizeStructs(file.Structs)); diff != "" {
@@ -90,13 +89,18 @@ func TestParseExtractsComponentDeclaration(t *testing.T) {
 	expectedStates := []stateSummary{
 		{Name: "expanded", GoName: "Expanded", Type: "bool"},
 		{Name: "count", GoName: "Count", Type: "int"},
-		{Name: "label", GoName: "Label", Type: "string"},
 	}
 	if diff := cmp.Diff(expectedStates, summarizeStates(component.States)); diff != "" {
 		t.Errorf("mismatch component states (-expected, +actual):\n%s", diff)
 	}
 
-	assertField(t, component.Computed, "total", FieldKindComputed, "tue.Computed[int]", "int")
+	expectedComputeds := []computedSummary{
+		{Name: "label", GoName: "Label", MethodName: "label", Type: "string"},
+		{Name: "total", GoName: "Total", MethodName: "total", Type: "int"},
+	}
+	if diff := cmp.Diff(expectedComputeds, summarizeComputeds(component.Computed)); diff != "" {
+		t.Errorf("mismatch component computeds (-expected, +actual):\n%s", diff)
+	}
 	assertField(t, component.Resources, "user", FieldKindResource, "tue.Resource[User]", "User")
 
 	init, err := requireInit(component)
@@ -128,6 +132,18 @@ func TestParseExtractsComponentDeclaration(t *testing.T) {
 			Results: []parameterSummary{{
 				Type: "string",
 			}},
+		},
+		{
+			Name:            "label",
+			ReceiverName:    "Dashboard",
+			PointerReceiver: true,
+			Results:         []parameterSummary{{Type: "string"}},
+		},
+		{
+			Name:            "total",
+			ReceiverName:    "Dashboard",
+			PointerReceiver: true,
+			Results:         []parameterSummary{{Type: "int"}},
 		},
 		{
 			Name:            "Name",
@@ -242,10 +258,10 @@ func TestParseExtractsComponentDeclaration(t *testing.T) {
 			Results:         []parameterSummary{{Type: "string"}},
 		},
 		{
-			Name:            "LabelSet",
+			Name:            "Total",
 			ReceiverName:    "Dashboard",
 			PointerReceiver: true,
-			Parameters:      []parameterSummary{{Name: "value", Type: "string"}},
+			Results:         []parameterSummary{{Type: "int"}},
 		},
 	}, summarizeMethods(component.Methods)); diff != "" {
 		t.Errorf("mismatch methods (-expected, +actual):\n%s", diff)
@@ -429,7 +445,7 @@ func TestParseSFCComponentDeclarationDiagnostics(t *testing.T) {
 		{
 			name:     "invalid field",
 			fixture:  "component_invalid_field.tue",
-			expected: []string{`component declaration field "Name": must declare exactly one prop, event, or state tag`},
+			expected: []string{`component declaration field "Name": must declare exactly one prop, event, state, or computed tag`},
 		},
 		{
 			name:     "unknown tag",
@@ -489,7 +505,7 @@ func TestParseSFCComponentDeclarationDiagnostics(t *testing.T) {
 		{
 			name:     "mixed tags",
 			fixture:  "component_mixed_tags.tue",
-			expected: []string{`component declaration field "Name": must declare exactly one prop, event, or state tag`},
+			expected: []string{`component declaration field "Name": must declare exactly one prop, event, state, or computed tag`},
 		},
 		{
 			name:     "named marker",
@@ -525,6 +541,51 @@ func TestParseSFCComponentDeclarationDiagnostics(t *testing.T) {
 			name:     "state outside marker",
 			fixture:  "component_external_state.tue",
 			expected: []string{`component state "Count" must be declared inside embedded tue.Comp`},
+		},
+		{
+			name:     "computed source is required",
+			fixture:  "component_computed_empty_source.tue",
+			expected: []string{`component computed "label" must name its source method`},
+		},
+		{
+			name:     "computed source is an identifier",
+			fixture:  "component_computed_invalid_source.tue",
+			expected: []string{`component computed "label" has invalid source method "label-value"`},
+		},
+		{
+			name:     "computed source exists",
+			fixture:  "component_computed_missing_method.tue",
+			expected: []string{`component computed "label" source method label was not found`},
+		},
+		{
+			name:     "computed source has no parameters",
+			fixture:  "component_computed_signature.tue",
+			expected: []string{`component computed "label" source method label must have signature func() string`},
+		},
+		{
+			name:     "computed source result matches",
+			fixture:  "component_computed_result.tue",
+			expected: []string{`component computed "label" source method label must have signature func() string`},
+		},
+		{
+			name:     "computed source returns one value",
+			fixture:  "component_computed_no_result.tue",
+			expected: []string{`component computed "label" source method label must have signature func() string`},
+		},
+		{
+			name:     "computed getter collision",
+			fixture:  "component_computed_collision.tue",
+			expected: []string{`generated computed getter Label conflicts with a component member`},
+		},
+		{
+			name:     "computed value is not a function",
+			fixture:  "component_computed_function.tue",
+			expected: []string{`component computed "format" must not have a function type`},
+		},
+		{
+			name:     "computed outside marker",
+			fixture:  "component_external_computed.tue",
+			expected: []string{`component computed "Label" must be declared inside embedded tue.Comp`},
 		},
 	}
 
@@ -734,6 +795,13 @@ type stateSummary struct {
 	Type   string
 }
 
+type computedSummary struct {
+	Name       string
+	GoName     string
+	MethodName string
+	Type       string
+}
+
 type fieldSummary struct {
 	Kind      FieldKind
 	Name      string
@@ -805,6 +873,19 @@ func summarizeStates(states []State) []stateSummary {
 	summaries := make([]stateSummary, len(states))
 	for index, state := range states {
 		summaries[index] = stateSummary{Name: state.Name, GoName: state.GoName, Type: state.Type}
+	}
+	return summaries
+}
+
+func summarizeComputeds(computeds []Computed) []computedSummary {
+	summaries := make([]computedSummary, len(computeds))
+	for index, computed := range computeds {
+		summaries[index] = computedSummary{
+			Name:       computed.Name,
+			GoName:     computed.GoName,
+			MethodName: computed.MethodName,
+			Type:       computed.Type,
+		}
 	}
 	return summaries
 }

--- a/internal/compiler/script/testdata/components/dashboard.go
+++ b/internal/compiler/script/testdata/components/dashboard.go
@@ -6,20 +6,20 @@ type User struct{}
 
 type Dashboard struct {
 	tue.Comp[struct {
-		Name      string              `prop:",required"`
-		Active    bool                `prop:"active"`
-		UserID    string              `prop:"user-id"`
-		Expanded  bool                `state:""`
-		Count     int                 `state:""`
-		Label     string              `state:""`
-		Close     func()              `event:""`
-		Select    func(name string)   `event:""`
-		Range     func(name string, count int) `event:""`
-		Pointer   func(*User)         `event:""`
-		Variadic  func(values ...string) `event:""`
+		Name     string                       `prop:",required"`
+		Active   bool                         `prop:"active"`
+		UserID   string                       `prop:"user-id"`
+		Expanded bool                         `state:""`
+		Count    int                          `state:""`
+		Label    string                       `computed:"label"`
+		Total    int                          `computed:"total"`
+		Close    func()                       `event:""`
+		Select   func(name string)            `event:""`
+		Range    func(name string, count int) `event:""`
+		Pointer  func(*User)                  `event:""`
+		Variadic func(values ...string)       `event:""`
 	}]
-	total tue.Computed[int]
-	user  tue.Resource[User]
+	user tue.Resource[User]
 }
 
 func (d *Dashboard) Init(ctx tue.Context) {}
@@ -27,3 +27,7 @@ func (d *Dashboard) Init(ctx tue.Context) {}
 func (d *Dashboard) increment() {}
 
 func (d Dashboard) snapshot() string { return "" }
+
+func (d *Dashboard) label() string { return d.Name() }
+
+func (d *Dashboard) total() int { return d.Count() }

--- a/internal/compiler/script/testdata/sfc/component_computed_collision.tue
+++ b/internal/compiler/script/testdata/sfc/component_computed_collision.tue
@@ -1,0 +1,21 @@
+<template></template>
+
+<script lang="go">
+package fixtures
+
+import tue "github.com/norunners/tue"
+
+type ComponentComputedCollision struct {
+	tue.Comp[struct {
+		Label string `computed:"label"`
+	}]
+}
+
+func (c *ComponentComputedCollision) label() string {
+	return "label"
+}
+
+func (c *ComponentComputedCollision) Label() string {
+	return "collision"
+}
+</script>

--- a/internal/compiler/script/testdata/sfc/component_computed_empty_source.tue
+++ b/internal/compiler/script/testdata/sfc/component_computed_empty_source.tue
@@ -1,0 +1,13 @@
+<template></template>
+
+<script lang="go">
+package fixtures
+
+import tue "github.com/norunners/tue"
+
+type ComponentComputedEmptySource struct {
+	tue.Comp[struct {
+		Label string `computed:""`
+	}]
+}
+</script>

--- a/internal/compiler/script/testdata/sfc/component_computed_function.tue
+++ b/internal/compiler/script/testdata/sfc/component_computed_function.tue
@@ -1,0 +1,13 @@
+<template></template>
+
+<script lang="go">
+package fixtures
+
+import tue "github.com/norunners/tue"
+
+type ComponentComputedFunction struct {
+	tue.Comp[struct {
+		Format func(string) string `computed:"format"`
+	}]
+}
+</script>

--- a/internal/compiler/script/testdata/sfc/component_computed_invalid_source.tue
+++ b/internal/compiler/script/testdata/sfc/component_computed_invalid_source.tue
@@ -1,0 +1,13 @@
+<template></template>
+
+<script lang="go">
+package fixtures
+
+import tue "github.com/norunners/tue"
+
+type ComponentComputedInvalidSource struct {
+	tue.Comp[struct {
+		Label string `computed:"label-value"`
+	}]
+}
+</script>

--- a/internal/compiler/script/testdata/sfc/component_computed_missing_method.tue
+++ b/internal/compiler/script/testdata/sfc/component_computed_missing_method.tue
@@ -1,0 +1,13 @@
+<template></template>
+
+<script lang="go">
+package fixtures
+
+import tue "github.com/norunners/tue"
+
+type ComponentComputedMissingMethod struct {
+	tue.Comp[struct {
+		Label string `computed:"label"`
+	}]
+}
+</script>

--- a/internal/compiler/script/testdata/sfc/component_computed_no_result.tue
+++ b/internal/compiler/script/testdata/sfc/component_computed_no_result.tue
@@ -1,0 +1,15 @@
+<template></template>
+
+<script lang="go">
+package fixtures
+
+import tue "github.com/norunners/tue"
+
+type ComponentComputedNoResult struct {
+	tue.Comp[struct {
+		Label string `computed:"label"`
+	}]
+}
+
+func (c *ComponentComputedNoResult) label() {}
+</script>

--- a/internal/compiler/script/testdata/sfc/component_computed_result.tue
+++ b/internal/compiler/script/testdata/sfc/component_computed_result.tue
@@ -1,0 +1,17 @@
+<template></template>
+
+<script lang="go">
+package fixtures
+
+import tue "github.com/norunners/tue"
+
+type ComponentComputedResult struct {
+	tue.Comp[struct {
+		Label string `computed:"label"`
+	}]
+}
+
+func (c *ComponentComputedResult) label() bool {
+	return true
+}
+</script>

--- a/internal/compiler/script/testdata/sfc/component_computed_signature.tue
+++ b/internal/compiler/script/testdata/sfc/component_computed_signature.tue
@@ -1,0 +1,17 @@
+<template></template>
+
+<script lang="go">
+package fixtures
+
+import tue "github.com/norunners/tue"
+
+type ComponentComputedSignature struct {
+	tue.Comp[struct {
+		Label string `computed:"label"`
+	}]
+}
+
+func (c *ComponentComputedSignature) label(prefix string) string {
+	return prefix
+}
+</script>

--- a/internal/compiler/script/testdata/sfc/component_external_computed.tue
+++ b/internal/compiler/script/testdata/sfc/component_external_computed.tue
@@ -1,0 +1,11 @@
+<template></template>
+
+<script lang="go">
+package fixtures
+
+import tue "github.com/norunners/tue"
+
+type ComponentExternalComputed struct {
+	Label tue.Computed[string]
+}
+</script>

--- a/mounting.go
+++ b/mounting.go
@@ -122,6 +122,7 @@ func (e *componentRenderEffect) run() {
 	if e == nil || e.stopped || e.mounted == nil || e.mounted.unmounted {
 		return
 	}
+	e.queued = false
 
 	e.dispose()
 	var vnode VNode

--- a/patch.go
+++ b/patch.go
@@ -268,13 +268,17 @@ func patchComponentVNode(old *mountedVNode, next VNode) (*mountedVNode, error) {
 	if old.component == nil {
 		return nil, fmt.Errorf("mounted component %q is required", old.vnode.Tag)
 	}
-	if next.ComponentUpdater != nil {
-		next.ComponentUpdater(old.component.component)
-	}
-	old.component.scopeAttrs = next.scopeAttrs
-	old.vnode = next
-	if err := old.component.Update(); err != nil {
-		return nil, err
+	var updateErr error
+	Batch(func() {
+		if next.ComponentUpdater != nil {
+			next.ComponentUpdater(old.component.component)
+		}
+		old.component.scopeAttrs = next.scopeAttrs
+		old.vnode = next
+		updateErr = old.component.Update()
+	})
+	if updateErr != nil {
+		return nil, updateErr
 	}
 	old.nodes = mountedNodes(old.component.tree)
 	return old, nil

--- a/reactivity.go
+++ b/reactivity.go
@@ -47,7 +47,8 @@ func (r *StateValue[T]) Watch(effect func(T)) func() {
 	})
 }
 
-// Computed is the read interface exposed to component code.
+// Computed is the read interface used by generated computed accessors and
+// handwritten reactive code.
 type Computed[T any] interface {
 	Get() T
 	Watch(func(T)) func()

--- a/reactivity.go
+++ b/reactivity.go
@@ -222,6 +222,7 @@ func (w *watcher) run() {
 	if w == nil || w.stopped {
 		return
 	}
+	w.queued = false
 	w.dispose()
 	pushSubscriber(w)
 	defer popSubscriber()
@@ -356,6 +357,9 @@ func flushSubscribers() {
 		pending := scheduler.pending
 		scheduler.pending = nil
 		for _, subscriber := range pending {
+			if !subscriber.isQueued() {
+				continue
+			}
 			subscriber.setQueued(false)
 			subscriber.run()
 		}

--- a/reactivity_test.go
+++ b/reactivity_test.go
@@ -161,6 +161,33 @@ func TestComponentScopedEffectsStopBeforeUserCleanup(t *testing.T) {
 	}
 }
 
+func TestCompOfScopesGeneratedInitializerEffects(t *testing.T) {
+	state := StateOf(0)
+	values := []int{}
+	component := &struct{}{}
+	comp := CompOf(component, func(*struct{}) VNode {
+		return Text("initializer")
+	}, func() {
+		Watch(func() {
+			values = append(values, state.Get())
+		})
+	})
+
+	mounted, err := mountComponent(comp, newStubDOMTarget())
+	if err != nil {
+		t.Fatalf("mountComponent returned error: %v", err)
+	}
+	state.Set(1)
+	if err := mounted.Unmount(); err != nil {
+		t.Fatalf("Unmount returned error: %v", err)
+	}
+	state.Set(2)
+
+	if diff := cmp.Diff([]int{0, 1}, values); diff != "" {
+		t.Errorf("mismatch generated initializer effect values (-expected, +actual):\n%s", diff)
+	}
+}
+
 type reactiveCleanupFixture struct {
 	count  *StateValue[int]
 	events *[]string

--- a/runtime.go
+++ b/runtime.go
@@ -171,17 +171,26 @@ type unmountedComponent interface {
 	OnUnmounted()
 }
 
-// CompOf returns a component wrapper for generated code.
-func CompOf[C any](component *C, render func(*C) VNode) *CompInstance {
+// CompOf returns a component wrapper for generated code. Generated initializers
+// run in component scope before the optional user Init method.
+func CompOf[C any](component *C, render func(*C) VNode, initializers ...func()) *CompInstance {
 	comp := &CompInstance{Component: component}
 	if render != nil {
 		comp.Render = func() VNode {
 			return render(component)
 		}
 	}
-	if initializable, ok := any(component).(initComponent); ok {
+	initializable, hasInit := any(component).(initComponent)
+	if len(initializers) != 0 || hasInit {
 		withComponentScope(comp, func() {
-			initializable.Init(&contextValue{component: comp})
+			for _, initialize := range initializers {
+				if initialize != nil {
+					initialize()
+				}
+			}
+			if hasInit {
+				initializable.Init(&contextValue{component: comp})
+			}
 		})
 	}
 	return comp

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -95,6 +95,18 @@ func TestCompOfCallsOptionalInit(t *testing.T) {
 	}
 }
 
+func TestCompOfRunsGeneratedInitializersBeforeInit(t *testing.T) {
+	component := &generatedInitFixture{}
+
+	CompOf(component, nil, func() {
+		component.value = "generated"
+	})
+
+	if diff := cmp.Diff("generated", component.initializedWith); diff != "" {
+		t.Errorf("mismatch value observed by Init (-expected, +actual):\n%s", diff)
+	}
+}
+
 func TestMountComponentRunsLifecycleInOrder(t *testing.T) {
 	events := []string{}
 	component := &lifecycleFixture{events: &events, value: "first"}
@@ -668,6 +680,15 @@ func TestMountValidatesInputBeforePlatformBoundary(t *testing.T) {
 
 type initFixture struct {
 	value string
+}
+
+type generatedInitFixture struct {
+	value           string
+	initializedWith string
+}
+
+func (f *generatedInitFixture) Init(Context) {
+	f.initializedWith = f.value
 }
 
 func (f *initFixture) Init(Context) {

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -574,6 +574,52 @@ func TestMountedComponentVNodeRefreshesDefaultSlotOnPatch(t *testing.T) {
 	}
 }
 
+func TestMountedComponentVNodeBatchesUpdaterInvalidations(t *testing.T) {
+	label := "first"
+	renderCount := 0
+	target := newStubDOMTarget()
+	mounted, err := mountComponent(CompOf(&patchFixture{}, func(*patchFixture) VNode {
+		return ComponentWithUpdate("Child", func() *CompInstance {
+			child := &componentUpdaterInvalidationFixture{
+				label:       func() string { return label },
+				version:     StateOf(0),
+				renderCount: &renderCount,
+			}
+			return CompOf(child, func(child *componentUpdaterInvalidationFixture) VNode {
+				*child.renderCount++
+				_ = child.version.Get()
+				return Text(child.label())
+			})
+		}, func(childComp *CompInstance) {
+			child := childComp.Component.(*componentUpdaterInvalidationFixture)
+			child.label = func() string { return label }
+			child.version.Set(child.version.Get() + 1)
+		})
+	}), target)
+	if err != nil {
+		t.Fatalf("mountComponent returned error: %v", err)
+	}
+
+	if diff := cmp.Diff("first", target.html()); diff != "" {
+		t.Errorf("mismatch mounted component HTML (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff(1, renderCount); diff != "" {
+		t.Errorf("mismatch mounted child render count (-expected, +actual):\n%s", diff)
+	}
+
+	label = "second"
+	if err := mounted.Update(); err != nil {
+		t.Fatalf("Update returned error: %v", err)
+	}
+
+	if diff := cmp.Diff("second", target.html()); diff != "" {
+		t.Errorf("mismatch patched component HTML (-expected, +actual):\n%s", diff)
+	}
+	if diff := cmp.Diff(2, renderCount); diff != "" {
+		t.Errorf("mismatch patched child render count (-expected, +actual):\n%s", diff)
+	}
+}
+
 func TestMountedComponentVNodeRendersSlotFallback(t *testing.T) {
 	target := newStubDOMTarget()
 	_, err := mountComponent(CompOf(&patchFixture{}, func(*patchFixture) VNode {
@@ -763,6 +809,12 @@ func (f *componentVNodeFixture) OnUnmounted() {
 type componentSlotPatchFixture struct {
 	label     func() string
 	initCount *int
+}
+
+type componentUpdaterInvalidationFixture struct {
+	label       func() string
+	version     State[int]
+	renderCount *int
 }
 
 func (f *componentSlotPatchFixture) Init(Context) {


### PR DESCRIPTION
## Summary

- added `computed:"method"` declarations to embedded `tue.Comp` component fields
- generated read-only cached getters that work as bare identifiers in templates
- initialized generated computed values inside component scope before user `Init`
- rejected legacy direct `tue.Computed[T]` component fields and invalid computed declarations
- migrated the router example from manually constructed computed fields to source methods

## Developer impact

Component authors now declare computed values alongside props, events, and state:

```go
type UserBadge struct {
    tue.Comp[struct {
        Name     string `prop:",required"`
        Expanded bool   `state:""`
        Label    string `computed:"label"`
    }]
}

func (u *UserBadge) label() string {
    if u.Expanded() {
        return u.Name() + " expanded"
    }
    return u.Name()
}
```

Templates can read `Label` without parentheses. Generated computed values remain lazy, cached, reactive, read-only, patch-stable, and lifecycle-scoped.

## Validation

- `go fmt ./...`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`
- GoGraph review, risk, API, complexity, and policy checks

GoGraph reported zero errors. Its remaining five complexity warnings predate this change; the new computed validation was split out and remains below the configured threshold.